### PR TITLE
GitHub: fix variable name

### DIFF
--- a/.github/workflows/sync-release-branch-2023a.yml
+++ b/.github/workflows/sync-release-branch-2023a.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   sync_latest_from_upstream:
     runs-on: ubuntu-latest
-    name: sync release branch {{ env.UPSTREAM_BRANCH }}
+    name: sync release branch ${{ env.UPSTREAM_BRANCH }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Fix syntax which not replace variable in job title,
See (from origin action run) : 
![Screenshot from 2023-03-20 09-41-12](https://user-images.githubusercontent.com/915053/226288199-f7367d1d-2dea-427d-bd18-1bb859785f60.png)

