### PR TITLE
Revert nginx version to 1.22 since 1.24 is not available on RHEL yet

### DIFF
--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -73,8 +73,8 @@ RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel har
 RUN R -e "install.packages('Rcpp')"
 
 # Install NGINX to proxy RStudio and pass probes check
-ENV NGINX_VERSION=1.24 \
-    NGINX_SHORT_VER=124 \
+ENV NGINX_VERSION=1.22 \
+    NGINX_SHORT_VER=122 \
     NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/nginx/nginx.conf \
     NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \


### PR DESCRIPTION

We updated the Nginx version on our RHEL system assuming it would function similarly to C9S. However, we discovered that version 1.24 is not yet available on RHEL.


Bellow shows that on C9S the 1.24 is available 

```
[user-acc@c9s-0 ~]$ dnf module list nginx
CentOS Stream 9 - BaseOS                                                        12 MB/s | 8.0 MB     00:00    
CentOS Stream 9 - AppStream                                                    254 kB/s |  19 MB     01:16    
CentOS Stream 9 - CRB                                                           13 MB/s | 6.1 MB     00:00    
CentOS Stream 9 - Extras packages                                               65 kB/s |  16 kB     00:00    
cuda                                                                           5.8 MB/s | 1.4 MB     00:00    
Extra Packages for Enterprise Linux 9 - x86_64                                  15 MB/s |  21 MB     00:01    
Extra Packages for Enterprise Linux 9 openh264 (From Cisco) - x86_64           6.9 kB/s | 2.5 kB     00:00    
Extra Packages for Enterprise Linux 9 - Next - x86_64                          2.2 MB/s | 1.9 MB     00:00    
CentOS Stream 9 - AppStream
Name                    Stream                     Profiles                    Summary                         
nginx                   1.22                       common [d]                  nginx webserver                 
nginx                   1.24 [e]                   common [d]                  nginx webserver                 Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled
```

However, on RHEL9 is not yet available. This is the documentation [link for RHEL9 ](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_web_servers_and_reverse_proxies/setting-up-and-configuring-nginx_deploying-web-servers-and-reverse-proxies)
```
[user-acc@rhel-0 ~]$ dnf module list nginx 
Not root, Subscription Management repositories not updated
Extra Packages for Enterprise Linux 9 - x86_64                                 3.9 MB/s |  21 MB     00:05    
Extra Packages for Enterprise Linux 9 openh264 (From Cisco) - x86_64           6.0 kB/s | 2.5 kB     00:00    
Red Hat Universal Base Image 9 (RPMs) - BaseOS                                 1.8 MB/s | 515 kB     00:00    
Red Hat Universal Base Image 9 (RPMs) - AppStream                              6.5 MB/s | 1.8 MB     00:00    
Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder                      740 kB/s | 192 kB     00:00    
Red Hat Universal Base Image 9 (RPMs) - AppStream
Name                    Stream                     Profiles                   Summary                          
nginx                   1.22 [e]                   common                     nginx webserver                  
Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled
````