### PR TITLE
Fix: Code Server notebook sha digest on the params.env file

### DIFF
--- a/manifests/base/commit.env
+++ b/manifests/base/commit.env
@@ -16,4 +16,4 @@ odh-tensorflow-gpu-notebook-image-commit-n-2=4c8f26e
 odh-trustyai-notebook-image-commit-n=cf1b63e
 odh-trustyai-notebook-image-commit-n-1=17c2e49
 odh-habana-notebook-image-commit-n=e5b5f1f
-odh-codeserver-notebook-image-commit-n=c91d58c
+odh-codeserver-notebook-image-commit-n=0e26442

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -16,4 +16,4 @@ odh-tensorflow-gpu-notebook-image-n-2=quay.io/modh/cuda-notebooks@sha256:6fadedc
 odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:b68c1bfd9926b224180835382b36ad25e2269ffb95fca0646a89c8cceb6a6e7a
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:de46659eccc3dd8e4b79cfbf7fc95464f76ffcc06f3f914841533130fba2985f
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:0f6ae8f0b1ef11896336e7f8611e77ccdb992b49a7942bf27e6bc64d73205d05
-odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:1c5bcbfc222dfb59849fee67e050719c688c93d3608f7b46edbe5666263641f3
+odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:f726d2e14b8595f4ac6a2f12f86d0ee0b35025fdc42595bd3ee2c1342c27dabb


### PR DESCRIPTION
Fix: Code Server notebook sha digest on the params.env file

[Quay.io](https://quay.io/repository/modh/codeserver?tab=tags) 