### PR TITLE
Update runtime image on 2023a based on the commit id: ff23c42

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:d8bac12fddaf0a3e4d4ac56773a5937d9a03858c961e5b06667cb3d7949c1fd5"
+        "image_name": "quay.io/modh/runtime-images@sha256:248efbd4fd4df5566ed8143bdc7b18f711d9e94ed720365ddc3f59ef0413b4ac"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:b14c39fcd1a701ae62d7eebfff41cc4afbd03ade1412d00d8fab1f83b6af9e64"
+        "image_name": "quay.io/modh/runtime-images@sha256:9e52b76e084c468392904b026be0b0c67951986b3e610cffebff6d0e1ae7a39d"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:b56b923f2f68339ac34eda956ad2cd2f369507b7f60f2264a74d947046077e0c"
+        "image_name": "quay.io/modh/runtime-images@sha256:c1afe16306b75733ca6c4bde639c8164eaf2f9b65334df8a7b207cd2d5a2d938"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:d9e152ef6ae10b2b721779f8e76fc27f38a1b68a0eb46180af47503b4241ddd6"
+        "image_name": "quay.io/modh/runtime-images@sha256:61fd437c2789f4c93a936dd4637dfdc915b2b7ed061b5e75626b5ae8557d2615"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Datascience with Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:cf3535db122d4474949debc931e115f27e5f60b7289cb6e2a55c952b7b4a1726"
+        "image_name": "quay.io/modh/runtime-images@sha256:682b2b6dca8449bef93864148551806cda05097fe7cd1e5970c40a5130baa2b7"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:b6000f91c1489ac5acaaac5e2ebf4b3e0a1e78d0c93b13bf41eba827fbf52098"
+        "image_name": "quay.io/modh/runtime-images@sha256:9740a9a647459b263120a2a914619226e8790bae47add31061a025157d834836"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:56b4cdade363b6536c4b62fde7717eba16cf2b9085d48361918b8d65ae9a4c41"
+        "image_name": "quay.io/modh/runtime-images@sha256:d617bc222535116821cdf03ce866de66cd8cd044ae44c815062e848be686adef"
     },
     "schema_name": "runtime-image"
 }

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": [],
         "display_name": "Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:db564cdab5f7b2d305a88cd4a0146d915d1c88988b1b0819803766a79a041693"
+        "image_name": "quay.io/modh/runtime-images@sha256:8d7d131765e41e8117f246ac5eac5e09e1d71f2d61183aaa6947aa7e099e4215"
     },
     "schema_name": "runtime-image"
 }


### PR DESCRIPTION
Update runtime image on 2023a based on the commit id: ff23c42
Related-to: https://github.com/opendatahub-io/notebooks/issues/202