### PR TITLE
HotFix: Remove the annotation notebook-images=true from RStudio imagestreams

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -23,7 +23,6 @@ metadata:
   name: cuda-rstudio-rhel9
   labels:
     opendatahub.io/dashboard: 'true'
-    opendatahub.io/notebook-image: 'true'
 spec:
   lookupPolicy:
     local: true

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -10,7 +10,6 @@ metadata:
   name: rstudio-rhel9
   labels:
     opendatahub.io/dashboard: 'true'
-    opendatahub.io/notebook-image: 'true'
 spec:
   lookupPolicy:
     local: true


### PR DESCRIPTION
HotFix: Remove the annotation notebook-images=true from RStudio imagestreams

Related-to: https://issues.redhat.com/browse/RHOAIENG-3008


Removed the annotation : `opendatahub.io/notebook-image: 'true'`
with this user (data scientist) wouldn't see the R studio image.

RHODS admins, could include this to imagestream once the build successful.