### PR TITLE
Fix check-params-env test with the new changes

### DIFF
--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -24,7 +24,7 @@ PARAMS_ENV_PATH="manifests/base/params.env"
 
 # This value needs to be updated everytime we deliberately change number of the
 # images we want to have in the `params.env` file.
-EXPECTED_NUM_RECORDS=24
+EXPECTED_NUM_RECORDS=26
 
 # ---------------------------- DEFINED FUNCTIONS ----------------------------- #
 
@@ -69,85 +69,115 @@ function check_image_variable_matches_name_and_commitref() {
     case "${image_variable}" in
         odh-minimal-notebook-image-n)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
-            expected_commitref="release-2023b"
+            expected_commitref="release-2024a"
             expected_build_name="jupyter-minimal-ubi9-python-3.9-amd64"
             ;;
         odh-minimal-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
-            expected_commitref="release-2023a"
+            expected_commitref="release-2023b"
             expected_build_name="jupyter-minimal-ubi9-python-3.9-amd64"
             ;;
         odh-minimal-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-minimal-ubi9-python-3.9-amd64"
+            ;;
+        odh-minimal-notebook-image-n-3)
             expected_name="odh-notebook-jupyter-minimal-ubi8-python-3.8"
             expected_commitref="release-1.2"
             expected_build_name="jupyter-minimal-ubi8-python-3.8-amd64"
             ;;
         odh-minimal-gpu-notebook-image-n)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
-            expected_commitref="release-2023b"
+            expected_commitref="release-2024a"
             expected_build_name="cuda-jupyter-minimal-ubi9-python-3.9-amd64"
             ;;
         odh-minimal-gpu-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
-            expected_commitref="release-2023a"
+            expected_commitref="release-2023b"
             expected_build_name="cuda-jupyter-minimal-ubi9-python-3.9-amd64"
             ;;
         odh-minimal-gpu-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="cuda-jupyter-minimal-ubi9-python-3.9-amd64"
+            ;;
+        odh-minimal-gpu-notebook-image-n-3)
             expected_name="odh-notebook-jupyter-minimal-ubi8-python-3.8"
             expected_commitref="release-1.2"
             expected_build_name="cuda-jupyter-minimal-ubi8-python-3.8-amd64"
             ;;
         odh-pytorch-gpu-notebook-image-n)
             expected_name="odh-notebook-jupyter-pytorch-ubi9-python-3.9"
-            expected_commitref="release-2023b"
+            expected_commitref="release-2024a"
             expected_build_name="jupyter-pytorch-ubi9-python-3.9-amd64"
             ;;
         odh-pytorch-gpu-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-pytorch-ubi9-python-3.9"
-            expected_commitref="release-2023a"
+            expected_commitref="release-2023b"
             expected_build_name="jupyter-pytorch-ubi9-python-3.9-amd64"
             ;;
         odh-pytorch-gpu-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-pytorch-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-pytorch-ubi9-python-3.9-amd64"
+            ;;
+        odh-pytorch-gpu-notebook-image-n-3)
             expected_name="odh-notebook-cuda-jupyter-pytorch-ubi8-python-3.8"
             expected_commitref="release-1.2"
             expected_build_name="jupyter-pytorch-ubi8-python-3.8-amd64"
             ;;
         odh-generic-data-science-notebook-image-n)
             expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.9"
-            expected_commitref="release-2023b"
+            expected_commitref="release-2024a"
             expected_build_name="jupyter-datascience-ubi9-python-3.9-amd64"
             ;;
         odh-generic-data-science-notebook-image-n-1)
             expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.9"
-            expected_commitref="release-2023a"
+            expected_commitref="release-2023b"
             expected_build_name="jupyter-datascience-ubi9-python-3.9-amd64"
             ;;
         odh-generic-data-science-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-datascience-ubi9-python-3.9-amd64"
+            ;;
+        odh-generic-data-science-notebook-image-n-3)
             expected_name="odh-notebook-jupyter-datascience-ubi8-python-3.8"
             expected_commitref="release-1.2"
             expected_build_name="jupyter-datascience-ubi8-python-3.8-amd64"
             ;;
         odh-tensorflow-gpu-notebook-image-n)
             expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9"
-            expected_commitref="release-2023b"
+            expected_commitref="release-2024a"
             expected_build_name="cuda-jupyter-tensorflow-ubi9-python-3.9-amd64"
             ;;
         odh-tensorflow-gpu-notebook-image-n-1)
             expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9"
-            expected_commitref="release-2023a"
+            expected_commitref="release-2023b"
             expected_build_name="cuda-jupyter-tensorflow-ubi9-python-3.9-amd64"
             ;;
         odh-tensorflow-gpu-notebook-image-n-2)
+            expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="cuda-jupyter-tensorflow-ubi9-python-3.9-amd64"
+            ;;
+        odh-tensorflow-gpu-notebook-image-n-3)
             expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi8-python-3.8"
             expected_commitref="release-1.2"
             expected_build_name="cuda-jupyter-tensorflow-ubi8-python-3.8-amd64"
             ;;
         odh-trustyai-notebook-image-n)
             expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.9"
-            expected_commitref="release-2023b"
+            expected_commitref="release-2024a"
             expected_build_name="jupyter-trustyai-ubi9-python-3.9-amd64"
             ;;
         odh-trustyai-notebook-image-n-1)
+            expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="jupyter-trustyai-ubi9-python-3.9-amd64"
+            ;;
+        odh-trustyai-notebook-image-n-2)
             expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.9"
             expected_commitref="release-2023a"
             expected_build_name="jupyter-trustyai-ubi9-python-3.9-amd64"
@@ -159,6 +189,11 @@ function check_image_variable_matches_name_and_commitref() {
             expected_build_name="habana-jupyter-1.10.0-ubi8-python-3.8-amd64"
             ;;
         odh-codeserver-notebook-n)
+            expected_name="odh-notebook-code-server-ubi9-python-3.9"
+            expected_commitref="release-2024a"
+            expected_build_name="codeserver-ubi9-python-3.9-amd64"
+            ;;
+        odh-codeserver-notebook-n-1)
             expected_name="odh-notebook-code-server-ubi9-python-3.9"
             expected_commitref="release-2023b"
             expected_build_name="codeserver-ubi9-python-3.9-amd64"


### PR DESCRIPTION
This PR updated the check-params-env test with the new changes.
(It adds checks for the new Habana as well, so failure about this is expected)

To check this localy run : `./ci/check-params-env.sh `