### PR TITLE
Fix test file for the trustyai image

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb
+++ b/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb
@@ -72,6 +72,19 @@
    "language": "python",
    "name": "python3"
   },
+  "language_info": {
+    "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+    },
+    "file_extension": ".py",
+    "mimetype": "text/x-python",
+    "name": "python",
+    "nbconvert_exporter": "python",
+    "pygments_lexer": "ipython3",
+    "version": "3.9.16"
+   }
+  },
   "nbformat": 4,
   "nbformat_minor": 5
 }


### PR DESCRIPTION
I don't really understand how and why this file was broken by this commit aac06623b4942d9ceb6ea8ef5189639f4943fb1b . Our CI check notifies that something is broken in the file.

Please, review this thoroughly, I simply put back original values.

Looks like this issue isn't present in the upstream repository - https://github.com/opendatahub-io/notebooks/blob/main/jupyter/trustyai/ubi9-python-3.9/test/test_notebook.ipynb?short_path=7b4adf3.

Edit: CI passed the point of checking JSON files. The hadolint failure is gonna be fixed by #179.