### PR TITLE
Fix library path version on rsession.conf file

### DIFF
--- a/rstudio/rhel9-python-3.9/rsession.conf
+++ b/rstudio/rhel9-python-3.9/rsession.conf
@@ -1,2 +1,2 @@
 # Set library path
-r-libs-user=/opt/app-root/src/Rpackages/4.2
+r-libs-user=/opt/app-root/src/Rpackages/4.3


### PR DESCRIPTION
Related to: https://github.com/red-hat-data-services/notebooks/pull/149

Missed one bit here to be totally fixed...

End to end image testing shows only one folder as expected

![image](https://github.com/red-hat-data-services/notebooks/assets/42587738/77c4e96c-a431-451f-8c8c-13d544bf547b)
