### PR TITLE
Replace fcgi with supervisord on rstudio rhel flavor

### DIFF
--- a/rstudio/rhel9-python-3.9/Dockerfile
+++ b/rstudio/rhel9-python-3.9/Dockerfile
@@ -86,13 +86,13 @@ ENV NGINX_VERSION=1.22 \
 
 # Modules does not exist
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig" && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl fcgiwrap initscripts chkconfig supervisor" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
-    # spawn-fcgi is not in epel9
-    rpm -i --nodocs https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/37/Everything/x86_64/os/Packages/s/spawn-fcgi-1.6.3-23.fc37.x86_64.rpm && \
     yum -y clean all --enablerepo='*'
+
+COPY --chown=1001:0 rstudio/rhel9-python-3.9/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Copy extra files to the image.
 COPY rstudio/rhel9-python-3.9/nginx/root/ /

--- a/rstudio/rhel9-python-3.9/run-rstudio.sh
+++ b/rstudio/rhel9-python-3.9/run-rstudio.sh
@@ -4,9 +4,9 @@
 SCRIPT_DIR=$(dirname -- "$0")
 source ${SCRIPT_DIR}/utils/*.sh
 
-# Start nginx and fastcgiwrap
+# Start nginx and supervisord
 run-nginx.sh &
-spawn-fcgi -s /var/run/fcgiwrap.socket -M 766 /usr/sbin/fcgiwrap 
+/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 
 
 # Add .bashrc for custom promt if not present

--- a/rstudio/rhel9-python-3.9/supervisord/supervisord.conf
+++ b/rstudio/rhel9-python-3.9/supervisord/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:fcgiwrap]
+command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket
+autostart=true
+autorestart=true
+redirect_stderr=true


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-8298

## How has been tested

Replace the `spec.source` part from rstudio-server-rhel9 Build Config with the following and press `start build` :
```
  source:
    type: Git
    git:
      uri: 'https://github.com/atheo89/notebooks'
      ref: RHOAIENG-8298
```
For further info check the following [article](https://developers.redhat.com/articles/2024/06/06/how-integrate-and-use-rstudio-server-openshift-ai) 

Once the BuildConfig finish should be Completed successfully like the image bellow:
![image](https://github.com/red-hat-data-services/notebooks/assets/42587738/63270887-7925-4ba8-b452-89d03ca883ce)

Spin Up `RStudio Server` image and ensure that is working properly:
![image](https://github.com/red-hat-data-services/notebooks/assets/42587738/6a96b8e5-0f00-4dd7-9e49-61ffd04d0872)

