### PR TITLE
Run the static code checks on push and when manually triggered

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,6 +1,9 @@
 ---
 name: Code static analysis
-on: [pull_request]  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
GHA that only runs on pull_request is hard to test; I have to create PR to see it run. With this change, the action can be tested in my personal fork before I create a PR

(cherry picked from commit da7c9da3369a971a929677e06ac11c7cde595f97)