### PR TITLE
Fix: Code Server notebook sha digest on the params.env file (rhoai-2.6)

### DIFF
--- a/manifests/base/commit.env
+++ b/manifests/base/commit.env
@@ -16,4 +16,4 @@ odh-tensorflow-gpu-notebook-image-commit-n-2=3e71410
 odh-trustyai-notebook-image-commit-n=91ee989
 odh-trustyai-notebook-image-commit-n-1=07015ec
 odh-habana-notebook-image-commit-n=7d8f86d
-odh-codeserver-notebook-image-commit-n=c91d58c
+odh-codeserver-notebook-image-commit-n=0e26442

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -16,4 +16,5 @@ odh-tensorflow-gpu-notebook-image-n-2=quay.io/modh/cuda-notebooks@sha256:6fadedc
 odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:ccd9ebc37b220bcde8088d4b4e18aee8bdf2a8be0ccedab7a0b10c0ccd8d9c4e
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:0f6ae8f0b1ef11896336e7f8611e77ccdb992b49a7942bf27e6bc64d73205d05
-odh-codeserver-notebook-n=quay.io/opendatahub/workbench-images@sha256:1c5bcbfc222dfb59849fee67e050719c688c93d3608f7b46edbe5666263641f3
+odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:f726d2e14b8595f4ac6a2f12f86d0ee0b35025fdc42595bd3ee2c1342c27dabb
+


### PR DESCRIPTION
Fix: Code Server notebook sha digest on the params.env file (rhoai-2.6)

[Quay.io](https://quay.io/repository/modh/codeserver?tab=tags) 