### PR TITLE
[fix] This fixes an inconsistency with the kustomize params

### DIFF
--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: |
               echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
-              IMAGES=("odh-minimal-notebook-image-n" "odh-minimal-gpu-notebook-image-n" "odh-pytorch-gpu-notebook-image-n" "odh-generic-data-science-notebook-image-n" "odh-tensorflow-gpu-notebook-image-n" "odh-trustyai-notebook-image-n" "odh-codeserver-notebook-n")
+              IMAGES=("odh-minimal-notebook-image-n" "odh-minimal-gpu-notebook-image-n" "odh-pytorch-gpu-notebook-image-n" "odh-generic-data-science-notebook-image-n" "odh-tensorflow-gpu-notebook-image-n" "odh-trustyai-notebook-image-n" "odh-codeserver-notebook-image-n")
               REGEXES=("v2-${{ env.RELEASE_VERSION_N }}-\d{8}+-${{ steps.hash-n.outputs.HASH_N }}" "cuda-[a-z]+-minimal-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N }}-\d{8}-${{ steps.hash-n.outputs.HASH_N }}" "v2-${{ env.RELEASE_VERSION_N }}-\d{8}+-${{ steps.hash-n.outputs.HASH_N }}" \
                        "v2-${{ env.RELEASE_VERSION_N }}-\d{8}+-${{ steps.hash-n.outputs.HASH_N }}" "cuda-[a-z]+-tensorflow-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N }}-\d{8}-${{ steps.hash-n.outputs.HASH_N }}" "v2-${{ env.RELEASE_VERSION_N }}-\d{8}+-${{ steps.hash-n.outputs.HASH_N }}" \
                        "codeserver-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N }}-\d{8}-${{ steps.hash-n.outputs.HASH_N }}")
@@ -101,7 +101,7 @@ jobs:
              "odh-generic-data-science-notebook-image-commit-n"
              "odh-tensorflow-gpu-notebook-image-commit-n"
              "odh-trustyai-notebook-image-commit-n"
-             "odh-codeserver-notebook-n")
+             "odh-codeserver-notebook-image-commit-n")
 
             for val in "${COMMIT[@]}"; do
               echo $val
@@ -142,7 +142,7 @@ jobs:
         shell: bash
         run: |
               echo Latest commit is: ${{ steps.hash-n-1.outputs.HASH_N_1 }} on ${{ env.RELEASE_VERSION_N_1}}
-              IMAGES=("odh-minimal-notebook-image-n-1" "odh-minimal-gpu-notebook-image-n-1" "odh-pytorch-gpu-notebook-image-n-1" "odh-generic-data-science-notebook-image-n-1" "odh-tensorflow-gpu-notebook-image-n-1" "odh-trustyai-notebook-image-n-1" "odh-codeserver-notebook-n-1")
+              IMAGES=("odh-minimal-notebook-image-n-1" "odh-minimal-gpu-notebook-image-n-1" "odh-pytorch-gpu-notebook-image-n-1" "odh-generic-data-science-notebook-image-n-1" "odh-tensorflow-gpu-notebook-image-n-1" "odh-trustyai-notebook-image-n-1" "odh-codeserver-notebook-image-n-1")
               REGEXES=("v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "cuda-[a-z]+-minimal-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N_1 }}-\d{8}-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" \
                        "v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "cuda-[a-z]+-tensorflow-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N_1 }}-\d{8}-${{ steps.hash-n-1.outputs.HASH_N_1 }}" "v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" \
                        "codeserver-[a-z0-9]+-[a-z]+-3.9-${{ env.RELEASE_VERSION_N_1 }}-\d{8}-${{ steps.hash-n-1.outputs.HASH_N_1 }}")
@@ -174,7 +174,7 @@ jobs:
                "odh-generic-data-science-notebook-image-commit-n-1"
                "odh-tensorflow-gpu-notebook-image-commit-n-1"
                "odh-trustyai-notebook-image-commit-n-1"
-               "odh-codeserver-notebook-n-1")
+               "odh-codeserver-notebook-image-commit-n-1")
 
               for val in "${COMMIT[@]}"; do
                 echo $val

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -213,7 +213,7 @@ vars:
       name: notebooks-parameters
       apiVersion: v1
     fieldref:
-      fieldpath: data.odh-codeserver-notebook-n-1
+      fieldpath: data.odh-codeserver-notebook-image-n-1
   - name: odh-minimal-notebook-image-commit-n
     objref:
       kind: ConfigMap

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -23,5 +23,5 @@ odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:926ed1
 odh-trustyai-notebook-image-n-2=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:64ca5d31d1d0d305bc99317eb9d453ce5fa8571f0311e171252df12b40c41b75
 odh-habana-notebook-image-n-1=quay.io/modh/odh-habana-notebooks@sha256:e115a0ad0106aaf72c53560c0b7d774f8a30fc2460ce9f773c715ba33d170063
-odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:3f1b86feed5ee437663ff1088471ccca1ba164b45b2bb4443a8d37a587e95e91
-odh-codeserver-notebook-n-1=quay.io/modh/codeserver@sha256:14b73e8a62b98fb9a70cb079b6048121ab0a7798fe1eca0adf06b6716f280115
+odh-codeserver-notebook-image-n=quay.io/modh/codeserver@sha256:3f1b86feed5ee437663ff1088471ccca1ba164b45b2bb4443a8d37a587e95e91
+odh-codeserver-notebook-image-n-1=quay.io/modh/codeserver@sha256:14b73e8a62b98fb9a70cb079b6048121ab0a7798fe1eca0adf06b6716f280115

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -107,4 +107,4 @@ varReference:
   - path: spec/tags[]/from/name
     kind: ImageStream
     apiGroup: image.openshift.io/v1
-    name: odh-codeserver-notebook-n-1
+    name: odh-codeserver-notebook-image-n-1


### PR DESCRIPTION
Inconsistency for codeserver notebook parameters. There was upstream change recently that probably not got properly backported to downstream, see [1,2].

* [1] https://github.com/opendatahub-io/notebooks/pull/524
* [2] https://github.com/red-hat-data-services/notebooks/commit/ceb3dc87609af758b03a1f9e0f3f881a9af81f52

Tested locally with:

`$ kubectl kustomize manifests/base`

I'll extend our CI to run this command when anything in manifests is changed - update: opendatahub-io/notebooks#545

---

The CI failures should be fixed by:
* #179 
* #254