### PR TITLE
Fix: Increase resources on R Studio BuildConfigs

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -86,10 +86,12 @@ spec:
   resources:
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 4Gi
     requests:
       cpu: "1"
-      memory: 1Gi
+      memory: 4Gi
+  successfulBuildsHistoryLimit: 2
+  failedBuildsHistoryLimit: 2
   runPolicy: Serial
   triggers:
     - imageChange: {}
@@ -145,11 +147,13 @@ spec:
       name: "cuda-rstudio-rhel9:latest"
   resources:
     limits:
-      cpu: "1"
-      memory: 1Gi
+      cpu: "1500m"
+      memory: 4Gi
     requests:
-      cpu: "1"
-      memory: 1Gi
+      cpu: "1500m"
+      memory: 4Gi
+  successfulBuildsHistoryLimit: 2
+  failedBuildsHistoryLimit: 2
   runPolicy: Serial
   triggers:
     - imageChange: {}

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -73,10 +73,12 @@ spec:
   resources:
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 2Gi
     requests:
       cpu: "1"
-      memory: 1Gi
+      memory: 2Gi
+  successfulBuildsHistoryLimit: 2
+  failedBuildsHistoryLimit: 2
   triggers:
     - imageChange: {}
       type: ImageChange


### PR DESCRIPTION
Increased resources to avoid Out of Memory issue while building, especially for the CUDA ones. 

`The node was low on resource: ephemeral-storage. Container docker-build was using 6574308Ki, which exceeds its request of 0.`