### PR TITLE
Remove wei bot

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,7 +1,0 @@
-version: "1"
-rules:
-  - base: main
-    upstream: opendatahub-io:main
-    mergeMethod: none # don't automatically merge
-    mergeUnstable: false
-conflictLabel: "needs-rebase"


### PR DESCRIPTION
Removed wei bot automation from the main, because we don't want always to pull all the commits for the upstream main. 