### PR TITLE
[RHOAIENG-11695] Critical CVEs in jupyter-server-proxy package

### DIFF
--- a/manifests/base/commit.env
+++ b/manifests/base/commit.env
@@ -22,6 +22,6 @@ odh-trustyai-notebook-image-commit-n=70df141
 odh-trustyai-notebook-image-commit-n-1=cccc3b8
 odh-trustyai-notebook-image-commit-n-2=07015ec
 odh-habana-notebook-image-commit-n=70df141
-odh-habana-notebook-image-commit-n-1=cccc3b8
+odh-habana-notebook-image-commit-n-1=76a016f
 odh-codeserver-notebook-image-commit-n=70df141
 odh-codeserver-notebook-image-commit-n-1=cccc3b8

--- a/manifests/base/params.env
+++ b/manifests/base/params.env
@@ -22,6 +22,6 @@ odh-trustyai-notebook-image-n=quay.io/modh/odh-trustyai-notebook@sha256:6756ea9b
 odh-trustyai-notebook-image-n-1=quay.io/modh/odh-trustyai-notebook@sha256:926ed1f947f79066de7a839ab13eabb0dabd90cc31a4541cb47ac3bf29dbf977
 odh-trustyai-notebook-image-n-2=quay.io/modh/odh-trustyai-notebook@sha256:8c5e653f6bc6a2050565cf92f397991fbec952dc05cdfea74b65b8fd3047c9d4
 odh-habana-notebook-image-n=quay.io/modh/odh-habana-notebooks@sha256:64ca5d31d1d0d305bc99317eb9d453ce5fa8571f0311e171252df12b40c41b75
-odh-habana-notebook-image-n-1=quay.io/modh/odh-habana-notebooks@sha256:e115a0ad0106aaf72c53560c0b7d774f8a30fc2460ce9f773c715ba33d170063
+odh-habana-notebook-image-n-1=quay.io/modh/odh-habana-notebooks@sha256:6923f084d66bf6b9b2bf87edfb9b3c1f8f9a5f2005482fbcc060c9872db8d28a
 odh-codeserver-notebook-image-n=quay.io/modh/codeserver@sha256:3f1b86feed5ee437663ff1088471ccca1ba164b45b2bb4443a8d37a587e95e91
 odh-codeserver-notebook-image-n-1=quay.io/modh/codeserver@sha256:14b73e8a62b98fb9a70cb079b6048121ab0a7798fe1eca0adf06b6716f280115


### PR DESCRIPTION
This change updates the Habana image used for the 2.10.z stream release with the bunch of updated packages where the main thing is update of the jupyter-server-proxy package [1].

* [1] https://issues.redhat.com/browse/RHOAIENG-11695

Changes between the image that is being updated: https://github.com/red-hat-data-services/notebooks/compare/cccc3b8...76a016f