### PR TITLE
Remove the intel based image from the overlay as its ODH only

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -1,4 +1,3 @@
-ci/check-params-env.sh---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:

--- a/manifests/overlays/additional/kustomization.yaml
+++ b/manifests/overlays/additional/kustomization.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 
 resources:
   - ../../base
-  - jupyter-intel-ml-notebook-imagestream.yaml
-  - jupyter-intel-pytorch-notebook-imagestream.yaml
-  - jupyter-intel-tensorflow-notebook-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"


### PR DESCRIPTION
Remove the intel based image from the overlay as its ODH only

verify:
`kustomize build manifests/overlays/additional | grep intel`

