### PR TITLE
[RHODS-1.34] CVE 44487: Upgrade ubi package libnghttp2 to fix http2 cve

### DIFF
--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -12,6 +12,10 @@ LABEL name="odh-notebook-base-ubi8-python-3.8" \
 
 WORKDIR /opt/app-root/bin
 
+USER root
+RUN dnf update -y libnghttp2 && dnf clean all
+USER 1001
+
 # Install micropipenv to deploy packages from Pipfile.lock
 RUN pip install -U "micropipenv[toml]"
 

--- a/base/ubi9-python-3.9/Dockerfile
+++ b/base/ubi9-python-3.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39:latest
+FROM registry.access.redhat.com/ubi9/python-39@sha256:bbac8c29fb0f834f616b3ec07aa78d942a6e4239a5537a52517acaff59350917
 
 LABEL name="odh-notebook-base-ubi9-python-3.9" \
       summary="Python 3.9 base image for ODH notebooks" \


### PR DESCRIPTION
CVE 44487: Upgrade ubi package libnghttp2 to fix http2 cve

Based on the update: 
- https://catalog.redhat.com/software/containers/ubi9/python-39/61a61032bfd4a5234d59629e?architecture=amd64&image=65301f5a53a51a886582fba1&container-tabs=security
- https://catalog.redhat.com/software/containers/ubi8/python-38/5dde9cacbed8bd164a0af24a?architecture=amd64&image=64cab6d204b5b858e24f2f62
as the ubi8 doesn't have fix, using dnf to update the packages.