### PR TITLE
RHOAI: Build VSCode notebook on RHEL9 base

### DIFF
--- a/base/rhel9-python-3.9/Dockerfile
+++ b/base/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,40 @@
+FROM registry.redhat.io/rhel9/python-39:latest
+
+LABEL name="odh-notebook-base-rhel9-python-3.9" \
+      summary="Python 3.9 Red Hat Enterprise Linux 9 base image for ODH notebooks" \
+      description="Base Python 3.9 builder image based on Red Hat Enterprise Linux 9 for ODH notebooks" \
+      io.k9s.display-name="Python 3.9 RHEL9 base image for ODH notebooks" \
+      io.k9s.description="Base Python 3.9 builder image based on RHEL9 for ODH notebooks" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/rhel9-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:base-rhel9-python-3.9"
+
+WORKDIR /opt/app-root/bin
+
+# Install micropipenv to deploy packages from Pipfile.lock
+RUN pip install -U "micropipenv[toml]"
+
+# Install Python dependencies from Pipfile.lock file
+COPY Pipfile.lock ./
+
+# OS Packages needs to be installed as root
+USER root
+
+# Install usefull OS packages
+RUN dnf install -y mesa-libGL
+
+# Other apps and tools installed as default user
+USER 1001
+
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Install the oc client \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+        -o /tmp/openshift-client-linux.tar.gz && \
+    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
+    rm -f /tmp/openshift-client-linux.tar.gz && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+    fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src

--- a/base/rhel9-python-3.9/Dockerfile
+++ b/base/rhel9-python-3.9/Dockerfile
@@ -3,8 +3,8 @@ FROM registry.redhat.io/rhel9/python-39:latest
 LABEL name="odh-notebook-base-rhel9-python-3.9" \
       summary="Python 3.9 Red Hat Enterprise Linux 9 base image for ODH notebooks" \
       description="Base Python 3.9 builder image based on Red Hat Enterprise Linux 9 for ODH notebooks" \
-      io.k9s.display-name="Python 3.9 RHEL9 base image for ODH notebooks" \
-      io.k9s.description="Base Python 3.9 builder image based on RHEL9 for ODH notebooks" \
+      io.k9s.display-name="Python 3.9 Red Hat Enterprise Linux 9 base image for ODH notebooks" \
+      io.k9s.description="Base Python 3.9 builder image based on Red Hat Enterprise Linux 9 for ODH notebooks" \
       authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
       io.openshift.build.commit.ref="main" \
       io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/rhel9-python-3.9" \

--- a/base/rhel9-python-3.9/Pipfile
+++ b/base/rhel9-python-3.9/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+# Base packages
+wheel = "~=0.41.2"
+setuptools = "~=68.1.2"
+
+[requires]
+python_version = "3.9"

--- a/base/rhel9-python-3.9/Pipfile.lock
+++ b/base/rhel9-python-3.9/Pipfile.lock
@@ -1,0 +1,39 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "54af5308fe912f4e39360fc1fa1d2fa9f9233d975a2e1ab42265db7c82aab4fa"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "setuptools": {
+            "hashes": [
+                "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d",
+                "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==68.1.2"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942",
+                "sha256:4d4987ce51a49370ea65c0bfd2234e8ce80a12780820d9dc462597a6e60d0841"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==0.41.3"
+        }
+    },
+    "develop": {}
+}

--- a/codeserver/rhel9-python-3.9/Dockerfile
+++ b/codeserver/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,90 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG CODESERVER_VERSION=v4.16.1
+
+LABEL name="odh-notebook-code-server-c9s-python-3.9" \
+      summary="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.display-name="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/c9s-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-c9s-python-3.9"
+
+USER 0
+
+WORKDIR /opt/app-root/bin
+
+# Install Code Server
+RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-amd64.rpm" && \
+    yum -y clean all --enablerepo='*'
+
+# Install NGINX to proxy VSCode and pass probes check
+ENV NGINX_VERSION=1.22 \
+    NGINX_SHORT_VER=122 \
+    NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+# Modules does not exist
+RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    INSTALL_PKGS="bind-utils nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    # spawn-fcgi is not in epel9 \
+    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    yum -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY nginx/root/ /
+
+# Changing ownership and user rights to support following use-cases:
+# 1) running container on OpenShift, whose default security model
+#    is to run the container under random UID, but GID=0
+# 2) for working root-less container with UID=1001, which does not have
+#    to have GID=0
+# 3) for default use-case, that is running container directly on operating system,
+#    with default UID and GID (1001:0)
+# Supported combinations of UID:GID are thus following:
+# UID=1001 && GID=0
+# UID=<any>&& GID=0
+# UID=1001 && GID=<any>
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/api/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    chown -R 1001:0 ${NGINX_CONF_PATH} && \
+    chown -R 1001:0 ${NGINX_APP_ROOT}/etc && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod    ug+rw  ${NGINX_CONF_PATH} && \
+    chmod -R ug+rwX ${NGINX_APP_ROOT}/etc && \
+    chmod -R ug+rwX ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run && \
+    rpm-file-permissions
+
+## Configure nginx
+COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY nginx/api/ /opt/app-root/api/
+
+# Launcher
+COPY utils utils/
+COPY run-code-server.sh run-nginx.sh ./
+
+ENV SHELL /bin/bash
+
+WORKDIR /opt/app-root/src
+
+USER 1001
+
+CMD /opt/app-root/bin/run-code-server.sh

--- a/codeserver/rhel9-python-3.9/Dockerfile
+++ b/codeserver/rhel9-python-3.9/Dockerfile
@@ -3,15 +3,15 @@ FROM ${BASE_IMAGE}
 
 ARG CODESERVER_VERSION=v4.16.1
 
-LABEL name="odh-notebook-code-server-c9s-python-3.9" \
-      summary="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
-      description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
-      io.k9s.display-name="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
-      io.k9s.description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
-      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+LABEL name="odh-notebook-code-server-rhel9-python-3.9" \
+      summary="Code Server (VS Code) image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      description="Code Server (VS Code) image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      io.k8s.display-name="Code Server (VS Code) image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      io.k8s.description="Code Server (VS Code) image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      authoritative-source-url="https://github.com/red-hat-data-services/notebooks" \
       io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/c9s-python-3.9" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-c9s-python-3.9"
+      io.openshift.build.source-location="https://github.com/red-hat-data-services/notebooks/tree/main/codeserver/rhel9-python-3.9" \
+      io.openshift.build.image="quay.io/modh/codeserver:codeserver-rhel9-python-3.9"
 
 USER 0
 

--- a/codeserver/rhel9-python-3.9/kustomize/base/kustomization.yaml
+++ b/codeserver/rhel9-python-3.9/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: codeserver-
+resources:
+  - pod.yaml
+images:
+  - name: codeserver-workbench
+    newName: quay.io/modh/codeserver
+    newTag: codeserver-rhel-python-3.9

--- a/codeserver/rhel9-python-3.9/kustomize/base/pod.yaml
+++ b/codeserver/rhel9-python-3.9/kustomize/base/pod.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  labels:
+    app: codeserver-image
+spec:
+  containers:
+    - name: codeserver
+      image: codeserver-workbench
+      command: ["/bin/sh", "-c", "while true ; do date; sleep 5; done;"]
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 8585
+      resources:
+        limits:
+          cpu: 500m
+          memory: 500Mi
+        requests:
+          cpu: 500m
+          memory: 500Mi

--- a/codeserver/rhel9-python-3.9/nginx/api/kernels/access.cgi
+++ b/codeserver/rhel9-python-3.9/nginx/api/kernels/access.cgi
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo "Status: 200"
+echo "Content-type: application/json"
+echo
+# Query the heartbeat endpoint
+HEALTHZ=$(curl -s http://127.0.0.1:8888/vscode/healthz)
+# Extract last_activity | remove milliseconds
+LAST_ACTIVITY_EPOCH=$(echo $HEALTHZ | grep -Po 'lastHeartbeat":\K.*?(?=})' | awk '{ print substr( $0, 1, length($0)-3 ) }')
+# Convert to ISO8601 date format
+LAST_ACTIVITY=$(date -d @$LAST_ACTIVITY_EPOCH -Iseconds)
+# Extract status and replace with terms expected by culler
+STATUS=$(sed 's/alive/busy/;s/expired/idle/' <<< $(echo $HEALTHZ | grep -Po 'status":"\K.*?(?=")'))
+# Export in format expected by the culling engine
+echo '[{"id":"code-server","name":"code-server","last_activity":"'$LAST_ACTIVITY'","execution_state":"'$STATUS'","connections":1}]'

--- a/codeserver/rhel9-python-3.9/nginx/httpconf/http.conf
+++ b/codeserver/rhel9-python-3.9/nginx/httpconf/http.conf
@@ -1,0 +1,39 @@
+# Make WebSockets working
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+###
+# Custom logging for direct last_activity based culling, brace yourself!
+###
+
+# Exclude heartbeat from logging for culling purposes
+map $request $loggable {
+    ~\/vscode\/healthz  0;
+    default 1;
+}
+
+# iso8601 with millisecond precision transformer (mimicking Jupyter output)
+map $time_iso8601 $time_iso8601_p1 {
+    ~([^+]+) $1;
+}
+map $time_iso8601 $time_iso8601_p2 {
+    ~\+([0-9:]+)$ $1;
+}
+map $msec $millisec {
+    ~\.([0-9]+)$ $1;
+}
+
+log_format json escape=json '[{'
+    '"id":"code-server",'
+    '"name":"code-server",'
+    '"last_activity":"$time_iso8601_p1.$millisec+$time_iso8601_p2",'
+    '"execution_state":"busy",'
+    '"connections": 1'
+    '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
@@ -1,0 +1,9 @@
+# Set current user in nss_wrapper
+PASSWD_DIR="/opt/app-root/etc"
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < ${PASSWD_DIR}/passwd.template > ${PASSWD_DIR}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${PASSWD_DIR}/passwd
+export NSS_WRAPPER_GROUP=/etc/group

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/passwd.template
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/passwd.template
@@ -1,0 +1,15 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin
+apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/scl_enable
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-nginx$NGINX_SHORT_VER

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
@@ -1,0 +1,21 @@
+# Change port
+/listen/s%80%8888 default_server%
+
+# Remove listening on IPv6
+/\[::\]/d
+
+# One worker only
+/worker_processes/s%auto%1%
+
+s/^user *nginx;//
+s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
+s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
+s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d
+
+# Addition for RStudio
+/server_name/s%server_name  _%server_name  ${BASE_URL}%

--- a/codeserver/rhel9-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
+++ b/codeserver/rhel9-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template
+++ b/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template
@@ -1,0 +1,64 @@
+###############
+# api calls from probes get to VSCode /healthz endpoint
+###############
+location = /api {
+  return 302 /vscode/healthz/;
+  access_log  off;
+}
+
+location /api/ {
+  return 302 /vscode/healthz/;
+  access_log  off;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = /api/kernels {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# root and prefix get to VSCode endpoint
+###############
+location = / {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location = /vscode {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location /vscode/ {
+    # Standard Code-Server/NGINX configuration
+    proxy_pass http://127.0.0.1:8787/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+
+    # Needed to make it work properly
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_redirect off;
+
+    access_log /var/log/nginx/vscode.access.log json if=$loggable;
+}
+###############

--- a/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
@@ -1,0 +1,71 @@
+###############
+# api calls from probes get to VSCode /healthz endpoint
+###############
+location = ${NB_PREFIX}/api {
+    return 302  /vscode/healthz/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/ {
+    return 302  /vscode/healthz/;
+    access_log  off;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = ${NB_PREFIX}/api/kernels {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/kernels/ {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# root and prefix get to VSCode endpoint
+###############
+location = ${NB_PREFIX} {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location ${NB_PREFIX}/ {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location = /vscode {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location = / {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location /vscode/ {
+    rewrite ^/vscode/(.*)$ /$1 break;
+    # Standard RStudio/NGINX configuration
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
+
+    access_log /var/log/nginx/vscode.access.log json if=$loggable;
+}
+###############

--- a/codeserver/rhel9-python-3.9/run-code-server.sh
+++ b/codeserver/rhel9-python-3.9/run-code-server.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Load bash libraries
+SCRIPT_DIR=$(dirname -- "$0")
+source ${SCRIPT_DIR}/utils/*.sh
+
+# Start nginx and fastcgiwrap
+run-nginx.sh &
+spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+
+# Add .bashrc for custom promt if not present
+if [ ! -f "/opt/app-root/src/.bashrc" ]; then
+  echo 'PS1="\[\033[34;1m\][\$(pwd)]\[\033[0m\]\n\[\033[1;0m\]$ \[\033[0m\]"' > /opt/app-root/src/.bashrc
+fi
+
+# Initilize access logs for culling
+echo '[{"id":"code-server","name":"code-server","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/vscode.access.log
+
+# Start server
+start_process /usr/bin/code-server \
+  --bind-addr 0.0.0.0:8787 \
+  --disable-telemetry \
+  --auth none \
+  --disable-update-check \
+  /opt/app-root/src

--- a/codeserver/rhel9-python-3.9/run-nginx.sh
+++ b/codeserver/rhel9-python-3.9/run-nginx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+# disabled, only used to source nginx files in user directory
+#process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
+
+if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
+fi
+
+# substitute NB_PREFIX in proxy configuratin if it exists
+if [ -z "$NB_PREFIX" ]; then
+    cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
+else
+    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+fi
+
+nginx

--- a/codeserver/rhel9-python-3.9/utils/process.sh
+++ b/codeserver/rhel9-python-3.9/utils/process.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function start_process() {
+    trap stop_process TERM INT
+
+    echo "Running command: $@"
+    "$@" &
+
+    PID=$!
+    wait $PID
+    trap - TERM INT
+    wait $PID
+    STATUS=$?
+    exit $STATUS
+}
+
+function stop_process() {
+    kill -TERM $PID
+}

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/codeserver"
+    opendatahub.io/notebook-image-name: "Code Server"
+    opendatahub.io/notebook-image-desc: "Code Server workbench image, allows to run Visual Studio Code (VSCode) on a remote server through the browser."
+    opendatahub.io/notebook-image-order: "80"
+  name: code-server-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # N Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.16"}]'
+        openshift.io/imported-from: quay.io/modh/codeserver
+        opendatahub.io/workbench-image-recommended: 'true'
+      from:
+        kind: DockerImage
+        name: $(odh-codeserver-notebook-n)
+      name: "2023.2"
+      referencePolicy:
+        type: Source

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -146,5 +146,12 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
+  - name: odh-codeserver-notebook-n
+    objref:
+      kind: ConfigMap
+      name: notebooks-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-n
 configurations:
   - params.yaml

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -16,3 +16,4 @@ odh-tensorflow-gpu-notebook-image-n-2=quay.io/modh/cuda-notebooks@sha256:6fadedc
 odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:b68c1bfd9926b224180835382b36ad25e2269ffb95fca0646a89c8cceb6a6e7a
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:de46659eccc3dd8e4b79cfbf7fc95464f76ffcc06f3f914841533130fba2985f
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:0f6ae8f0b1ef11896336e7f8611e77ccdb992b49a7942bf27e6bc64d73205d05
+odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -72,3 +72,7 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-habana-notebook-image-n
+  - path: spec/tags[]/from/name
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-n


### PR DESCRIPTION
Ref. Issue: https://github.com/opendatahub-io/notebooks/issues/283

Depend on: https://github.com/openshift/release/pull/45089

This PR incorporates the VSCode notebook to RHOAI.

**How has been tested:**
The behavior of the notebook looks the same as the one based on C9S in ODH.
The RHEL base image that used is : https://catalog.redhat.com/software/containers/rhel9/python-39/61a6101fbfd4a5234d59629d?architecture=amd64&image=65301f5a53a51a886582fba1

**1. On a Local Run** 
1. Build the notebook: `make codeserver-rhel9-python-3.9`
2. Run the VSCode locally: 
```podman run --network=host --name validation-container quay.io/rh_ee_atheodor/workbench-images:codeserver-rhel9-python-3.9-2023b_20231106```
  
![image](https://github.com/red-hat-data-services/notebooks/assets/42587738/f7333e08-769a-405d-9e97-7277c4468bbe)

Once you finish the inspection: `podman stop validation-container && podman rm validation-container`

**2. On the Cluster** 

Deploy on the cluster: `make deploy-rhel9-codeserver-rhel9-python-3.9`
Run the Test: `make validate-codeserver-image image=codeserver-rhel9-python-3.9-2023b_20231106` ensure that the test completed successfully
Undeploy: `make undeploy-rhel9-codeserver-rhel9-python-3.9`



