### PR TITLE
[fix] hadolint warnings to base and rstudio Dockerfiles

### DIFF
--- a/base/rhel9-python-3.9/Dockerfile
+++ b/base/rhel9-python-3.9/Dockerfile
@@ -13,7 +13,7 @@ LABEL name="rhoai-notebook-base-rhel9-python-3.9" \
 WORKDIR /opt/app-root/bin
 
 # Install micropipenv to deploy packages from Pipfile.lock
-RUN pip install -U "micropipenv[toml]"
+RUN pip install --no-cache-dir -U "micropipenv[toml]"
 
 # Install Python dependencies from Pipfile.lock file
 
@@ -24,7 +24,7 @@ RUN echo "Installing softwares and packages" && micropipenv install && rm -f ./P
 USER root
 
 # Install usefull OS packages
-RUN dnf install -y mesa-libGL
+RUN dnf install -y mesa-libGL && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user
 USER 1001

--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -58,7 +58,7 @@ ENV R_LIBS_USER /opt/app-root/bin/Rpackages/4.3
 WORKDIR /tmp/
 
 # Install RStudio
-RUN wget https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2023.12.1-402-x86_64.rpm && \
+RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2023.12.1-402-x86_64.rpm && \
     yum install -y rstudio-server-rhel-2023.12.1-402-x86_64.rpm && \
     rm rstudio-server-rhel-2023.12.1-402-x86_64.rpm && \
     yum -y clean all  --enablerepo='*'
@@ -68,8 +68,9 @@ RUN chmod 1777 /var/run/rstudio-server && \
     mkdir -p /usr/share/doc/R
 COPY rstudio/rhel9-python-3.9/rsession.conf /etc/rstudio/rsession.conf
 
-# package installation
-RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*"
+# package installation 
+RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" && \
+    dnf clean all && rm -rf /var/cache/yum
 RUN R -e "install.packages('Rcpp')"
 
 # Install NGINX to proxy RStudio and pass probes check
@@ -142,4 +143,4 @@ WORKDIR /opt/app-root/src
 
 USER 1001
 
-CMD /opt/app-root/bin/run-rstudio.sh
+CMD ["/opt/app-root/bin/run-rstudio.sh"]


### PR DESCRIPTION
These changes shouldn't have any functional impact.

https://issues.redhat.com/browse/RHOAIENG-7884

This is a followup of #169.

Waiting for #180. Then I rebase to see that this fix the CI completely.

Note: these files aren't in upstream, thus this change is for downstream repository right now.

Test locally:

```
find . -name "Dockerfile" | xargs hadolint --config ./ci/hadolint-config.yaml
```