### PR TITLE
Update runtimes workflow to don't break when a file doe not exists

### DIFF
--- a/.github/workflows/runtimes-digest-updater.yaml
+++ b/.github/workflows/runtimes-digest-updater.yaml
@@ -84,6 +84,12 @@ jobs:
 
               for ((i=0;i<${#PATHS[@]};++i)); do
                 path=${PATHS[$i]}
+
+                if [[ ! -f "$path" ]]; then
+                  echo "File $path does not exist. Skipping..."
+                  continue
+                fi
+
                 img=$(cat ${path} | jq -r '.metadata.image_name')
                 name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
                 py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]')


### PR DESCRIPTION
Update runtimes workflow to don't break when a file doe not exists

Bug found here: https://github.com/opendatahub-io/notebooks/actions/runs/10610954620/job/29409452122#step:5:78