### PR TITLE
RHOAIENG-8255: Fix spawn-fcgi-1.6.3-23.fc37.x86_64.rpm download location

### DIFF
--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -63,7 +63,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # spawn-fcgi is not in epel9 \
-    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/codeserver/ubi9-python-3.9/Dockerfile
+++ b/codeserver/ubi9-python-3.9/Dockerfile
@@ -63,7 +63,7 @@ RUN yum install -y https://download.fedoraproject.org/pub/epel/epel-release-late
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # spawn-fcgi is not in epel9 \
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -78,7 +78,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/rstudio/c9s-python-3.9/Dockerfile
+++ b/rstudio/c9s-python-3.9/Dockerfile
@@ -78,7 +78,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://kojipkgs.fedoraproject.org//packages/spawn-fcgi/1.6.3/23.fc37/x86_64/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.

--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -91,7 +91,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.


### PR DESCRIPTION
* [RHOAIENG-8255](https://issues.redhat.com//browse/RHOAIENG-8255): Fix spawn-fcgi-1.6.3-23.fc37.x86_64.rpm download location

Previously used location is now unavailable and returns 404 error.

This new location comes from https://koji.fedoraproject.org/koji/buildinfo?buildID=2028619

(cherry picked from commit https://github.com/red-hat-data-services/notebooks/commit/e9c3f9a977583015679c9935a5c0cbb5207280d2)

* fixup from review, use a little bit more proper rpm link

(cherry picked from commit ab0f785)

* also fix the rhel9 downstream-only build