### PR TITLE
Fix naming for RStudio Server on rhel flavor

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -17,8 +17,8 @@ metadata:
   annotations:
     opendatahub.io/notebook-image-creator: RHOAI
     opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/rstudio"
-    opendatahub.io/notebook-image-name: "CUDA - R Studio"
-    opendatahub.io/notebook-image-desc: "R Studio Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
+    opendatahub.io/notebook-image-name: "CUDA - RStudio Server"
+    opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: cuda-rstudio-rhel9
   labels:
@@ -31,7 +31,7 @@ spec:
     - name: latest
       annotations:
         opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"R","version":"v4.3"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"r-studio","version":"4.3"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"4.3"}]'
       referencePolicy:
         type: Source
 ---
@@ -98,10 +98,10 @@ spec:
 kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
-  name: cuda-rstudio-rhel9
+  name: cuda-rstudio-server-rhel9
   labels:
     app: buildchain
-    component: cuda-rstudio-image
+    component: cuda-rstudio-server-image
 spec:
   source:
     type: Git

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -5,8 +5,8 @@ metadata:
   annotations:
     opendatahub.io/notebook-image-creator: RHOAI
     opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/rstudio"
-    opendatahub.io/notebook-image-name: "R Studio"
-    opendatahub.io/notebook-image-desc: "R Studio Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
+    opendatahub.io/notebook-image-name: "RStudio Server"
+    opendatahub.io/notebook-image-desc: "RStudio Server Workbench image with an integrated development environment for R, a programming language designed for statistical computing and graphics."
   name: rstudio-rhel9
   labels:
     opendatahub.io/dashboard: 'true'
@@ -18,16 +18,16 @@ spec:
     - name: latest
       annotations:
         opendatahub.io/notebook-software: '[{"name":"R","version":"v4.3"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"r-studio","version":"4.3"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"4.3"}]'
       referencePolicy:
         type: Source
 ---
 kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
-  name: rstudio-rhel9
+  name: rstudio-server-rhel9
   labels:
-    component: rstudio-rhel9-image
+    component: rstudio-server-rhel9-image
 spec:
   source:
     type: Git

--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -8,11 +8,11 @@ ENV PASSWORD=$PASSWORD
 ENV SERVERURL=$SERVERURL
 ENV BASEURL=$BASEURL
 
-LABEL name="odh-notebook-rstudio-rhel9-python-3.9" \
-      summary="R Studio image with python 3.9 based on Red Hat Enterprise Linux 9" \
-      description="Code Server (VS Code) image with python 3.9 based on Red Hat Enterprise Linux 9" \
-      io.k9s.display-name="R Studio image with python 3.9 based on Red Hat Enterprise Linux 9" \
-      io.k9s.description="R Studio image with python 3.9 based on Red Hat Enterprise Linux 9" \
+LABEL name="odh-notebook-rstudio-server-rhel9-python-3.9" \
+      summary="RStudio Server image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      description="RStudio Server image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      io.k9s.display-name="RStudio Server image with python 3.9 based on Red Hat Enterprise Linux 9" \
+      io.k9s.description="RStudio Server image with python 3.9 based on Red Hat Enterprise Linux 9" \
       authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
       io.openshift.build.commit.ref="main" \
       io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.9" \

--- a/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
+++ b/rstudio/rhel9-python-3.9/nginx/root/opt/app-root/nginxconf.sed
@@ -14,5 +14,5 @@ s%/usr/share/nginx/html%/opt/app-root/src%
 /40x.html/,+1d
 /50x.html/,+1d
 
-# Addition for RStudio
+# Addition for RStudio Server
 /server_name/s%server_name  _%server_name  ${BASE_URL}%


### PR DESCRIPTION
This Pull Request attends to change the name of R Studio to R Studio Server in all possible changes where applicable.

Note: It doesn't include changes on the rest files since will flow in downstream through the upstream PR https://github.com/opendatahub-io/notebooks/pull/407

