### PR TITLE
Update pytorch version for 2023.b on imagestream annotations

### DIFF
--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -30,8 +30,8 @@ spec:
         type: Source
     # N-1 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"2.0"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.0"},{"name":"Tensorboard","version":"2.13"},{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.13"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"2.2"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.2"},{"name":"Tensorboard","version":"2.13"},{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.13"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/workbench-image-recommended: "false"
         opendatahub.io/notebook-build-commit: $(odh-pytorch-gpu-notebook-image-commit-n-1)


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-8469


Note: This PR should be opened separately because the ImageStreams on downstream are dedicated for downstream use only!