### PR TITLE
[Release-1.2] CVE 44487: Upgrade ubi package libnghttp2 to fix http2 cve

### DIFF
--- a/base/ubi8-python-3.8/Dockerfile
+++ b/base/ubi8-python-3.8/Dockerfile
@@ -12,6 +12,10 @@ LABEL name="odh-notebook-base-ubi8-python-3.8" \
 
 WORKDIR /opt/app-root/bin
 
+USER root
+RUN dnf update -y libnghttp2 && dnf clean all
+USER 1001
+
 # Install Python dependencies from requirements.txt file
 COPY requirements.txt ./
 


### PR DESCRIPTION
CVE 44487: Upgrade ubi package libnghttp2 to fix http2 cve

Based on the update:
https://catalog.redhat.com/software/containers/ubi8/python-38/5dde9cacbed8bd164a0af24a?architecture=amd64&image=64cab6d204b5b858e24f2f62
as the ubi8 doesn't have fix, using dnf to update the packages.