### PR TITLE
[2023b] RHOAIENG-8299, RHOAIENG-8255, RHOAIENG-8740: Fix spawn-fcgi-1.6.3-23.fc37.x86_64.rpm and CentOS Stream 8 download locations

### DIFF
--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -90,7 +90,7 @@ RUN yum -y module enable nginx:$NGINX_VERSION && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
     # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://www.rpmfind.net/linux/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
+    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
 
 # Copy extra files to the image.


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-8299, https://issues.redhat.com/browse/RHOAIENG-8255, https://issues.redhat.com/browse/RHOAIENG-8740

This cherry-picks the 2023 branch changes:

* https://github.com/opendatahub-io/notebooks/pull/570
* https://github.com/opendatahub-io/notebooks/pull/571