### PR TITLE
Update Codeserver ImageStream for the 2024a release inclusion

### DIFF
--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -17,7 +17,7 @@ spec:
     # N Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.22"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-server","version":"4.22"}]'
         openshift.io/imported-from: quay.io/modh/codeserver
         opendatahub.io/workbench-image-recommended: "true"
         opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n)

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -30,7 +30,7 @@ spec:
     # N - 1 Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.16"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-server","version":"4.16"}]'
         openshift.io/imported-from: quay.io/modh/codeserver
         opendatahub.io/workbench-image-recommended: 'false'
         opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n-1)

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -17,7 +17,7 @@ spec:
     # N Version of the image
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"code-server","version":"4.16"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.22"}]'
         openshift.io/imported-from: quay.io/modh/codeserver
         opendatahub.io/workbench-image-recommended: "true"
         opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n)
@@ -25,5 +25,18 @@ spec:
         kind: DockerImage
         name: $(odh-codeserver-notebook-n)
       name: "2024.1"
+      referencePolicy:
+        type: Source
+    # N - 1 Version of the image
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.16"}]'
+        openshift.io/imported-from: quay.io/modh/codeserver
+        opendatahub.io/workbench-image-recommended: 'false'
+        opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n-1)
+      from:
+        kind: DockerImage
+        name: $(odh-codeserver-notebook-n-1)
+      name: "2023.2"
       referencePolicy:
         type: Source

--- a/manifests/base/commit.env
+++ b/manifests/base/commit.env
@@ -17,4 +17,5 @@ odh-trustyai-notebook-image-commit-n=852adda
 odh-trustyai-notebook-image-commit-n-1=07015ec
 odh-trustyai-notebook-image-commit-n-2=07015ec
 odh-habana-notebook-image-commit-n=7d8f86d
-odh-codeserver-notebook-image-commit-n=852adda
+odh-codeserver-notebook-image-commit-n=0e26442
+odh-codeserver-notebook-image-commit-n-1=0e26442

--- a/manifests/base/commit.yaml
+++ b/manifests/base/commit.yaml
@@ -60,3 +60,7 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-codeserver-notebook-image-commit-n
+  - path: spec/tags[]/annotations/opendatahub.io\/notebook-build-commit
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-image-commit-n-1

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -130,6 +130,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-codeserver-notebook-n
+  - name: odh-codeserver-notebook-n-1
+    objref:
+      kind: ConfigMap
+      name: notebooks-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-n-1
   - name: odh-minimal-notebook-image-commit-n
     objref:
       kind: ConfigMap
@@ -235,6 +242,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-codeserver-notebook-image-commit-n
+  - name: odh-codeserver-notebook-image-commit-n-1
+    objref:
+      kind: ConfigMap
+      name: notebook
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.odh-codeserver-notebook-image-commit-n-1
 configurations:
   - params.yaml
   - commit.yaml

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -17,4 +17,5 @@ odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:dc49e549
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
 odh-trustyai-notebook-image-n-2=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:0f6ae8f0b1ef11896336e7f8611e77ccdb992b49a7942bf27e6bc64d73205d05
-odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:17e5bd18d6faaab72754936e4a89c2c596b2dfeb4be0aac6890b6f6145a13d6c
+odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:f726d2e14b8595f4ac6a2f12f86d0ee0b35025fdc42595bd3ee2c1342c27dabb
+odh-codeserver-notebook-n-1=quay.io/modh/codeserver@sha256:f726d2e14b8595f4ac6a2f12f86d0ee0b35025fdc42595bd3ee2c1342c27dabb

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -60,3 +60,7 @@ varReference:
     kind: ImageStream
     apiGroup: image.openshift.io/v1
     name: odh-codeserver-notebook-n
+  - path: spec/tags[]/from/name
+    kind: ImageStream
+    apiGroup: image.openshift.io/v1
+    name: odh-codeserver-notebook-n-1


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-4345

This PR updates code-server's ImageStream object to include the new 2024a release.

**NOTE:** The updates to the code-server notebook itself will be included with the sync with upstream. 
Changes are introduced here: https://github.com/opendatahub-io/notebooks/pull/452