### PR TITLE
Fix digest updater from failing if there are no updates on the image SHA on the params.env file 

### DIFF
--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -71,6 +71,8 @@ jobs:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
       - name: Fetch digest, and update the params.env file
+        shell: bash
+        continue-on-error: true
         run: |
               echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
               IMAGES=("odh-minimal-notebook-image-n" "odh-minimal-gpu-notebook-image-n" "odh-pytorch-gpu-notebook-image-n" "odh-generic-data-science-notebook-image-n" "odh-tensorflow-gpu-notebook-image-n" "odh-trustyai-notebook-image-n")
@@ -121,6 +123,8 @@ jobs:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
       - name: Fetch digest, and update the params.env file
+        shell: bash
+        continue-on-error: true
         run: |
               echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N-1 }} on ${{ env.RELEASE_VERSION_N_1}}
               IMAGES=("odh-minimal-notebook-image-n-1" "odh-minimal-gpu-notebook-image-n-1" "odh-pytorch-gpu-notebook-image-n-1" "odh-generic-data-science-notebook-image-n-1" "odh-tensorflow-gpu-notebook-image-n-1" "odh-trustyai-notebook-image-n-1")


### PR DESCRIPTION
Fix digest updater from failing if there are no updates on the image SHA on the params.env file 

Currently, the digest updater is failing if there are no updates to commit. Ref [link](https://github.com/red-hat-data-services/notebooks/actions/runs/6655418115)

By using the 
```
        shell: bash
        continue-on-error: true
```
inside the `- name: Fetch digest, and update the params.env file` procedure, allow as to continue