### PR TITLE
Incorporate VSCode on downstream

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/codeserver"
+    opendatahub.io/notebook-image-name: "Code Server"
+    opendatahub.io/notebook-image-desc: "Code Server workbench image, allows to run Visual Studio Code (VSCode) on a remote server through the browser."
+    opendatahub.io/notebook-image-order: "80"
+  name: odh-code-server-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # N Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.16"}]'
+        openshift.io/imported-from: quay.io/modh/codeserver
+        opendatahub.io/workbench-image-recommended: 'true'
+      from:
+        kind: DockerImage
+        name: $(odh-codeserver-notebook-n)
+      name: "2023.2"
+      referencePolicy:
+        type: Source

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - jupyter-pytorch-notebook-imagestream.yaml
   - jupyter-tensorflow-notebook-imagestream.yaml
   - jupyter-trustyai-notebook-imagestream.yaml
+  - code-server-notebook-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"
@@ -146,5 +147,12 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
+  - name: odh-codeserver-notebook-n
+    objref:
+      kind: ConfigMap
+      name: notebooks-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-n
 configurations:
   - params.yaml

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -72,3 +72,7 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-habana-notebook-image-n
+  - path: spec/tags[]/from/name
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-n


### PR DESCRIPTION
This PR incorporates code-server notebook on downstream project by adding:

1. Its ImageStream object
2. and the kustomazation configurations

**NOTE:** Remains to  be declared the final image on the `params.env` ([link](https://github.com/red-hat-data-services/notebooks/blob/main/manifests/base/params.env#L18)) from code-server [registry](https://quay.io/repository/modh/codeserver?tab=tags&tag=latest) 

`odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:xxxxxxxxxxxxxx`