### PR TITLE
Patch the imagestream to have same name as in odh-manifests

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Standard Data Science"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
     opendatahub.io/notebook-image-order: "20"
-  name: generic-data-science
+  name: s2i-generic-data-science-notebook
 spec:
   lookupPolicy:
     local: true

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -17,7 +17,7 @@ spec:
     # N Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/workbench-image-recommended: 'true'
       from:

--- a/manifests/base/jupyter-habana-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-habana-notebook-imagestream.yaml
@@ -10,7 +10,7 @@ metadata:
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of habana libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
     opendatahub.io/notebook-image-order: "70"
     opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
-  name: habana
+  name: habana-notebook
 spec:
   lookupPolicy:
     local: true

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -32,7 +32,6 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
-        opendatahub.io/workbench-image-recommended: 'true'
       from:
         kind: DockerImage
         name: $(odh-minimal-gpu-notebook-image-n-1)

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -32,8 +32,6 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.5"}, {"name": "Notebook","version": "6.5"}]'
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
-        opendatahub.io/workbench-image-recommended: 'true'
-        opendatahub.io/default-image: "true"
       from:
         kind: DockerImage
         name: $(odh-minimal-notebook-image-n-1)

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "Minimal Python"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "10"
-  name: minimal
+  name: s2i-minimal-notebook
 spec:
   lookupPolicy:
     local: true

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -18,7 +18,7 @@ spec:
     # N Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"2.0"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.0"},{"name":"Tensorboard","version":"2.13"}, {"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.0"},{"name":"Tensorboard","version":"2.13"}, {"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/workbench-image-recommended: 'true'
       from:
@@ -32,7 +32,6 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
-        opendatahub.io/workbench-image-recommended: 'true'
       from:
         kind: DockerImage
         name: $(odh-pytorch-gpu-notebook-image-n-1)

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -18,7 +18,7 @@ spec:
     # N Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.13"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.13"},{"name":"Tensorboard","version":"2.13"}, {"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.13"},{"name":"Tensorboard","version":"2.13"}, {"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/workbench-image-recommended: 'true'
       from:
@@ -32,7 +32,6 @@ spec:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
-        opendatahub.io/workbench-image-recommended: 'true'
       from:
         kind: DockerImage
         name: $(odh-tensorflow-gpu-notebook-image-n-1)

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -17,8 +17,9 @@ spec:
     # N Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.3"}, {"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.3"}, {"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.10"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
         openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
+        opendatahub.io/workbench-image-recommended: 'true'
       from:
         kind: DockerImage
         name: $(odh-trustyai-notebook-image-n)

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "TrustyAI"
     opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
     opendatahub.io/notebook-image-order: "60"
-  name: trustyai
+  name: odh-trustyai-notebook
 spec:
   lookupPolicy:
     local: true


### PR DESCRIPTION
Patch the imagestream to have the same name as in odh-manifests
https://github.com/red-hat-data-services/odh-manifests/tree/master/jupyterhub/notebook-images/overlays/additional

Fixes:
- This would fix the duplication.
as older deployments would have the same image streams.

![image (3)](https://github.com/red-hat-data-services/notebooks/assets/14028058/70d93675-107a-4cd5-b50b-f073b9b179e8)

- All fixes the annotation of the sklear-onnx and removes additional recommend: true