### PR TITLE
Add rhel9 base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,13 @@ rstudio-c9s-python-3.9: base-c9s-python-3.9
 cuda-rstudio-c9s-python-3.9: cuda-c9s-python-3.9
 	$(call image,$@,rstudio/c9s-python-3.9,$<)
 
+####################################### Buildchain for RHEL9 #######################################
+
+# Build and push base-rhel9-python-3.9 image to the registry
+.PHONY: base-rhel9-python-3.9
+base-rhel9-python-3.9:
+	$(call image,$@,base/rhel9-python-3.9)
+
 ####################################### Buildchain for Anaconda Python #######################################
 
 # Build and push base-anaconda-python-3.8 image to the registry

--- a/base/rhel9-python-3.9/Dockerfile
+++ b/base/rhel9-python-3.9/Dockerfile
@@ -1,0 +1,42 @@
+FROM registry.redhat.io/rhel9/python-39:latest
+
+LABEL name="rhoai-notebook-base-rhel9-python-3.9" \
+      summary="Python 3.9 Red Hat Enterprise Linux 9 base image for RHOAI notebooks" \
+      description="Base Python 3.9 builder image based on Red Hat Enterprise Linux 9 for RHOAI notebooks" \
+      io.k9s.display-name="Python 3.9 RHEL9 base image for RHOAI notebooks" \
+      io.k9s.description="Base Python 3.9 builder image based on RHEL9 for RHOAI notebooks" \
+      authoritative-source-url="https://github.com/red-hat-data-services/notebooks" \
+      io.openshift.build.commit.ref="main" \
+      io.openshift.build.source-location="https://github.com/red-hat-data-services/notebooks/tree/main/base/rhel9-python-3.9" \
+      io.openshift.build.image="quay.io/modh/odh-base-rhel9"
+
+WORKDIR /opt/app-root/bin
+
+# Install micropipenv to deploy packages from Pipfile.lock
+RUN pip install -U "micropipenv[toml]"
+
+# Install Python dependencies from Pipfile.lock file
+COPY Pipfile.lock ./
+
+RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./Pipfile.lock
+
+# OS Packages needs to be installed as root
+USER root
+
+# Install usefull OS packages
+RUN dnf install -y mesa-libGL
+
+# Other apps and tools installed as default user
+USER 1001
+
+# Install the oc client
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz \
+        -o /tmp/openshift-client-linux.tar.gz && \
+    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
+    rm -f /tmp/openshift-client-linux.tar.gz
+
+# Fix permissions to support pip in Openshift environments
+RUN chmod -R g+w /opt/app-root/lib/python3.9/site-packages && \
+      fix-permissions /opt/app-root -P
+
+WORKDIR /opt/app-root/src

--- a/base/rhel9-python-3.9/Pipfile
+++ b/base/rhel9-python-3.9/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+# Base packages
+wheel = "~=0.41.2"
+setuptools = "~=68.1.2"
+
+[requires]
+python_version = "3.9"

--- a/base/rhel9-python-3.9/Pipfile.lock
+++ b/base/rhel9-python-3.9/Pipfile.lock
@@ -1,0 +1,37 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "54af5308fe912f4e39360fc1fa1d2fa9f9233d975a2e1ab42265db7c82aab4fa"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "setuptools": {
+            "hashes": [
+                "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d",
+                "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"
+            ],
+            "index": "pypi",
+            "version": "==68.1.2"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942",
+                "sha256:4d4987ce51a49370ea65c0bfd2234e8ce80a12780820d9dc462597a6e60d0841"
+            ],
+            "index": "pypi",
+            "version": "==0.41.3"
+        }
+    },
+    "develop": {}
+}


### PR DESCRIPTION
This PR related to: https://github.com/red-hat-data-services/notebooks/pull/118

The goal here is to reduce the build time for RStudio. It doesn't need to build every time the RHEL base.

The second part of this work is the modification on the OCP-CI to store the image on a registry, the related PR is here: https://github.com/openshift/release/pull/48110