### PR TITLE
Set the release branch rhoai-2.7 as the ref in buildconfig

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -47,7 +47,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: main
+      ref: rhoai-2.7
   strategy:
     type: Docker
     dockerStrategy:
@@ -107,7 +107,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: main
+      ref: rhoai-2.7
   strategy:
     type: Docker
     dockerStrategy:

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -33,7 +33,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: main
+      ref: rhoai-2.7
   strategy:
     type: Docker
     dockerStrategy:


### PR DESCRIPTION
Set the release branch rhoai-2.7 as the ref in buildconfig
Related-to: https://issues.redhat.com/browse/RHOAIENG-1478