### PR TITLE
Mount the secret on the buildConfig instead of using ENVs to avoid their exposure on the logs

### DIFF
--- a/cuda/rhel9-python-3.9/Dockerfile
+++ b/cuda/rhel9-python-3.9/Dockerfile
@@ -2,11 +2,9 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 # Access the client's secret for the subscription manager from the environment variable
-ENV USERNAME=$USERNAME
-ENV PASSWORD=$PASSWORD
-# These should be removed after testing the recipe
-ENV SERVERURL=$SERVERURL
-ENV BASEURL=$BASEURL
+ARG SECRET_DIR=/opt/app-root/src/.sec
+ARG SERVERURL_DEFAULT=""
+ARG BASEURL_DEFAULT=""
 
 LABEL name="odh-notebook-cuda-c9s-python-3.9" \
       summary="CUDA Python 3.9 base image for ODH notebooks" \
@@ -24,7 +22,11 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Run the subscription manager command using the provided credentials. Only include --serverurl and --baseurl if they are provided
-RUN subscription-manager register \
+RUN SERVERURL=$(cat ${SECRET_DIR}/SERVERURL 2>/dev/null || echo ${SERVERURL_DEFAULT}) && \
+    BASEURL=$(cat ${SECRET_DIR}/BASEURL 2>/dev/null || echo ${BASEURL_DEFAULT}) && \
+    USERNAME=$(cat ${SECRET_DIR}/USERNAME) && \
+    PASSWORD=$(cat ${SECRET_DIR}/PASSWORD) && \
+    subscription-manager register \
     ${SERVERURL:+--serverurl=$SERVERURL} \
     ${BASEURL:+--baseurl=$BASEURL} \
     --username=$USERNAME \

--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -56,29 +56,15 @@ spec:
       from:
         kind: "DockerImage"
         name: "quay.io/modh/odh-base-rhel9:base-rhel9-python-3.9-20240131-378dafd"
-      env:
-        - name: USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: USERNAME
-        - name: PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: PASSWORD
-        - name: SERVERURL
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: SERVERURL
-              optional: true
-        - name: BASEURL
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: BASEURL
-              optional: true
+      volumes:
+        - name: secret-mvn
+          source:
+            type: Secret
+            secret:
+              secretName: rhel-subscription-secret
+              defaultMode: 420
+          mounts:
+            - destinationPath: /opt/app-root/src/.sec
   output:
     to:
       kind: ImageStreamTag
@@ -116,29 +102,15 @@ spec:
       from:
         kind: "ImageStreamTag"
         name: "cuda-rhel9:latest"
-      env:
-        - name: USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: USERNAME
-        - name: PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: PASSWORD
-        - name: SERVERURL
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: SERVERURL
-              optional: true
-        - name: BASEURL
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: BASEURL
-              optional: true
+      volumes:
+        - name: secret-mvn
+          source:
+            type: Secret
+            secret:
+              secretName: rhel-subscription-secret
+              defaultMode: 420
+          mounts:
+            - destinationPath: /opt/app-root/src/.sec
   output:
     to:
       kind: ImageStreamTag

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -41,29 +41,15 @@ spec:
         kind: "DockerImage"
         name: "quay.io/modh/odh-base-rhel9:base-rhel9-python-3.9-20240131-378dafd"
       dockerfilePath: "rstudio/rhel9-python-3.9/Dockerfile"
-      env:
-        - name: USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: USERNAME
-        - name: PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: PASSWORD
-        - name: SERVERURL
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: SERVERURL
-              optional: true
-        - name: BASEURL
-          valueFrom:
-            secretKeyRef:
-              name: rhel-subscription-secret
-              key: BASEURL
-              optional: true
+      volumes:
+        - name: secret-mvn
+          source:
+            type: Secret
+            secret:
+              secretName: rhel-subscription-secret
+              defaultMode: 420
+          mounts:
+            - destinationPath: /opt/app-root/src/.sec
       noCache: true
   output:
     to:

--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -2,11 +2,9 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 # Access the client's secret for the subscription manager from the environment variable
-ENV USERNAME=$USERNAME
-ENV PASSWORD=$PASSWORD
-# These should be removed after testing the recipe
-ENV SERVERURL=$SERVERURL
-ENV BASEURL=$BASEURL
+ARG SECRET_DIR=/opt/app-root/src/.sec
+ARG SERVERURL_DEFAULT=""
+ARG BASEURL_DEFAULT=""
 
 LABEL name="odh-notebook-rstudio-rhel9-python-3.9" \
       summary="R Studio image with python 3.9 based on Red Hat Enterprise Linux 9" \
@@ -24,7 +22,11 @@ USER root
 #RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
 
 # Run the subscription manager command using the provided credentials. Only include --serverurl and --baseurl if they are provided
-RUN subscription-manager register \
+RUN SERVERURL=$(cat ${SECRET_DIR}/SERVERURL 2>/dev/null || echo ${SERVERURL_DEFAULT}) && \
+    BASEURL=$(cat ${SECRET_DIR}/BASEURL 2>/dev/null || echo ${BASEURL_DEFAULT}) && \
+    USERNAME=$(cat ${SECRET_DIR}/USERNAME) && \
+    PASSWORD=$(cat ${SECRET_DIR}/PASSWORD) && \
+    subscription-manager register \
     ${SERVERURL:+--serverurl=$SERVERURL} \
     ${BASEURL:+--baseurl=$BASEURL} \
     --username=$USERNAME \


### PR DESCRIPTION
This fix ensure that the credentials of the subscription manager are not revealed on while the build logs.

This way is documented here: [ocp-doc](https://docs.openshift.com/container-platform/4.10/cicd/builds/build-strategies.html#builds-using-build-volumes_build-strategies-docker)

 
![Screenshot from 2024-02-06 19-03-45](https://github.com/red-hat-data-services/notebooks/assets/42587738/8b57d83e-a974-48a9-b09a-6479e99370ce)
