### PR TITLE
[Enhancement] Digest updater now checks whether there are any changes

### DIFF
--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -72,7 +72,6 @@ jobs:
 
       - name: Fetch digest, and update the params.env file
         shell: bash
-        continue-on-error: true
         run: |
               echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
               IMAGES=("odh-minimal-notebook-image-n" "odh-minimal-gpu-notebook-image-n" "odh-pytorch-gpu-notebook-image-n" "odh-generic-data-science-notebook-image-n" "odh-tensorflow-gpu-notebook-image-n" "odh-trustyai-notebook-image-n")
@@ -90,7 +89,15 @@ jobs:
                 echo $output
                 sed -i "s|${image}=.*|${image}=$output|" manifests/base/params.env
               done
-              git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && git add manifests/base/params.env && git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+              if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+                  git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git add manifests/base/params.env && \
+                  git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                  git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+              else
+                  echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+              fi
 
   update-n-1-version:
     needs: [initialize, update-n-version]
@@ -124,9 +131,8 @@ jobs:
 
       - name: Fetch digest, and update the params.env file
         shell: bash
-        continue-on-error: true
         run: |
-              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N-1 }} on ${{ env.RELEASE_VERSION_N_1}}
+              echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1}}
               IMAGES=("odh-minimal-notebook-image-n-1" "odh-minimal-gpu-notebook-image-n-1" "odh-pytorch-gpu-notebook-image-n-1" "odh-generic-data-science-notebook-image-n-1" "odh-tensorflow-gpu-notebook-image-n-1" "odh-trustyai-notebook-image-n-1")
               REGEXES=("v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "cuda-[a-z]+-minimal-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N_1 }}-\d{8}-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" \
                        "v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "cuda-[a-z]+-tensorflow-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N_1 }}-\d{8}-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}")
@@ -143,7 +149,15 @@ jobs:
                 echo $output
                 sed -i "s|${image}=.*|${image}=$output|" manifests/base/params.env
               done
-              git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && git add manifests/base/params.env && git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }}GitHub action" && git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+              if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+                  git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+                  git add manifests/base/params.env && \
+                  git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                  git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
+              else
+                  echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1}}"
+              fi
 
 
   open-pull-request:


### PR DESCRIPTION
This is a followup for the recent update of the digest updater in which we allowed it to continue in case of an error. Let's not allow that and pro-actively try to avoid such error by checking whether there are actually any changes to be commited to the repository. If not, simply tell this to user and end gracefully.

Also, this fixes 2 typos.

Follows up on #70.

WDYT?

Note - this hasn't been tested since I didn't dare to touch the digest update workflow at the moment.

We should provide relevant changes also to https://github.com/opendatahub-io/notebooks/blob/main/.github/workflows/notebooks-digest-updater-upstream.yaml