### PR TITLE
[CI] add basic checks for params.env and commit.env files content and also runtime images check

### DIFF
--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -12,7 +12,7 @@ jobs:
   validation-of-params-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -1,9 +1,10 @@
 ---
-name: Validation of params.env content (image SHAs)
+name: Validation of image references (image SHAs) in params.env and runtime images
 on:  # yamllint disable-line rule:truthy
   pull_request:
     paths:
       - 'manifests/base/params.env'
+      - 'ci/check-params-env.sh'
 
 permissions:
   contents: read
@@ -21,3 +22,8 @@ jobs:
       - name: Validate the 'manifests/base/params.env' file content
         run: |
           bash ./ci/check-params-env.sh
+
+      - name: Validate references for runtime images
+        id: validate-runtime-images-references
+        run: |
+          bash ./ci/check-runtime-images.sh

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -1,0 +1,23 @@
+---
+name: Validation of params.env content (image SHAs)
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+      - 'manifests/base/params.env'
+
+permissions:
+  contents: read
+
+jobs:
+  validation-of-params-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y skopeo jq
+
+      - name: Validate the 'manifests/base/params.env' file content
+        run: |
+          bash ./ci/check-params-env.sh

--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -3,6 +3,7 @@ name: Validation of image references (image SHAs) in params.env and runtime imag
 on:  # yamllint disable-line rule:truthy
   pull_request:
     paths:
+      - 'manifests/base/commit.env'
       - 'manifests/base/params.env'
       - 'ci/check-params-env.sh'
 

--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -20,6 +20,7 @@
 
 # ----------------------------- GLOBAL VARIABLES ----------------------------- #
 
+COMMIT_ENV_PATH="manifests/base/commit.env"
 PARAMS_ENV_PATH="manifests/base/params.env"
 
 # This value needs to be updated everytime we deliberately change number of the
@@ -29,13 +30,13 @@ EXPECTED_NUM_RECORDS=19
 # ---------------------------- DEFINED FUNCTIONS ----------------------------- #
 
 function check_variables_uniq() {
-    local params_env_path="${1}"
+    local env_file_path="${1}"
     local ret_code=0
 
-    echo "Checking that all variables in the file '${params_env_path}' are unique and expected"
+    echo "Checking that all variables in the file '${env_file_path}' are unique and expected"
 
     local content
-    content=$(sed 's#\(.*\)=.*#\1#' "${params_env_path}" | sort)
+    content=$(sed 's#\(.*\)=.*#\1#' "${env_file_path}" | sort)
 
     local num_records
     num_records=$(echo "${content}" | wc -l)
@@ -184,6 +185,30 @@ function check_image_variable_matches_name_and_commitref() {
     }
 }
 
+function check_image_commit_id_matches_metadata() {
+    local image_variable="${1}"
+    local image_commit_id="${2}"
+
+    local short_image_commit_id
+    # We're interested only in the first 7 characters of the commit ID
+    short_image_commit_id=${image_commit_id:0:7}
+
+    local file_image_commit_id
+
+    file_image_commit_id=$(sed 's#-commit##' "${COMMIT_ENV_PATH}" | grep "${image_variable}=" | cut --delimiter "=" --field 2)
+    test -n "${file_image_commit_id}" || {
+        echo "Couldn't retrieve commit id for image variable '${image_variable}' in '${COMMIT_ENV_PATH}'!"
+        return 1
+    }
+
+    test "${short_image_commit_id}" = "${file_image_commit_id}" || {
+        echo "Image commit IDs for image variable '${image_variable}' don't equal!"
+        echo "Image commit ID gathered from image: '${short_image_commit_id}'"
+        echo "Image commit ID in '${COMMIT_ENV_PATH}': '${file_image_commit_id}'"
+        return 1
+    }
+}
+
 function check_image() {
     local image_variable="${1}"
     local image_url="${2}"
@@ -192,6 +217,7 @@ function check_image() {
 
     local image_metadata
     local image_name
+    local image_commit_id
     local image_commitref
 
     image_metadata="$(skopeo inspect --config "docker://${image_url}")" || {
@@ -200,6 +226,10 @@ function check_image() {
     }
     image_name=$(echo "${image_metadata}" | jq --raw-output '.config.Labels.name') ||  {
         echo "Couldn't parse '.config.Labels.name' from image metadata!"
+        return 1
+    }
+    image_commit_id=$(echo "${image_metadata}" | jq --raw-output '.config.Labels."io.openshift.build.commit.id"') ||  {
+        echo "Couldn't parse '.config.Labels."io.openshift.build.commit.id"' from image metadata!"
         return 1
     }
     image_commitref=$(echo "${image_metadata}" | jq --raw-output '.config.Labels."io.openshift.build.commit.ref"') ||  {
@@ -233,6 +263,8 @@ function check_image() {
 
     check_image_variable_matches_name_and_commitref "${image_variable}" "${image_name}" "${image_commitref}" "${openshift_build_name}" || return 1
 
+    check_image_commit_id_matches_metadata "${image_variable}" "${image_commit_id}" || return 1
+
     echo "---------------------------------------------"
 }
 
@@ -240,11 +272,17 @@ function check_image() {
 
 ret_code=0
 
-echo "Starting check for file: '${PARAMS_ENV_PATH}'"
+echo "Starting check of image references in files: '${COMMIT_ENV_PATH}' and '${PARAMS_ENV_PATH}'"
 echo "---------------------------------------------"
 
+check_variables_uniq "${COMMIT_ENV_PATH}" || {
+    echo "ERROR: Variable names in the '${COMMIT_ENV_PATH}' file failed validation!"
+    echo "----------------------------------------------------"
+    ret_code=1
+}
+
 check_variables_uniq "${PARAMS_ENV_PATH}" || {
-    echo "ERROR: Variable names in the file failed validation!"
+    echo "ERROR: Variable names in the '${PARAMS_ENV_PATH}' file failed validation!"
     echo "----------------------------------------------------"
     ret_code=1
 }

--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -159,7 +159,7 @@ function check_image_variable_matches_name_and_commitref() {
             expected_commitref="rhods-1.34"
             expected_build_name="habana-jupyter-1.10.0-ubi8-python-3.8-amd64"
             ;;
-        odh-codeserver-notebook-n)
+        odh-codeserver-notebook-image-n)
             expected_name="odh-notebook-code-server-ubi9-python-3.9"
             expected_commitref="release-2023b"
             expected_build_name="codeserver-ubi9-python-3.9-amd64"

--- a/ci/check-params-env.sh
+++ b/ci/check-params-env.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+#
+# This script serves to check and validate the `params.env` file that contains
+# definitions of the notebook images that are supposed to be used in the resulting
+# release.
+#
+# It is verified that particular image link exists and is a proper type for the
+# assigned variable name. Structure of the `params.env` file is also checked.
+#
+# THIS FILE DOESN'T CHECK THAT THE USED LINK TO IMAGE IS THE LATEST ONE AVAILABLE!
+#
+# This script uses `skopeo` and `jq` tools installed locally for retrieving
+# information about the particular remote images.
+#
+# Local execution: ./ci/check-params-env.sh
+#   Note: please execute from the root directory so that relative path matches
+#
+# In case of the PR on GitHub, this check is tied to GitHub actions automatically,
+# see `.github/workflows` directory.
+
+# ----------------------------- GLOBAL VARIABLES ----------------------------- #
+
+PARAMS_ENV_PATH="manifests/base/params.env"
+
+# This value needs to be updated everytime we deliberately change number of the
+# images we want to have in the `params.env` file.
+EXPECTED_NUM_RECORDS=19
+
+# ---------------------------- DEFINED FUNCTIONS ----------------------------- #
+
+function check_variables_uniq() {
+    local params_env_path="${1}"
+    local ret_code=0
+
+    echo "Checking that all variables in the file '${params_env_path}' are unique and expected"
+
+    local content
+    content=$(sed 's#\(.*\)=.*#\1#' "${params_env_path}" | sort)
+
+    local num_records
+    num_records=$(echo "${content}" | wc -l)
+
+    local num_uniq_records
+    num_uniq_records=$(echo "${content}" | uniq | wc -l)
+
+    test "${num_records}" -eq "${num_uniq_records}" || {
+        echo "Some of the records in the file aren't unique!"
+        ret_code=1
+    }
+
+    test "${num_records}" -eq "${EXPECTED_NUM_RECORDS}" || {
+        echo "Number of records in the file is incorrect - expected '${EXPECTED_NUM_RECORDS}' but got '${num_records}'!"
+        ret_code=1
+    }
+
+    echo "---------------------------------------------"
+    return "${ret_code}"
+}
+
+function check_image_variable_matches_name_and_commitref() {
+    local image_variable="${1}"
+    local image_name="${2}"
+    local image_commitref="${3}"
+    local openshift_build_name="${4}"
+
+    local expected_name
+    local expected_commitref
+    local expected_build_name  # Why some of the images has `-amd64` suffix and others not?
+    case "${image_variable}" in
+        odh-minimal-notebook-image-n)
+            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="jupyter-minimal-ubi9-python-3.9-amd64"
+            ;;
+        odh-minimal-notebook-image-n-1)
+            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-minimal-ubi9-python-3.9-amd64"
+            ;;
+        odh-minimal-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-minimal-ubi8-python-3.8"
+            expected_commitref="release-1.2"
+            expected_build_name="jupyter-minimal-ubi8-python-3.8-amd64"
+            ;;
+        odh-minimal-gpu-notebook-image-n)
+            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="cuda-jupyter-minimal-ubi9-python-3.9-amd64"
+            ;;
+        odh-minimal-gpu-notebook-image-n-1)
+            expected_name="odh-notebook-jupyter-minimal-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="cuda-jupyter-minimal-ubi9-python-3.9-amd64"
+            ;;
+        odh-minimal-gpu-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-minimal-ubi8-python-3.8"
+            expected_commitref="release-1.2"
+            expected_build_name="cuda-jupyter-minimal-ubi8-python-3.8-amd64"
+            ;;
+        odh-pytorch-gpu-notebook-image-n)
+            expected_name="odh-notebook-jupyter-pytorch-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="jupyter-pytorch-ubi9-python-3.9-amd64"
+            ;;
+        odh-pytorch-gpu-notebook-image-n-1)
+            expected_name="odh-notebook-jupyter-pytorch-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-pytorch-ubi9-python-3.9-amd64"
+            ;;
+        odh-pytorch-gpu-notebook-image-n-2)
+            expected_name="odh-notebook-cuda-jupyter-pytorch-ubi8-python-3.8"
+            expected_commitref="release-1.2"
+            expected_build_name="jupyter-pytorch-ubi8-python-3.8-amd64"
+            ;;
+        odh-generic-data-science-notebook-image-n)
+            expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="jupyter-datascience-ubi9-python-3.9-amd64"
+            ;;
+        odh-generic-data-science-notebook-image-n-1)
+            expected_name="odh-notebook-jupyter-datascience-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-datascience-ubi9-python-3.9-amd64"
+            ;;
+        odh-generic-data-science-notebook-image-n-2)
+            expected_name="odh-notebook-jupyter-datascience-ubi8-python-3.8"
+            expected_commitref="release-1.2"
+            expected_build_name="jupyter-datascience-ubi8-python-3.8-amd64"
+            ;;
+        odh-tensorflow-gpu-notebook-image-n)
+            expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="cuda-jupyter-tensorflow-ubi9-python-3.9-amd64"
+            ;;
+        odh-tensorflow-gpu-notebook-image-n-1)
+            expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="cuda-jupyter-tensorflow-ubi9-python-3.9-amd64"
+            ;;
+        odh-tensorflow-gpu-notebook-image-n-2)
+            expected_name="odh-notebook-cuda-jupyter-tensorflow-ubi8-python-3.8"
+            expected_commitref="release-1.2"
+            expected_build_name="cuda-jupyter-tensorflow-ubi8-python-3.8-amd64"
+            ;;
+        odh-trustyai-notebook-image-n)
+            expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="jupyter-trustyai-ubi9-python-3.9-amd64"
+            ;;
+        odh-trustyai-notebook-image-n-1)
+            expected_name="odh-notebook-jupyter-trustyai-ubi9-python-3.9"
+            expected_commitref="release-2023a"
+            expected_build_name="jupyter-trustyai-ubi9-python-3.9-amd64"
+            ;;
+        odh-habana-notebook-image-n)
+            expected_name="odh-notebook-habana-jupyter-1.10.0-ubi8-python-3.8"
+            # expected_commitref="release-2023b"
+            expected_commitref="rhods-1.34"
+            expected_build_name="habana-jupyter-1.10.0-ubi8-python-3.8-amd64"
+            ;;
+        odh-codeserver-notebook-n)
+            expected_name="odh-notebook-code-server-ubi9-python-3.9"
+            expected_commitref="release-2023b"
+            expected_build_name="codeserver-ubi9-python-3.9-amd64"
+            ;;
+        *)
+            echo "Unimplemented variable name: '${image_variable}'"
+            return 1
+    esac
+
+    test "${image_name}" = "${expected_name}" || {
+        echo "Image URL points to an incorrect image: expected name '${expected_name}'; actual '${image_name}'"
+        return 1
+    }
+
+    test "${image_commitref}" = "${expected_commitref}" || {
+        echo "Image URL points to an incorrect image: expected commitref '${expected_commitref}'; actual '${image_commitref}'"
+        return 1
+    }
+
+    test "${openshift_build_name}" = "${expected_build_name}" || {
+        echo "Image URL points to an incorrect image: expected OPENSHIFT_BUILD_NAME '${expected_build_name}'; actual '${openshift_build_name}'"
+        return 1
+    }
+}
+
+function check_image() {
+    local image_variable="${1}"
+    local image_url="${2}"
+
+    echo "Checking metadata for image '${image_variable}' with URL '${image_url}'"
+
+    local image_metadata
+    local image_name
+    local image_commitref
+
+    image_metadata="$(skopeo inspect --config "docker://${image_url}")" || {
+        echo "Couldn't download image metadata with skopeo tool!"
+        return 1
+    }
+    image_name=$(echo "${image_metadata}" | jq --raw-output '.config.Labels.name') ||  {
+        echo "Couldn't parse '.config.Labels.name' from image metadata!"
+        return 1
+    }
+    image_commitref=$(echo "${image_metadata}" | jq --raw-output '.config.Labels."io.openshift.build.commit.ref"') ||  {
+        echo "Couldn't parse '.config.Labels."io.openshift.build.commit.ref"' from image metadata!"
+        return 1
+    }
+
+    local config_env
+    local build_name_raw
+    local openshift_build_name
+
+    config_env=$(echo "${image_metadata}" | jq --raw-output '.config.Env') || {
+        echo "Couldn't parse '.config.Env' from image metadata!"
+        return 1
+    }
+    build_name_raw=$(echo "${config_env}" | grep '"OPENSHIFT_BUILD_NAME=') || {
+        echo "Couldn't get 'OPENSHIFT_BUILD_NAME' from set of the image environment variables!"
+        return 1
+    }
+    openshift_build_name=$(echo "${build_name_raw}" | sed 's/.*"OPENSHIFT_BUILD_NAME=\(.*\)".*/\1/') || {
+        echo "Couldn't parse value of the 'OPENSHIFT_BUILD_NAME' variable from '${build_name_raw}'!"
+        return 1
+    }
+
+    test -n "${image_name}" || {
+        echo "Couldn't retrieve the name of the image - got empty value!"
+        return 1
+    }
+
+    echo "Image name retrieved: '${image_name}'"
+
+    check_image_variable_matches_name_and_commitref "${image_variable}" "${image_name}" "${image_commitref}" "${openshift_build_name}" || return 1
+
+    echo "---------------------------------------------"
+}
+
+# ------------------------------ MAIN SCRIPT --------------------------------- #
+
+ret_code=0
+
+echo "Starting check for file: '${PARAMS_ENV_PATH}'"
+echo "---------------------------------------------"
+
+check_variables_uniq "${PARAMS_ENV_PATH}" || {
+    echo "ERROR: Variable names in the file failed validation!"
+    echo "----------------------------------------------------"
+    ret_code=1
+}
+
+while IFS= read -r LINE; do
+    echo "Checking format of: '${LINE}'"
+    [[ "${LINE}" = *[[:space:]]* ]] && {
+        echo "ERROR: Line contains white-space and it shouldn't!"
+        echo "--------------------------------------------------"
+        ret_code=1
+        continue
+    }
+    [[ "${LINE}" != *=* ]] && {
+        echo "ERROR: Line doesn't contain '=' and it should!"
+        echo "----------------------------------------------"
+        ret_code=1
+        continue
+    }
+
+    IMAGE_VARIABLE=$(echo "${LINE}" | cut --delimiter '=' --field 1)
+    IMAGE_URL=$(echo "${LINE}" | cut --delimiter '=' --field 2)
+
+    test -n "${IMAGE_VARIABLE}" || {
+        echo "ERROR: Couldn't parse image variable - got empty value!"
+        echo "-------------------------------------------------------"
+        ret_code=1
+        continue
+    }
+
+    test -n "${IMAGE_URL}" || {
+        echo "ERROR: Couldn't parse image URL - got empty value!"
+        echo "--------------------------------------------------"
+        ret_code=1
+        continue
+    }
+
+    check_image "${IMAGE_VARIABLE}" "${IMAGE_URL}" || {
+        echo "ERROR: Image definition for '${IMAGE_VARIABLE}' isn't okay!"
+        echo "------------------------"
+        ret_code=1
+        continue
+    }
+done < "${PARAMS_ENV_PATH}"
+
+echo ""
+if test "${ret_code}" -eq 0; then
+    echo "Validation of '${PARAMS_ENV_PATH}' was successful! Congrats :)"
+else
+    echo "The '${PARAMS_ENV_PATH}' file isn't valid, please check above!"
+fi
+
+exit "${ret_code}"

--- a/ci/check-runtime-images.sh
+++ b/ci/check-runtime-images.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# This script serves to check and validate the definitions for runtime images.
+# It does just a brief check of the metadata defined in the json file:
+#   1. checks that given `.metadata.image_name` is valid and can be accessed by skopeo tool
+#   2. checks that tag in `.metadata.tags[0]` can be found in the output from skopeo tool
+#
+# THIS FILE DOESN'T CHECK THAT THE USED LINK TO IMAGE IS THE LATEST ONE AVAILABLE!
+#
+# This script uses `skopeo` and `jq` tools installed locally for retrieving
+# information about the particular remote images.
+#
+# Local execution: ./ci/check-runtime-image.sh
+#   Note: please execute from the root directory so that relative path matches
+#
+# In case of the PR on GitHub, this check is tied to GitHub actions automatically,
+# see `.github/workflows` directory.
+
+# ---------------------------- DEFINED FUNCTIONS ----------------------------- #
+
+function check_image() {
+    local runtime_image_file="${1}"
+
+    echo "---------------------------------------------"
+    echo "Checking file: '${runtime_image_file}'"
+
+    local img_tag
+    local img_url
+    local img_metadata
+
+    img_tag=$(jq -r '.metadata.tags[0]' "${runtime_image_file}") || {
+        echo "ERROR: Couldn't parse image tags metadata for '${runtime_image_file}' runtime image file!"
+        return 1
+    }
+    img_url=$(jq -r '.metadata.image_name' "${runtime_image_file}") || {
+        echo "ERROR: Couldn't parse image URL metadata for '${runtime_image_file}' runtime image file!"
+        return 1
+    }
+
+    img_metadata="$(skopeo inspect --config "docker://${img_url}")" || {
+        echo "ERROR: Couldn't download '${img_url}' image metadata with skopeo tool!"
+        return 1
+    }
+
+    local expected_string="runtime-${img_tag}-ubi"
+    echo "Checking that '${expected_string}' is present in the image metadata"
+    echo "${img_metadata}" | grep --quiet "${expected_string}" || {
+        echo "ERROR: The string '${expected_string}' isn't present in the image metadata at all. Please check that the referenced image '${img_url}' is the correct one!"
+        return 1
+    }
+
+    # TODO: we shall extend this check to check also Label "io.openshift.build.commit.ref" value (e.g. '2024a') or something similar
+}
+
+function main() {
+    ret_code=0
+
+    # If name of the directory isn't good enough, maybe we can improve this to search for the: `"schema_name": "runtime-image"` string.
+    runtime_image_files=$(find . -name "*.json" | grep "runtime-images" | sort --unique)
+
+    IFS=$'\n'
+    for file in ${runtime_image_files}; do
+        check_image "${file}" || {
+            echo "ERROR: Check for '${file}' failed!"
+            ret_code=1
+        }
+    done
+
+    echo "---------------------------------------------"
+    echo ""
+    if test "${ret_code}" -eq 0; then
+        echo "Validation of runtime images definitions was successful! Congrats :)"
+    else
+        echo "ERROR: Some of the runtime image definitions aren't valid, please check above!"
+    fi
+
+    return "${ret_code}"
+}
+
+# ------------------------------ MAIN SCRIPT --------------------------------- #
+
+main
+
+exit "${?}"

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -23,7 +23,7 @@ spec:
         opendatahub.io/notebook-build-commit: $(odh-codeserver-notebook-image-commit-n)
       from:
         kind: DockerImage
-        name: $(odh-codeserver-notebook-n)
+        name: $(odh-codeserver-notebook-image-n)
       name: "2023.2"
       referencePolicy:
         type: Source

--- a/manifests/base/commit.env
+++ b/manifests/base/commit.env
@@ -16,4 +16,4 @@ odh-tensorflow-gpu-notebook-image-commit-n-2=3e71410
 odh-trustyai-notebook-image-commit-n=cccc3b8
 odh-trustyai-notebook-image-commit-n-1=ff9e51d
 odh-habana-notebook-image-commit-n=7d8f86d
-odh-codeserver-notebook-image-commit-n=852adda
+odh-codeserver-notebook-image-commit-n=6560116

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -151,13 +151,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.odh-habana-notebook-image-n
-  - name: odh-codeserver-notebook-n
+  - name: odh-codeserver-notebook-image-n
     objref:
       kind: ConfigMap
       name: notebooks-parameters
       apiVersion: v1
     fieldref:
-      fieldpath: data.odh-codeserver-notebook-n
+      fieldpath: data.odh-codeserver-notebook-image-n
   - name: odh-minimal-notebook-image-commit-n
     objref:
       kind: ConfigMap

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -16,4 +16,4 @@ odh-tensorflow-gpu-notebook-image-n-2=quay.io/modh/cuda-notebooks@sha256:6fadedc
 odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:926ed1f947f79066de7a839ab13eabb0dabd90cc31a4541cb47ac3bf29dbf977
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:392ed524193b3d26e052e04094c97c5be230d534eb2d23a4b84014bdbc9d515b
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:0f6ae8f0b1ef11896336e7f8611e77ccdb992b49a7942bf27e6bc64d73205d05
-odh-codeserver-notebook-n=quay.io/modh/codeserver@sha256:575df4c8ce5bfb2c6dc355fcae74e0cc7499e0490f4d9deeb9788fe3aaa7f6d1
+odh-codeserver-notebook-image-n=quay.io/modh/codeserver@sha256:575df4c8ce5bfb2c6dc355fcae74e0cc7499e0490f4d9deeb9788fe3aaa7f6d1

--- a/manifests/base/params.yaml
+++ b/manifests/base/params.yaml
@@ -75,4 +75,4 @@ varReference:
   - path: spec/tags[]/from/name
     kind: ImageStream
     apiGroup: image.openshift.io/v1
-    name: odh-codeserver-notebook-n
+    name: odh-codeserver-notebook-image-n


### PR DESCRIPTION
This adds basic checks for the content in params.env and commit.env files with the extension of:
* https://issues.redhat.com/browse/RHOAIENG-8739
  * https://issues.redhat.com/browse/RHOAIENG-7882
  * https://issues.redhat.com/browse/RHOAIENG-7885

Note: this is in draft right now, since there are things that would deserved to be fixed in our code and we should discuss this:
1. there is more to backport than we expected initially (whole check-params-env.sh)
2. commit reference for code-server is wrong - this PR fixes this too, which is kind of a functional change
   * part of that is that we should fix the commit reference value that we propagate for the code-server image as it is not correct now