### PR TITLE
Update runtime image on 2023b based on the commit id: c8e0724

### DIFF
--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["datascience","runtime-datascience-ubi8-python-3.8-2023b-20231110-865fe76"],
         "display_name": "Datascience with Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:b81f1dceb852207a67ec578a0b59982974c103048a151b30f5f166efb4e3db46",
+        "image_name": "quay.io/modh/runtime-images@sha256:77a42c6c05edd6d53db6c911f1e258a4a80930c430815ab57d0409ac308b891d",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["pytorch","runtime-pytorch-ubi8-python-3.8-2023b-20231110-865fe76"],
         "display_name": "Pytorch with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:833a042aa833f6f7df172d8586711b2a3010d988ebb0b679c184bbd3ae0dc9b6",
+        "image_name": "quay.io/modh/runtime-images@sha256:1f61a361c09d3338c35ebc2bd6b0b95a3d130e04901e4b0270c79c85007753dd",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["tensorflow","runtime-cuda-tensorflow-ubi8-python-3.8-2023b-20231110-865fe76"],
         "display_name": "TensorFlow with CUDA and Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:f48c69cbf6e1cfdb33dd7039ba6c361e617baf9b2121cb88263dda969098b173",
+        "image_name": "quay.io/modh/runtime-images@sha256:88c3a3106486dfc8cbd24a3b446d71365107aed17b9e24faf908f9d921f7b09e",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
+++ b/jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["minimal","runtime-minimal-ubi8-python-3.8-2023b-20231110-865fe76"],
         "display_name": "Python 3.8 (UBI8)",
-        "image_name": "quay.io/modh/runtime-images@sha256:a77ee72e18e23e0218b87b5b4fd0497e0b97cfea4432bff2e26c1ea64a36c84e",
+        "image_name": "quay.io/modh/runtime-images@sha256:7f6a9cbfbd963eb2713cc752f329ed1bba30108c3eb65d140b3827521de4f56f",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["datascience", "runtime-datascience-ubi9-python-3.9-2023b-20231110-865fe76"],
         "display_name": "Datascience with Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:9ab9f1851ff24f1d1249136507bc6c1fd6c15c433fa402a7ee08deb021f06b25",
+        "image_name": "quay.io/modh/runtime-images@sha256:58d45c4313097ccc4a8f2c81b30a5861cb51f0aa468a3bb66c5bb1ef16526c6b",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["pytorch","runtime-pytorch-ubi9-python-3.9-2023b-20231110-865fe76"],
         "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:bac3c47454910c065d5beaa6d4cad4ea51ced9c5c5770549e0c51c108bb33fa8",
+        "image_name": "quay.io/modh/runtime-images@sha256:2d7b74e328be91a0d570eb5bdb818955a72be808b605992815b56991dbe90514",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["tensorflow","runtime-cuda-tensorflow-ubi9-python-3.9-2023b-20231110-865fe76"],
         "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:1f369ade72a79b24b500aaddd601cc57f7ab12638af0aae5678a13851801e201",
+        "image_name": "quay.io/modh/runtime-images@sha256:647c65023e62f292161640e6420d564ac618ed441b5b542e6fd7d81497e5f28a",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -3,7 +3,7 @@
     "metadata": {
         "tags": ["minimal","runtime-minimal-ubi9-python-3.9-2023b-20231110-865fe76"],
         "display_name": "Python 3.9 (UBI9)",
-        "image_name": "quay.io/modh/runtime-images@sha256:6ebdcb9486fbad7feecc8cd66a75b414fec9d3604db188a1c8fed7a0187f40ba",
+        "image_name": "quay.io/modh/runtime-images@sha256:70e893f82b80626b694205152268c13991c131a11c6e04f037464dfd163b8bea",
         "pull_policy": "IfNotPresent"
     },
     "schema_name": "runtime-image"


### PR DESCRIPTION
Update runtime image on 2023b based on the commit id: c8e0724

Related-to: OAI 2.5
https://github.com/opendatahub-io/notebooks/issues/329