### PR TITLE
Upgrade the runtime images with rhods runtime,ref:b7e647e

### DIFF
--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:cb54fa7c48b2bbca0e173470330ea37efa6d5dd0acd015ac8a0230aa31661eba"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:c775356ad2efcb59e151cef57dab48cabc9f12e3c69f1453bcb768eabb950cbf"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:cccbf0b9c85921578853211c3a2857e68f3cf856cfc59af7268afe2948eb19a6"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/anaconda-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/anaconda-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-minimal-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:03e0f71042dad9953f49e57c2f547ea8ac346feffcee5cc5f1c47c530174afcf"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:cb54fa7c48b2bbca0e173470330ea37efa6d5dd0acd015ac8a0230aa31661eba"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:c775356ad2efcb59e151cef57dab48cabc9f12e3c69f1453bcb768eabb950cbf"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:cccbf0b9c85921578853211c3a2857e68f3cf856cfc59af7268afe2948eb19a6"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-minimal-ubi8-python-3.8-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:03e0f71042dad9953f49e57c2f547ea8ac346feffcee5cc5f1c47c530174afcf"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-datascience-ubi9-python-3.9-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:7dd23e58291cad7a0ab4a8e04bda06492f2c027eb33b226358380db58dcdd60b"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-pytorch-ubi9-python-3.9-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:8b962c575adfdb46a9aa3e3fc30fdbe470d049b0ff69f68c5c9f950496ae26c5"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-cuda-tensorflow-ubi9-python-3.9-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:8df90db22b29afb1cd9c81d52be9145fed50e3b04ec80bb7ea7ecaa7476dbe5c"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.9 (UBI9)",
-        "image_name": "quay.io/opendatahub/workbench-images:runtime-minimal-ubi9-python-3.9-6a6098d"
+        "image_name": "quay.io/modh/runtime-images@sha256:7ca2509fa522cb38720a8d30f19077a1f5acefa8be2801ee541b8fc8731daf84"
     },
     "schema_name": "runtime-image"
 }


### PR DESCRIPTION
Upgrade the runtime images with rhods runtime,ref:b7e647e

The runtime image are updated with RHODS based image from quay.io/modh.
Commit reference: https://github.com/red-hat-data-services/notebooks/commit/b7e647edd3e637e7d22f4a3ef0200d128c87d296

Tags:

- runtime-cuda-tensorflow-ubi9-python-3.9-2023a-20230817-b7e647e 
- runtime-cuda-tensorflow-ubi8-python-3.8-2023a-20230817-b7e647e 
- runtime-pytorch-ubi9-python-3.9-2023a-20230817-b7e647e
- runtime-pytorch-ubi8-python-3.8-2023a-20230817-b7e647e 
- runtime-datascience-ubi8-python-3.8-2023a-20230817-b7e647e
- runtime-datascience-ubi9-python-3.9-2023a-20230817-b7e647e 
- runtime-minimal-ubi9-python-3.9-2023a-20230817-b7e647e
- runtime-minimal-ubi8-python-3.8-2023a-20230817-b7e647e
