### PR TITLE
[WIP] Build RStudio notebook on RHEL base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,18 @@ base-rhel9-python-3.9:
 codeserver-rhel9-python-3.9: base-rhel9-python-3.9
 	$(call image,$@,codeserver/rhel9-python-3.9,$<)
 
+.PHONY: cuda-rhel9-python-3.9
+cuda-rhel9-python-3.9: base-rhel9-python-3.9
+	$(call image,$@,cuda/rhel9-python-3.9,$<)
+
+.PHONY: rstudio-rhel9-python-3.9
+rstudio-rhel9-python-3.9: base-rhel9-python-3.9
+	$(call image,$@,rstudio/rhel9-python-3.9,$<)
+
+.PHONY: cuda-rstudio-rhel9-python-3.9
+cuda-rstudio-rhel9-python-3.9: cuda-rhel9-python-3.9
+	$(call image,$@,rstudio/rhel9-python-3.9,$<)
+
 ####################################### Buildchain for Anaconda Python #######################################
 
 # Build and push base-anaconda-python-3.8 image to the registry

--- a/base/rhel9-python-3.9/Dockerfile
+++ b/base/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,40 @@
+FROM registry.redhat.io/rhel9/python-39:latest
+
+LABEL name="odh-notebook-base-rhel9-python-3.9" \
+      summary="Python 3.9 Red Hat Enterprise Linux 9 base image for ODH notebooks" \
+      description="Base Python 3.9 builder image based on Red Hat Enterprise Linux 9 for ODH notebooks" \
+      io.k9s.display-name="Python 3.9 RHEL9 base image for ODH notebooks" \
+      io.k9s.description="Base Python 3.9 builder image based on RHEL9 for ODH notebooks" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/base/rhel9-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:base-rhel9-python-3.9"
+
+WORKDIR /opt/app-root/bin
+
+# Install micropipenv to deploy packages from Pipfile.lock
+RUN pip install -U "micropipenv[toml]"
+
+# Install Python dependencies from Pipfile.lock file
+COPY Pipfile.lock ./
+
+# OS Packages needs to be installed as root
+USER root
+
+# Install usefull OS packages
+RUN dnf install -y mesa-libGL
+
+# Other apps and tools installed as default user
+USER 1001
+
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock && \
+    # Install the oc client \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+        -o /tmp/openshift-client-linux.tar.gz && \
+    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
+    rm -f /tmp/openshift-client-linux.tar.gz && \
+    # Fix permissions to support pip in Openshift environments \
+    chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+    fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src

--- a/base/rhel9-python-3.9/Pipfile
+++ b/base/rhel9-python-3.9/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+# Base packages
+wheel = "~=0.41.2"
+setuptools = "~=68.1.2"
+
+[requires]
+python_version = "3.9"

--- a/base/rhel9-python-3.9/Pipfile.lock
+++ b/base/rhel9-python-3.9/Pipfile.lock
@@ -1,0 +1,39 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "54af5308fe912f4e39360fc1fa1d2fa9f9233d975a2e1ab42265db7c82aab4fa"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "setuptools": {
+            "hashes": [
+                "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d",
+                "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==68.1.2"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942",
+                "sha256:4d4987ce51a49370ea65c0bfd2234e8ce80a12780820d9dc462597a6e60d0841"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==0.41.3"
+        }
+    },
+    "develop": {}
+}

--- a/codeserver/rhel9-python-3.9/Dockerfile
+++ b/codeserver/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,90 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG CODESERVER_VERSION=v4.16.1
+
+LABEL name="odh-notebook-code-server-c9s-python-3.9" \
+      summary="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.display-name="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/codeserver/c9s-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:codeserver-c9s-python-3.9"
+
+USER 0
+
+WORKDIR /opt/app-root/bin
+
+# Install Code Server
+RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-amd64.rpm" && \
+    yum -y clean all --enablerepo='*'
+
+# Install NGINX to proxy VSCode and pass probes check
+ENV NGINX_VERSION=1.22 \
+    NGINX_SHORT_VER=122 \
+    NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+# Modules does not exist
+RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    INSTALL_PKGS="bind-utils nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    # spawn-fcgi is not in epel9 \
+    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    yum -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY nginx/root/ /
+
+# Changing ownership and user rights to support following use-cases:
+# 1) running container on OpenShift, whose default security model
+#    is to run the container under random UID, but GID=0
+# 2) for working root-less container with UID=1001, which does not have
+#    to have GID=0
+# 3) for default use-case, that is running container directly on operating system,
+#    with default UID and GID (1001:0)
+# Supported combinations of UID:GID are thus following:
+# UID=1001 && GID=0
+# UID=<any>&& GID=0
+# UID=1001 && GID=<any>
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/api/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    chown -R 1001:0 ${NGINX_CONF_PATH} && \
+    chown -R 1001:0 ${NGINX_APP_ROOT}/etc && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod    ug+rw  ${NGINX_CONF_PATH} && \
+    chmod -R ug+rwX ${NGINX_APP_ROOT}/etc && \
+    chmod -R ug+rwX ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run && \
+    rpm-file-permissions
+
+## Configure nginx
+COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY nginx/api/ /opt/app-root/api/
+
+# Launcher
+COPY utils utils/
+COPY run-code-server.sh run-nginx.sh ./
+
+ENV SHELL /bin/bash
+
+WORKDIR /opt/app-root/src
+
+USER 1001
+
+CMD /opt/app-root/bin/run-code-server.sh

--- a/codeserver/rhel9-python-3.9/kustomize/base/kustomization.yaml
+++ b/codeserver/rhel9-python-3.9/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: codeserver-
+resources:
+  - pod.yaml
+images:
+  - name: codeserver-workbench
+    newName: quay.io/modh/codeserver
+    newTag: codeserver-rhel-python-3.9

--- a/codeserver/rhel9-python-3.9/kustomize/base/pod.yaml
+++ b/codeserver/rhel9-python-3.9/kustomize/base/pod.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  labels:
+    app: codeserver-image
+spec:
+  containers:
+    - name: codeserver
+      image: codeserver-workbench
+      command: ["/bin/sh", "-c", "while true ; do date; sleep 5; done;"]
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 8585
+      resources:
+        limits:
+          cpu: 500m
+          memory: 500Mi
+        requests:
+          cpu: 500m
+          memory: 500Mi

--- a/codeserver/rhel9-python-3.9/nginx/api/kernels/access.cgi
+++ b/codeserver/rhel9-python-3.9/nginx/api/kernels/access.cgi
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo "Status: 200"
+echo "Content-type: application/json"
+echo
+# Query the heartbeat endpoint
+HEALTHZ=$(curl -s http://127.0.0.1:8888/vscode/healthz)
+# Extract last_activity | remove milliseconds
+LAST_ACTIVITY_EPOCH=$(echo $HEALTHZ | grep -Po 'lastHeartbeat":\K.*?(?=})' | awk '{ print substr( $0, 1, length($0)-3 ) }')
+# Convert to ISO8601 date format
+LAST_ACTIVITY=$(date -d @$LAST_ACTIVITY_EPOCH -Iseconds)
+# Extract status and replace with terms expected by culler
+STATUS=$(sed 's/alive/busy/;s/expired/idle/' <<< $(echo $HEALTHZ | grep -Po 'status":"\K.*?(?=")'))
+# Export in format expected by the culling engine
+echo '[{"id":"code-server","name":"code-server","last_activity":"'$LAST_ACTIVITY'","execution_state":"'$STATUS'","connections":1}]'

--- a/codeserver/rhel9-python-3.9/nginx/httpconf/http.conf
+++ b/codeserver/rhel9-python-3.9/nginx/httpconf/http.conf
@@ -1,0 +1,39 @@
+# Make WebSockets working
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+###
+# Custom logging for direct last_activity based culling, brace yourself!
+###
+
+# Exclude heartbeat from logging for culling purposes
+map $request $loggable {
+    ~\/vscode\/healthz  0;
+    default 1;
+}
+
+# iso8601 with millisecond precision transformer (mimicking Jupyter output)
+map $time_iso8601 $time_iso8601_p1 {
+    ~([^+]+) $1;
+}
+map $time_iso8601 $time_iso8601_p2 {
+    ~\+([0-9:]+)$ $1;
+}
+map $msec $millisec {
+    ~\.([0-9]+)$ $1;
+}
+
+log_format json escape=json '[{'
+    '"id":"code-server",'
+    '"name":"code-server",'
+    '"last_activity":"$time_iso8601_p1.$millisec+$time_iso8601_p2",'
+    '"execution_state":"busy",'
+    '"connections": 1'
+    '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
@@ -1,0 +1,9 @@
+# Set current user in nss_wrapper
+PASSWD_DIR="/opt/app-root/etc"
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < ${PASSWD_DIR}/passwd.template > ${PASSWD_DIR}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${PASSWD_DIR}/passwd
+export NSS_WRAPPER_GROUP=/etc/group

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/passwd.template
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/passwd.template
@@ -1,0 +1,15 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin
+apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/scl_enable
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-nginx$NGINX_SHORT_VER

--- a/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
+++ b/codeserver/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
@@ -1,0 +1,21 @@
+# Change port
+/listen/s%80%8888 default_server%
+
+# Remove listening on IPv6
+/\[::\]/d
+
+# One worker only
+/worker_processes/s%auto%1%
+
+s/^user *nginx;//
+s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
+s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
+s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d
+
+# Addition for RStudio
+/server_name/s%server_name  _%server_name  ${BASE_URL}%

--- a/codeserver/rhel9-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
+++ b/codeserver/rhel9-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template
+++ b/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template
@@ -1,0 +1,64 @@
+###############
+# api calls from probes get to VSCode /healthz endpoint
+###############
+location = /api {
+  return 302 /vscode/healthz/;
+  access_log  off;
+}
+
+location /api/ {
+  return 302 /vscode/healthz/;
+  access_log  off;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = /api/kernels {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# root and prefix get to VSCode endpoint
+###############
+location = / {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location = /vscode {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location /vscode/ {
+    # Standard Code-Server/NGINX configuration
+    proxy_pass http://127.0.0.1:8787/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+
+    # Needed to make it work properly
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_redirect off;
+
+    access_log /var/log/nginx/vscode.access.log json if=$loggable;
+}
+###############

--- a/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/codeserver/rhel9-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
@@ -1,0 +1,71 @@
+###############
+# api calls from probes get to VSCode /healthz endpoint
+###############
+location = ${NB_PREFIX}/api {
+    return 302  /vscode/healthz/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/ {
+    return 302  /vscode/healthz/;
+    access_log  off;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = ${NB_PREFIX}/api/kernels {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/kernels/ {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# root and prefix get to VSCode endpoint
+###############
+location = ${NB_PREFIX} {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location ${NB_PREFIX}/ {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location = /vscode {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location = / {
+    return 302 $custom_scheme://$http_host/vscode/;
+}
+
+location /vscode/ {
+    rewrite ^/vscode/(.*)$ /$1 break;
+    # Standard RStudio/NGINX configuration
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
+
+    access_log /var/log/nginx/vscode.access.log json if=$loggable;
+}
+###############

--- a/codeserver/rhel9-python-3.9/run-code-server.sh
+++ b/codeserver/rhel9-python-3.9/run-code-server.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Load bash libraries
+SCRIPT_DIR=$(dirname -- "$0")
+source ${SCRIPT_DIR}/utils/*.sh
+
+# Start nginx and fastcgiwrap
+run-nginx.sh &
+spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+
+# Add .bashrc for custom promt if not present
+if [ ! -f "/opt/app-root/src/.bashrc" ]; then
+  echo 'PS1="\[\033[34;1m\][\$(pwd)]\[\033[0m\]\n\[\033[1;0m\]$ \[\033[0m\]"' > /opt/app-root/src/.bashrc
+fi
+
+# Initilize access logs for culling
+echo '[{"id":"code-server","name":"code-server","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/vscode.access.log
+
+# Start server
+start_process /usr/bin/code-server \
+  --bind-addr 0.0.0.0:8787 \
+  --disable-telemetry \
+  --auth none \
+  --disable-update-check \
+  /opt/app-root/src

--- a/codeserver/rhel9-python-3.9/run-nginx.sh
+++ b/codeserver/rhel9-python-3.9/run-nginx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+# disabled, only used to source nginx files in user directory
+#process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
+
+if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
+fi
+
+# substitute NB_PREFIX in proxy configuratin if it exists
+if [ -z "$NB_PREFIX" ]; then
+    cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
+else
+    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+fi
+
+nginx

--- a/codeserver/rhel9-python-3.9/utils/process.sh
+++ b/codeserver/rhel9-python-3.9/utils/process.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function start_process() {
+    trap stop_process TERM INT
+
+    echo "Running command: $@"
+    "$@" &
+
+    PID=$!
+    wait $PID
+    trap - TERM INT
+    wait $PID
+    STATUS=$?
+    exit $STATUS
+}
+
+function stop_process() {
+    kill -TERM $PID
+}

--- a/cuda/rhel9-python-3.9/Dockerfile
+++ b/cuda/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,127 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+LABEL name="odh-notebook-cuda-rhel9-python-3.9" \
+      summary="CUDA Python 3.9 base image for ODH notebooks" \
+      description="CUDA Python 3.9 builder image based on Red Hat Enterprise Linux 9 for ODH notebooks" \
+      io.k8s.display-name="CUDA Python 3.9 base image for ODH notebooks" \
+      io.k8s.description="CUDA Python 3.9 builder image based on RHEL9 for ODH notebooks" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/cuda/rhel9-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:cuda-rhel9-python-3.9"
+
+# Install CUDA base from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/base/Dockerfile
+USER 0
+WORKDIR /opt/app-root/bin
+
+ENV NVARCH x86_64
+ENV NVIDIA_REQUIRE_CUDA "cuda>=11.8 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471"
+ENV NV_CUDA_CUDART_VERSION 11.8.89-1
+
+COPY cuda.repo-x86_64 /etc/yum.repos.d/cuda.repo
+
+RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${NVARCH}/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+    echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
+
+ENV CUDA_VERSION 11.8.0
+
+# For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
+RUN yum upgrade -y && yum install -y \
+    cuda-cudart-11-8-${NV_CUDA_CUDART_VERSION} \
+    cuda-compat-11-8 \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+# nvidia-docker 1.0
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+COPY NGC-DL-CONTAINER-LICENSE /
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Install CUDA runtime from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/runtime/Dockerfile
+ENV NV_CUDA_LIB_VERSION 11.8.0-1
+ENV NV_NVTX_VERSION 11.8.86-1
+ENV NV_LIBNPP_VERSION 11.8.0.86-1
+ENV NV_LIBNPP_PACKAGE libnpp-11-8-${NV_LIBNPP_VERSION}
+ENV NV_LIBCUBLAS_VERSION 11.11.3.6-1
+ENV NV_LIBNCCL_PACKAGE_NAME libnccl
+ENV NV_LIBNCCL_PACKAGE_VERSION 2.15.5-1
+ENV NV_LIBNCCL_VERSION 2.15.5
+ENV NCCL_VERSION 2.15.5
+ENV NV_LIBNCCL_PACKAGE ${NV_LIBNCCL_PACKAGE_NAME}-${NV_LIBNCCL_PACKAGE_VERSION}+cuda11.8
+
+RUN yum install -y \
+    cuda-libraries-11-8-${NV_CUDA_LIB_VERSION} \
+    cuda-nvtx-11-8-${NV_NVTX_VERSION} \
+    ${NV_LIBNPP_PACKAGE} \
+    libcublas-11-8-${NV_LIBCUBLAS_VERSION} \
+    ${NV_LIBNCCL_PACKAGE} \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+# Install CUDA devel from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/devel/Dockerfile
+ENV NV_CUDA_LIB_VERSION 11.8.0-1
+ENV NV_NVPROF_VERSION 11.8.87-1
+ENV NV_NVPROF_DEV_PACKAGE cuda-nvprof-11-8-${NV_NVPROF_VERSION}
+ENV NV_CUDA_CUDART_DEV_VERSION 11.8.89-1
+ENV NV_NVML_DEV_VERSION 11.8.86-1
+ENV NV_LIBCUBLAS_DEV_VERSION 11.11.3.6-1
+ENV NV_LIBNPP_DEV_VERSION 11.8.0.86-1
+ENV NV_LIBNPP_DEV_PACKAGE libnpp-devel-11-8-${NV_LIBNPP_DEV_VERSION}
+ENV NV_LIBNCCL_DEV_PACKAGE_NAME libnccl-devel
+ENV NV_LIBNCCL_DEV_PACKAGE_VERSION 2.15.5-1
+ENV NCCL_VERSION 2.15.5
+ENV NV_LIBNCCL_DEV_PACKAGE ${NV_LIBNCCL_DEV_PACKAGE_NAME}-${NV_LIBNCCL_DEV_PACKAGE_VERSION}+cuda11.8
+
+RUN yum install -y \
+    make \
+    cuda-command-line-tools-11-8-${NV_CUDA_LIB_VERSION} \
+    cuda-libraries-devel-11-8-${NV_CUDA_LIB_VERSION} \
+    cuda-minimal-build-11-8-${NV_CUDA_LIB_VERSION} \
+    cuda-cudart-devel-11-8-${NV_CUDA_CUDART_DEV_VERSION} \
+    ${NV_NVPROF_DEV_PACKAGE} \
+    cuda-nvml-devel-11-8-${NV_NVML_DEV_VERSION} \
+    libcublas-devel-11-8-${NV_LIBCUBLAS_DEV_VERSION} \
+    ${NV_LIBNPP_DEV_PACKAGE} \
+    ${NV_LIBNCCL_DEV_PACKAGE} \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+
+# Install CUDA devel cudnn8 from:
+# https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.8.0/ubi8/devel/cudnn8/Dockerfile
+ENV NV_CUDNN_VERSION 8.9.0.131-1
+ENV NV_CUDNN_PACKAGE libcudnn8-${NV_CUDNN_VERSION}.cuda11.8
+ENV NV_CUDNN_PACKAGE_DEV libcudnn8-devel-${NV_CUDNN_VERSION}.cuda11.8
+
+LABEL com.nvidia.cudnn.version="${NV_CUDNN_VERSION}"
+
+RUN yum install -y \
+    ${NV_CUDNN_PACKAGE} \
+    ${NV_CUDNN_PACKAGE_DEV} \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+# Install CUDA toolkit 11.8
+RUN yum -y install cuda-toolkit-11-8 && \
+    yum -y clean all --enablerepo="*"
+
+# Set this flag so that libraries can find the location of CUDA
+ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
+
+# Restore notebook user workspace
+USER 1001
+WORKDIR /opt/app-root/src

--- a/cuda/rhel9-python-3.9/NGC-DL-CONTAINER-LICENSE
+++ b/cuda/rhel9-python-3.9/NGC-DL-CONTAINER-LICENSE
@@ -1,0 +1,230 @@
+NVIDIA DEEP LEARNING CONTAINER LICENSE
+
+This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs the use
+of the NVIDIA container and all its contents (“CONTAINER”).
+
+This license can be accepted only by an adult of legal age of majority in the country in which the
+CONTAINER is used. If you are under the legal age of majority, you must ask your parent or legal
+guardian to consent to this license. If you are entering this license on behalf of a company or
+other legal entity, you represent that you have legal authority and “you” will mean the entity you
+represent.
+
+By using the CONTAINER, you affirm that you have reached the legal age of majority, you accept the
+terms of this license, and you take legal and financial responsibility for the actions of your
+permitted users.
+
+You agree to use the CONTAINER only for purposes that are permitted by (a) this license, and (b) any
+applicable law, regulation or generally accepted practices or guidelines in the relevant
+jurisdictions.
+
+1. LICENSE. Subject to the terms of this license, NVIDIA hereby grants you a non-exclusive,
+non-transferable license, without the right to sublicense (except as expressly provided in this
+license) to:
+
+a. Install and use copies of the CONTAINER, and modify and create derivative works of samples or
+example source code delivered in the CONTAINER (if applicable), to develop and test services and
+applications,
+
+b. Deploy the CONTAINER on infrastructure you own or lease to offer a service to third parties,
+without distributing the CONTAINER or exposing the NVIDIA APIs in the CONTAINER directly to such
+service users, and
+
+c. Develop and extend the CONTAINER to create a Compatible (as defined below) derived CONTAINER that
+includes the entire CONTAINER plus other software with primary functionality, to develop and compile
+applications, and distribute such derived CONTAINER to run applications, subject to the distribution
+requirements indicated in this license. As used in this section, “Compatible” means that extensions
+to the CONTAINER must not adversely affect the functionality of the other components in the
+CONTAINER.
+
+2. DISTRIBUTION REQUIREMENTS. For purposes of this Section 2, the term “distribution” also means the
+deployment of CONTAINERS in a service or an application for third parties to access over the
+internet. These are the distribution requirements for you to exercise the grants above:
+
+a. A service or an application must have material additional functionality, beyond the included
+portions of the CONTAINER.
+
+b. The following notice shall be included in modifications and derivative works of source code
+distributed: “This software contains source code provided by NVIDIA Corporation.”
+
+c. You agree to distribute the CONTAINER subject to the terms at least as protective as the terms of
+this license, including (without limitation) terms relating to the license grant, license
+restrictions and protection of NVIDIA’s intellectual property rights. Additionally, you agree that
+you will protect the privacy, security and legal rights of your application users.
+
+d. You agree to notify NVIDIA in writing of any known or suspected distribution or use of the
+CONTAINER not in compliance with the requirements of this license, and to enforce the terms of your
+agreements with respect to the distributed CONTAINER.
+
+3. AUTHORIZED USERS. You may allow employees and contractors of your entity or of your
+subsidiary(ies) to access and use the CONTAINER from your secure network to perform work on your
+behalf. If you are an academic institution you may allow users enrolled or employed by the academic
+institution to access and use the CONTAINER from your secure network. You are responsible for the
+compliance with the terms of this license by your authorized users.
+
+4. LIMITATIONS. Your license to use the CONTAINER is restricted as follows:
+
+a. The CONTAINER is licensed for you to develop services and applications only for their use in
+systems with NVIDIA GPUs.
+
+b. You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary
+notices from any portion of the CONTAINER or copies of the CONTAINER.
+
+c. Except as expressly provided in this license, you may not copy, sell, rent, sublicense, transfer,
+distribute, modify, or create derivative works of any portion of the CONTAINER. For clarity, you may
+not distribute or sublicense the CONTAINER as a stand-alone product.
+
+d. Unless you have an agreement with NVIDIA for this purpose, you may not indicate that a service or
+an application created with the CONTAINER is sponsored or endorsed by NVIDIA.
+
+e. You may not bypass, disable, or circumvent any technical limitation, encryption, security,
+digital rights management or authentication mechanism in the CONTAINER.
+
+f. You may not replace any NVIDIA software components in the CONTAINER that are governed by this
+license with other software that implements NVIDIA APIs.
+
+g. You may not use the CONTAINER in any manner that would cause it to become subject to an open
+source software license. As examples, licenses that require as a condition of use, modification,
+and/or distribution that the CONTAINER be: (i) disclosed or distributed in source code form; (ii)
+licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+
+h. Unless you have an agreement with NVIDIA for this purpose, you may not use the CONTAINER with any
+system or application where the use or failure of the system or application can reasonably be
+expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use
+in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA
+does not design, test or manufacture the CONTAINER for these critical uses and NVIDIA shall not be
+liable to you or any third party, in whole or in part, for any claims or damages arising from such
+uses.
+
+i. You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective
+employees, contractors, agents, officers and directors, from and against any and all claims,
+damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses
+(including but not limited to attorney’s fees and costs incident to establishing the right of
+indemnification) arising out of or related to your use of the CONTAINER outside of the scope of this
+license, or not in compliance with its terms.
+
+5. UPDATES. NVIDIA may, at its option, make available patches, workarounds or other updates to this
+CONTAINER. Unless the updates are provided with their separate governing terms, they are deemed part
+of the CONTAINER licensed to you as provided in this license. You agree that the form and content of
+the CONTAINER that NVIDIA provides may change without prior notice to you. While NVIDIA generally
+maintains compatibility between versions, NVIDIA may in some cases make changes that introduce
+incompatibilities in future versions of the CONTAINER.
+
+6. PRE-RELEASE VERSIONS. CONTAINER versions identified as alpha, beta, preview, early access or
+otherwise as pre-release may not be fully functional, may contain errors or design flaws, and may
+have reduced or different security, privacy, availability, and reliability standards relative to
+commercial versions of NVIDIA software and materials. You may use a pre-release CONTAINER version at
+your own risk, understanding that these versions are not intended for use in production or
+business-critical systems. NVIDIA may choose not to make available a commercial version of any
+pre-release CONTAINER. NVIDIA may also choose to abandon development and terminate the availability
+of a pre-release CONTAINER at any time without liability.
+
+7. THIRD-PARTY COMPONENTS. The CONTAINER may include third-party components with separate legal
+notices or terms as may be described in proprietary notices accompanying the CONTAINER. If and to
+the extent there is a conflict between the terms in this license and the third-party license terms,
+the third-party terms control only to the extent necessary to resolve the conflict.
+
+You acknowledge and agree that it is your sole responsibility to obtain any additional third-party
+licenses required to make, have made, use, have used, sell, import, and offer for sale your products
+or services that include or incorporate any third-party software and content relating to audio
+and/or video encoders and decoders from, including but not limited to, Microsoft, Thomson,
+Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding Technologies. NVIDIA does not grant to you under
+this license any necessary patent or other rights with respect to any audio and/or video encoders
+and decoders.
+
+Subject to the other terms of this license, you may use the CONTAINER to develop and test
+applications released under Open Source Initiative (OSI) approved open source software licenses.
+
+8. OWNERSHIP.
+
+8.1 NVIDIA reserves all rights, title and interest in and to the CONTAINER not expressly granted to
+you under this license. NVIDIA and its suppliers hold all rights, title and interest in and to the
+CONTAINER, including their respective intellectual property rights. The CONTAINER is copyrighted and
+protected by the laws of the United States and other countries, and international treaty provisions.
+
+8.2 Subject to the rights of NVIDIA and its suppliers in the CONTAINER, you hold all rights, title
+and interest in and to your services, applications and your derivative works of the sample source
+code delivered in the CONTAINER including their respective intellectual property rights.
+
+9. FEEDBACK. You may, but are not obligated to, provide to NVIDIA suggestions, fixes, modifications,
+feature requests or other feedback regarding the CONTAINER (“Feedback”). Feedback, even if
+designated as confidential by you, shall not create any confidentiality obligation for NVIDIA.
+NVIDIA and its designees have a perpetual, non-exclusive, worldwide, irrevocable license to use,
+reproduce, publicly display, modify, create derivative works of, license, sublicense, and otherwise
+distribute and exploit Feedback as NVIDIA sees fit without payment and without obligation or
+restriction of any kind on account of intellectual property rights or otherwise.
+
+10. NO WARRANTIES. THE CONTAINER IS PROVIDED AS-IS. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE
+LAW NVIDIA AND ITS AFFILIATES EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND OR NATURE, WHETHER
+EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY,
+NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE CONTAINER
+WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR
+THAT ALL ERRORS WILL BE CORRECTED.
+
+11. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW NVIDIA AND ITS
+AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR
+FOR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF
+PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR
+PERFORMANCE OF THE CONTAINER, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF
+CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF
+ACTION OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY
+HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL
+CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE
+LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT.
+
+12. TERMINATION. Your rights under this license will terminate automatically without notice from
+NVIDIA if you fail to comply with any term and condition of this license or if you commence or
+participate in any legal proceeding against NVIDIA with respect to the CONTAINER. NVIDIA may
+terminate this license with advance written notice to you, if NVIDIA decides to no longer provide
+the CONTAINER in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer
+commercially viable. Upon any termination of this license, you agree to promptly discontinue use of
+the CONTAINER and destroy all copies in your possession or control. Your prior distributions in
+accordance with this license are not affected by the termination of this license. All provisions of
+this license will survive termination, except for the license granted to you.
+
+13. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States
+and of the State of Delaware, without regard to the conflicts of laws principles. The United Nations
+Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to
+all terms of this license in the English language. The state or federal courts residing in Santa
+Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of
+this license. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for
+injunctive remedies or urgent legal relief in any jurisdiction.
+
+14. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by
+you by any means or operation of law without NVIDIA’s permission. Any attempted assignment not
+approved by NVIDIA in writing shall be void and of no effect. NVIDIA may assign, delegate or
+transfer this license and its rights and obligations, and if to a non-affiliate you will be
+notified.
+
+15. EXPORT. The CONTAINER is subject to United States export laws and regulations. You agree to
+comply with all applicable
+
+U.S. and international export laws, including the Export Administration Regulations (EAR)
+administered by the U.S. Department of Commerce and economic sanctions administered by the U.S.
+Department of Treasury’s Office of Foreign Assets Control (OFAC). These laws include restrictions on
+destinations, end-users and end-use. By accepting this license, you confirm that you are not
+currently residing in a country or region currently embargoed by the U.S. and that you are not
+otherwise prohibited from receiving the CONTAINER.
+
+16. GOVERNMENT USE. The CONTAINER is, and shall be treated as being, “Commercial Items” as that term
+is defined at 48 CFR § 2.101, consisting of “commercial computer software” and “commercial computer
+software documentation”, respectively, as such terms are used in, respectively, 48 CFR § 12.212 and
+48 CFR §§ 227.7202 & 252.227-7014(a)(1). Use, duplication or disclosure by the U.S. Government or a
+U.S. Government subcontractor is subject to the restrictions in this license pursuant to 48 CFR §
+12.212 or 48 CFR § 227.7202. In no event shall the US Government user acquire rights in the
+CONTAINER beyond those specified in 48 C.F.R. 52.227-19(b)(1)-(2).
+
+17. NOTICES. Please direct your legal notices or other correspondence to NVIDIA Corporation, 2788
+San Tomas Expressway, Santa Clara, California 95051, United States of America, Attention: Legal
+Department.
+
+18. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the
+parties relating to the subject matter of this license and supersedes all prior or contemporaneous
+understandings and agreements relating to this subject matter, whether oral or written. If any court
+of competent jurisdiction determines that any provision of this license is illegal, invalid or
+unenforceable, the remaining provisions will remain in full force and effect. Any amendment or
+waiver under this license shall be in writing and signed by representatives of both parties.
+
+19. LICENSING. If the distribution terms in this license are not suitable for your organization, or
+for any questions regarding this license, please contact NVIDIA at nvidia-compute-license-questions@nvidia.com.
+
+(v. December 4, 2020)

--- a/cuda/rhel9-python-3.9/cuda.repo-x86_64
+++ b/cuda/rhel9-python-3.9/cuda.repo-x86_64
@@ -1,0 +1,6 @@
+[cuda]
+name=cuda
+baseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/codeserver"
+    opendatahub.io/notebook-image-name: "Code Server"
+    opendatahub.io/notebook-image-desc: "Code Server workbench image, allows to run Visual Studio Code (VSCode) on a remote server through the browser."
+    opendatahub.io/notebook-image-order: "80"
+  name: code-server-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # N Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.16"}]'
+        openshift.io/imported-from: quay.io/modh/codeserver
+        opendatahub.io/workbench-image-recommended: 'true'
+      from:
+        kind: DockerImage
+        name: $(odh-codeserver-notebook-n)
+      name: "2023.2"
+      referencePolicy:
+        type: Source

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -146,5 +146,12 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
+  - name: odh-codeserver-notebook-n
+    objref:
+      kind: ConfigMap
+      name: notebooks-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-n
 configurations:
   - params.yaml

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -16,3 +16,4 @@ odh-tensorflow-gpu-notebook-image-n-2=quay.io/modh/cuda-notebooks@sha256:6fadedc
 odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:b68c1bfd9926b224180835382b36ad25e2269ffb95fca0646a89c8cceb6a6e7a
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:de46659eccc3dd8e4b79cfbf7fc95464f76ffcc06f3f914841533130fba2985f
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:0f6ae8f0b1ef11896336e7f8611e77ccdb992b49a7942bf27e6bc64d73205d05
+odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -72,3 +72,7 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-habana-notebook-image-n
+  - path: spec/tags[]/from/name
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-n

--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,120 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+LABEL name="odh-notebook-rstudio-rhel9-python-3.9" \
+      summary="R Studio image with python 3.9 based on CentOS Stream 9" \
+      description="Code Server (VS Code) image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.display-name="R Studio image with python 3.9 based on CentOS Stream 9" \
+      io.k9s.description="R Studio image with python 3.9 based on CentOS Stream 9" \
+      authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.9" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.9"
+
+USER 0
+
+ENV R_VERSION=4.3.1
+
+# Enable EPEL repositories and Install R
+RUN dnf install -y yum-utils && \
+    subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms && \
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    INSTALL_PKGS="R-core R-core-devel R-java R-Rcpp R-highlight \
+    R-littler R-littler-examples openssl-libs compat-openssl11" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /usr/lib64/R/etc/Rprofile.site && \
+    (umask 002;touch /usr/lib64/R/etc/Renviron.site) && \
+    dnf -y clean all --enablerepo='*'
+
+
+# R needs the CUDA toolkit and special flags to build Tensorflow and other packages
+RUN yum -y install cuda-toolkit-11-8 && \
+    yum -y clean all  --enablerepo='*'; \
+
+# set R library to default (used in install.r from littler)
+ENV LIBLOC /usr/lib64/R/library
+
+# set User R Library path
+ENV R_LIBS_USER /opt/app-root/src/Rpackages/4.2
+
+WORKDIR /tmp/
+
+# Install RStudio
+RUN wget https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2023.06.1-524-x86_64.rpm && \
+    yum install -y rstudio-server-rhel-2023.06.1-524-x86_64.rpm && \
+    rm rstudio-server-rhel-2023.06.1-524-x86_64.rpm && \
+    yum -y clean all  --enablerepo='*'
+
+# Specific RStudio config and fixes
+RUN chmod 1777 /var/run/rstudio-server && \
+    mkdir -p /usr/share/doc/R
+COPY rsession.conf /etc/rstudio/rsession.conf
+
+# Install NGINX to proxy RStudio and pass probes check 
+ENV NGINX_VERSION=1.22 \
+    NGINX_SHORT_VER=122 \
+    NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+# Modules does not exist
+RUN yum -y module enable nginx:$NGINX_VERSION && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
+    # spawn-fcgi is not in epel9
+    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    yum -y clean all --enablerepo='*'
+
+# Copy extra files to the image.
+COPY nginx/root/ /
+
+# Changing ownership and user rights to support following use-cases:
+# 1) running container on OpenShift, whose default security model
+#    is to run the container under random UID, but GID=0
+# 2) for working root-less container with UID=1001, which does not have
+#    to have GID=0
+# 3) for default use-case, that is running container directly on operating system,
+#    with default UID and GID (1001:0)
+# Supported combinations of UID:GID are thus following:
+# UID=1001 && GID=0
+# UID=<any>&& GID=0
+# UID=1001 && GID=<any>
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/api/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    chown -R 1001:0 ${NGINX_CONF_PATH} && \
+    chown -R 1001:0 ${NGINX_APP_ROOT}/etc && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod    ug+rw  ${NGINX_CONF_PATH} && \
+    chmod -R ug+rwX ${NGINX_APP_ROOT}/etc && \
+    chmod -R ug+rwX ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run && \
+    rpm-file-permissions
+
+# Configure nginx
+COPY nginx/serverconf/ /opt/app-root/etc/nginx.default.d/
+COPY nginx/httpconf/ /opt/app-root/etc/nginx.d/
+COPY nginx/api/ /opt/app-root/api/
+
+# Launcher
+WORKDIR /opt/app-root/bin
+
+COPY utils utils/
+COPY run-rstudio.sh setup_rstudio.py rsession.sh run-nginx.sh ./
+
+WORKDIR /opt/app-root/src
+
+USER 1001
+
+CMD /opt/app-root/bin/run-rstudio.sh

--- a/rstudio/rhel9-python-3.9/kustomize/base/kustomization.yaml
+++ b/rstudio/rhel9-python-3.9/kustomize/base/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: rstudio-
+resources:
+  - pod.yaml
+images:
+  - name: rstudio-workbench
+    newName: quay.io/opendatahub/workbench-images
+    newTag: rstudio-c9s-python-3.9

--- a/rstudio/rhel9-python-3.9/kustomize/base/pod.yaml
+++ b/rstudio/rhel9-python-3.9/kustomize/base/pod.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  labels:
+    app: rstudio-image
+spec:
+  containers:
+    - name: rstudio
+      image: rstudio-workbench
+      command: ["/bin/sh", "-c", "while true ; do date; sleep 5; done;"]
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 8787
+      resources:
+        limits:
+          cpu: 500m
+          memory: 500Mi
+        requests:
+          cpu: 500m
+          memory: 500Mi

--- a/rstudio/rhel9-python-3.9/nginx/api/kernels/access.cgi
+++ b/rstudio/rhel9-python-3.9/nginx/api/kernels/access.cgi
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Status: 200"
+echo "Content-type: application/json"
+echo
+# Retrieve last line from custom logs
+LOG_TAIL=$(tail -n 1 /var/log/nginx/rstudio.access.log)
+# Extract last_activity field
+LAST_ACTIVITY=$(echo $LOG_TAIL | grep -Po 'last_activity":"\K.*?(?=")')
+if [[ $(date -d $LAST_ACTIVITY"+10 minutes" +%s) -lt $(date +%s) ]]; then
+    # No activity for the past 10mn, we consider VSCode idle and begin to send idle response
+    # As logs always write "busy", we first substitute with "idle" in the answer
+    sed s/busy/idle/ <<<"$LOG_TAIL"
+else
+    echo $LOG_TAIL
+fi

--- a/rstudio/rhel9-python-3.9/nginx/api/probe.cgi
+++ b/rstudio/rhel9-python-3.9/nginx/api/probe.cgi
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [[ $(ps -aux | grep server | grep rsession) ]]; then
+    echo "Status: 200"
+    echo "Content-type: text/html"
+    echo
+    echo  "<html><body>RServer is up!</body></html>"
+else
+    echo "Status: 404"
+    echo "Content-type: text/html"
+    echo ""
+    echo "<html><body>RServer is not running!</body></html>"
+fi

--- a/rstudio/rhel9-python-3.9/nginx/httpconf/http.conf
+++ b/rstudio/rhel9-python-3.9/nginx/httpconf/http.conf
@@ -1,0 +1,39 @@
+# Make WebSockets working
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+###
+# Custom logging for direct last_activity based culling, brace yourself!
+###
+
+# Exclude heartbeat from logging for culling purposes
+map $request $loggable {
+    ~\/rstudio\/events\/get_events  0;
+    default 1;
+}
+
+# iso8601 with millisecond precision transformer (mimicking Jupyter output)
+map $time_iso8601 $time_iso8601_p1 {
+    ~([^+]+) $1;
+}
+map $time_iso8601 $time_iso8601_p2 {
+    ~\+([0-9:]+)$ $1;
+}
+map $msec $millisec {
+    ~\.([0-9]+)$ $1;
+}
+
+log_format json escape=json '[{'
+    '"id":"rstudio",'
+    '"name":"rstudio",'
+    '"last_activity":"$time_iso8601_p1.$millisec+$time_iso8601_p2",'
+    '"execution_state":"busy",'
+    '"connections": 1'
+    '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
+++ b/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/etc/generate_container_user
@@ -1,0 +1,9 @@
+# Set current user in nss_wrapper
+PASSWD_DIR="/opt/app-root/etc"
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < ${PASSWD_DIR}/passwd.template > ${PASSWD_DIR}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${PASSWD_DIR}/passwd
+export NSS_WRAPPER_GROUP=/etc/group

--- a/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/etc/passwd.template
+++ b/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/etc/passwd.template
@@ -1,0 +1,15 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin
+apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin

--- a/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/etc/scl_enable
+++ b/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-nginx$NGINX_SHORT_VER

--- a/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
+++ b/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
@@ -1,0 +1,18 @@
+# Change port
+/listen/s%80%8888 default_server%
+
+# One worker only
+/worker_processes/s%auto%1%
+
+s/^user *nginx;//
+s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
+s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
+s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d
+
+# Addition for RStudio
+/server_name/s%server_name  _%server_name  ${BASE_URL}%

--- a/rstudio/rhel9-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
+++ b/rstudio/rhel9-python-3.9/nginx/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/rstudio/rhel9-python-3.9/nginx/serverconf/proxy.conf.template
+++ b/rstudio/rhel9-python-3.9/nginx/serverconf/proxy.conf.template
@@ -1,0 +1,67 @@
+###############
+# Fix rstudio-server auth-sign-in redirect bug
+###############
+rewrite ^/auth-sign-in(.*) "$custom_scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$custom_scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+###############
+
+###############
+# api calls from probes get to CGI processing
+###############
+location /api/ {
+  index probe.cgi;
+  fastcgi_index probe.cgi;
+  gzip off;
+  access_log  off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+
+location = /api/kernels {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = / {
+    return 302 $custom_scheme://$http_host/rstudio/;
+}
+
+location = /rstudio {
+    return 302 $custom_scheme://$http_host/rstudio/;
+}
+
+location /rstudio/ {
+    rewrite ^/rstudio/(.*)$ /$1 break;
+    # Standard RStudio/NGINX configuration
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+
+    # Needed to make it work properly
+    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Root-Path /rstudio;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
+
+    access_log /var/log/nginx/rstudio.access.log json if=$loggable;
+}
+###############

--- a/rstudio/rhel9-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/rstudio/rhel9-python-3.9/nginx/serverconf/proxy.conf.template_nbprefix
@@ -1,0 +1,94 @@
+###############
+# Fix rstudio-server auth-sign-in redirect bug
+###############
+rewrite ^/auth-sign-in(.*) "$custom_scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$custom_scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+###############
+
+###############
+# api calls from probes get to CGI processing
+###############
+location = ${NB_PREFIX}/api {
+    return 302 /api/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/ {
+    return 302 /api/;
+    access_log  off;
+}
+
+location /api/ {
+  index probe.cgi;
+  fastcgi_index probe.cgi;
+  gzip off;
+  access_log  off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# api calls from culler get to CGI processing
+###############
+location = ${NB_PREFIX}/api/kernels {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location ${NB_PREFIX}/api/kernels/ {
+    return 302 $custom_scheme://$http_host/api/kernels/;
+    access_log  off;
+}
+
+location /api/kernels/ {
+  index access.cgi;
+  fastcgi_index access.cgi;
+  gzip  off;
+  access_log    off;
+  root  /opt/app-root;
+  fastcgi_pass  unix:/var/run/fcgiwrap.socket;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME  /opt/app-root$fastcgi_script_name;
+}
+###############
+
+###############
+# root and prefix get to RStudio endpoint
+###############
+location = ${NB_PREFIX} {
+    return 302 $custom_scheme://$http_host/rstudio/;
+}
+
+location ${NB_PREFIX}/ {
+    return 302 $custom_scheme://$http_host/rstudio/;
+}
+
+location = /rstudio {
+    return 302 $custom_scheme://$http_host/rstudio/;
+}
+
+location = / {
+    return 302 $custom_scheme://$http_host/rstudio/;
+}
+
+location /rstudio/ {
+    rewrite ^/rstudio/(.*)$ /$1 break;
+    # Standard RStudio/NGINX configuration
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 20d;
+
+    # Needed to make it work properly
+    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Root-Path /rstudio;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
+
+    access_log /var/log/nginx/rstudio.access.log json if=$loggable;
+}
+###############

--- a/rstudio/rhel9-python-3.9/rsession.conf
+++ b/rstudio/rhel9-python-3.9/rsession.conf
@@ -1,0 +1,2 @@
+# Set library path
+r-libs-user=/opt/app-root/src/Rpackages/4.2

--- a/rstudio/rhel9-python-3.9/rsession.sh
+++ b/rstudio/rhel9-python-3.9/rsession.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/lib/rstudio-server/bin/rsession "$@"

--- a/rstudio/rhel9-python-3.9/run-nginx.sh
+++ b/rstudio/rhel9-python-3.9/run-nginx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+# disabled, only used to source nginx files in user directory
+#process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
+
+if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
+fi
+
+# substitute NB_PREFIX in proxy configuratin if it exists
+if [ -z "$NB_PREFIX" ]; then
+    cp /opt/app-root/etc/nginx.default.d/proxy.conf.template /opt/app-root/etc/nginx.default.d/proxy.conf
+else
+    export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
+    envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+fi
+
+nginx

--- a/rstudio/rhel9-python-3.9/run-rstudio.sh
+++ b/rstudio/rhel9-python-3.9/run-rstudio.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Load bash libraries
+SCRIPT_DIR=$(dirname -- "$0")
+source ${SCRIPT_DIR}/utils/*.sh
+
+# Start nginx and fastcgiwrap
+run-nginx.sh &
+spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+
+
+# Add .bashrc for custom promt if not present
+if [ ! -f "/opt/app-root/src/.bashrc" ]; then
+  echo 'PS1="\[\033[34;1m\][\$(pwd)]\[\033[0m\]\n\[\033[1;0m\]$ \[\033[0m\]"' > /opt/app-root/src/.bashrc
+fi
+
+# Create lib folders if it does not exist
+mkdir -p  /opt/app-root/src/Rpackages/4.3
+
+# rstudio terminal cant see environment variables set by the container runtime
+# (which breaks kubectl, to fix this we store the KUBERNETES_* env vars in Renviron.site)
+env | grep KUBERNETES_ >> /usr/lib64/R/etc/Renviron.site
+
+export USER=$(whoami)
+
+# Initilize access logs for culling
+echo '[{"id":"rstudio","name":"rstudio","last_activity":"'$(date -Iseconds)'","execution_state":"running","connections":1}]' > /var/log/nginx/rstudio.access.log
+
+# Create RStudio launch command
+launch_command=$(python /opt/app-root/bin/setup_rstudio.py)
+
+echo $launch_command
+
+start_process $launch_command

--- a/rstudio/rhel9-python-3.9/setup_rstudio.py
+++ b/rstudio/rhel9-python-3.9/setup_rstudio.py
@@ -1,0 +1,83 @@
+import getpass
+import os
+import shutil
+import subprocess
+import tempfile
+from textwrap import dedent
+from urllib.parse import urlparse, urlunparse
+
+def get_rstudio_executable(prog):
+    # Find prog in known locations
+    other_paths = [
+        # When rstudio-server deb is installed
+        os.path.join('/usr/lib/rstudio-server/bin', prog),
+        # When just rstudio deb is installed
+        os.path.join('/usr/lib/rstudio/bin', prog),
+    ]
+    if shutil.which(prog):
+        return shutil.which(prog)
+
+    for op in other_paths:
+        if os.path.exists(op):
+            return op
+
+    raise FileNotFoundError(f'Could not find {prog} in PATH')
+
+def db_config(db_dir):
+    '''
+    Create a temporary directory to hold rserver's database, and create
+    the configuration file rserver uses to find the database.
+
+    https://docs.rstudio.com/ide/server-pro/latest/database.html
+    https://github.com/rstudio/rstudio/tree/v1.4.1103/src/cpp/server/db
+    '''
+    # create the rserver database config
+    db_conf = dedent("""
+        provider=sqlite
+        directory={directory}
+    """).format(directory=db_dir)
+    f = tempfile.NamedTemporaryFile(mode='w', delete=False, dir=db_dir)
+    db_config_name = f.name
+    f.write(db_conf)
+    f.close()
+    return db_config_name
+
+def _support_arg(arg):
+    ret = subprocess.check_output([get_rstudio_executable('rserver'), '--help'])
+    return ret.decode().find(arg) != -1
+
+def _get_cmd(port):
+    ntf = tempfile.NamedTemporaryFile()
+
+    # use mkdtemp() so the directory and its contents don't vanish when
+    # we're out of scope
+    server_data_dir = tempfile.mkdtemp()
+    database_config_file = db_config(server_data_dir)
+
+    cmd = [
+        get_rstudio_executable('rserver'),
+        '--server-daemonize=0',
+        '--server-working-dir=' + os.getenv('HOME'),
+        '--auth-none=1',
+        '--www-frame-origin=same',
+        #'--www-address=0.0.0.0',
+        '--www-port=' + str(port),
+        '--www-verify-user-agent=0',
+        '--rsession-which-r=' + get_rstudio_executable('R'),
+        '--secure-cookie-key-file=' + ntf.name,
+        '--server-user=' + getpass.getuser(),
+        '--rsession-path=/opt/app-root/bin/rsession.sh',
+    ]
+    # Support at least v1.2.1335 and up
+
+    #if _support_arg('www-root-path'):
+    #    cmd.append('--www-root-path=/rstudio/')
+    if _support_arg('server-data-dir'):
+        cmd.append(f'--server-data-dir={server_data_dir}')
+    if _support_arg('database-config-file'):
+        cmd.append(f'--database-config-file={database_config_file}')
+    
+    return(' '.join(cmd))
+
+if __name__ == "__main__":
+    print(_get_cmd(8787))

--- a/rstudio/rhel9-python-3.9/utils/process.sh
+++ b/rstudio/rhel9-python-3.9/utils/process.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+function start_process() {
+    trap stop_process TERM INT
+
+    echo "Running command: $@"
+    "$@" &
+
+    PID=$!
+    wait $PID
+    trap - TERM INT
+    wait $PID
+    STATUS=$?
+    exit $STATUS
+}
+
+function stop_process() {
+    echo "Stopping rstudio-server"
+    rstudio-server suspend-all
+    sleep 5 #Wait for the session to properly stop
+    kill -TERM $PID
+}


### PR DESCRIPTION
This is a testing PR to work on the RStudio based on RHEL9.

There are the following issues while we try to install R on RHEL:

**1. CRB repo**

The Docker build process is breaking on this [line](https://github.com/atheo89/notebooks/blob/rstudio-rhel/rstudio/rhel9-python-3.9/Dockerfile#L19) while it tries to enable the CRB repo, with the error:
`No matching repo to modify: crb.`

If you investigate on the container about the repo list we have only: the following:
```
(app-root) (app-root) cat /etc/redhat-release
Red Hat Enterprise Linux release 9.2 (Plow)

(app-root) (app-root) dnf repolist
Updating Subscription Management repositories.
Unable to read consumer identity
Subscription Manager is operating in container mode.

This system is not registered with an entitlement server. You can use subscription-manager to register.

repo id                                              repo name
ubi-9-appstream-rpms                                 Red Hat Universal Base Image 9 (RPMs) - AppStream
ubi-9-baseos-rpms                                    Red Hat Universal Base Image 9 (RPMs) - BaseOS
ubi-9-codeready-builder                              Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder
```
If you do it in different way, like `RUN /usr/bin/crb enable`  
again it throws the following: `/usr/bin/crb: No such file or directory`

The R language and all its dependencies are hosted CRB repo [ref link](https://infotechys.com/install-r-rstudio-on-rhel9-centos9/)

**2. CUDA Toolkit**

Also another issue is that we can not install the cuda toolkit on this [instruction](https://github.com/atheo89/notebooks/blob/rstudio-rhel/rstudio/rhel9-python-3.9/Dockerfile#L42)



Could these be subscription issues? Since on C9S these instructions are working as expected. 
