### PR TITLE
[RHOAIENG-12621] Update the updater github action to the latest branch

### DIFF
--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -13,8 +13,8 @@ on:  # yamllint disable-line rule:truthy
 env:
   DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
   BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
-  RELEASE_VERSION_N: 2024a
-  RELEASE_VERSION_N_1: 2023b
+  RELEASE_VERSION_N: 2024b
+  RELEASE_VERSION_N_1: 2024a
 jobs:
   initialize:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -6,10 +6,10 @@ on:  # yamllint disable-line rule:truthy
     inputs:
       branch:
         required: true
-        description: "Provide branch name: "
-# Put the scheduler on comment until automate the full release procedure
-#   schedule:
-#     - cron:  "0 0 * * 5" #Scheduled every Friday
+        description: "Provide the name of the branch you want to update ex main, vYYYYx etc: "
+        # Put the scheduler on comment until automate the full release procedure
+        # schedule:
+        #   - cron: "0 0 * * 5"  #Scheduled every Friday
 env:
   DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
   BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
@@ -68,7 +68,7 @@ jobs:
       - name: Update the params.env file
         shell: bash
         run: |
-          echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
+          echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
 
           # Get the complete list of images N-version to update
           PARAMS_ENV_PATH="manifests/base/params.env"
@@ -108,12 +108,12 @@ jobs:
             git commit -m "Update images for release N via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
             git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
           else
-            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
           fi
 
       - name: Update the commit.env file
         run: |
-          echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
+          echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}
 
           COMMIT_ENV_PATH="manifests/base/commit.env"
 
@@ -167,7 +167,7 @@ jobs:
 
           # Get the complete list of images N-1-version to update
           PARAMS_ENV_PATH="manifests/base/params.env"
-          IMAGES=$(cat "${PARAMS_ENV_PATH}" | grep "\-n-1=" | cut -d "=" -f 1)
+          IMAGES=$(grep "\-n-1=" "${PARAMS_ENV_PATH}" | cut -d "=" -f 1)
 
           # The order of the regexes array should match with the params.env file
           REGEXES=("v2-${{ env.RELEASE_VERSION_N_1 }}-\d{8}+-${{ steps.hash-n-1.outputs.HASH_N_1 }}" \
@@ -192,14 +192,15 @@ jobs:
             sed -i "s|${image}=.*|${image}=${output}|" "${PARAMS_ENV_PATH}"
             i=$((i+1))
           done
+
           if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-            git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-            git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-            git add manifests/base/params.env && \
+            git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git add "${PARAMS_ENV_PATH}" && \
             git commit -m "Update images for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
-            git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+            git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
           else
-            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1}}"
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1 }}"
           fi
 
       - name: Update the commit.env file
@@ -214,13 +215,15 @@ jobs:
             echo "${val}"
             sed -i "s|${val}=.*|${val}=${{ steps.hash-n-1.outputs.HASH_N_1 }}|" "${COMMIT_ENV_PATH}"
           done
+
           if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-            git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-            git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && \
-            git add manifests/base/commit.env && \
-            git commit -m "Update image commits for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+            git fetch origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git pull origin ${{ env.DIGEST_UPDATER_BRANCH }} && \
+            git add "${COMMIT_ENV_PATH}" && \
+            git commit -m "Update image commits for release N-1 via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+            git push origin ${{ env.DIGEST_UPDATER_BRANCH }}
           else
-            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1}}"
+            echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N_1 }}"
           fi
 
   open-pull-request:
@@ -236,7 +239,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ${{ env.DIGEST_UPDATER_BRANCH }}
-          destination_branch: ${{ env.BRANCH_NAME}}
+          destination_branch: ${{ env.BRANCH_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_label: "automated pr"
           pr_title: "[Digest Updater Action] Update Notebook Images"
@@ -248,4 +251,4 @@ jobs:
             - `manifests/base/params.env` file with the latest updated SHA digests of the notebooks (N & N-1).
             - `manifests/base/commit.env` file with the latest commit (N & N-1).
 
-            :exclamation: **IMPORTANT NOTE**: Remember to delete the ` ${{ env.DIGEST_UPDATER_BRANCH }}` branch after merging the changes
+            :exclamation: **IMPORTANT NOTE**: Remember to delete the `${{ env.DIGEST_UPDATER_BRANCH }}` branch after merging the changes

--- a/.github/workflows/runtimes-digest-updater.yaml
+++ b/.github/workflows/runtimes-digest-updater.yaml
@@ -6,10 +6,10 @@ on:  # yamllint disable-line rule:truthy
     inputs:
       branch:
         required: true
-        description: "Provide branch name: "
-# Put the scheduler on comment until automate the full release procedure
-#   schedule:
-#     - cron:  "0 0 * * 5" #Scheduled every Friday
+        description: "Provide the name of the branch you want to update ex main, vYYYYx etc: "
+        # Put the scheduler on comment until automate the full release procedure
+        # schedule:
+        #   - cron: "0 0 * * 5"  #Scheduled every Friday
 env:
   DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
   BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
@@ -66,42 +66,43 @@ jobs:
 
       - name: Update Runtimes
         run: |
-              echo "Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}"
+            echo "Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}"
 
-              find . -name runtime-images -type d -exec find {} -type f -print \; | while read -r path; do
-                echo "Processing the '${path}' file."
+            find . -name runtime-images -type d -exec find {} -type f -print \; | grep python-3.11 | while read -r path; do
+              echo "Processing the '${path}' file."
 
-                img=$(jq -r '.metadata.image_name' "${path}")
-                name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
-                py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]*')
-                # Handling specific cases
-                if [[ $name == tensorflow* ]]; then
-                    name="cuda-$name"
-                elif [[ $name == ubi* ]]; then
-                    name="minimal-$name"
-                fi
-                registry=$(echo "$img" | cut -d '@' -f1)
-                regex="runtime-$name-$py_version-${{ env.RELEASE_VERSION_N }}-\d+-${{ steps.hash-n.outputs.HASH_N }}"
-                latest_tag=$(skopeo inspect "docker://$img" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-                echo "CHECKING: ${latest_tag}"
-                if [[ -z "${latest_tag}" ]]; then
-                  echo "No matching tag found"
-                  exit 1
-                fi
-                digest=$(skopeo inspect "docker://$registry:$latest_tag" | jq .Digest | tr -d '"')
-                output="${registry}@${digest}"
-                echo "NEW: ${output}"
-                jq --arg output "$output" '.metadata.image_name = $output' "$path" > "$path.tmp" && mv "$path.tmp" "$path"
-              done
-              if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
-                  git pull origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
-                  git add jupyter/datascience/* && \
-                  git commit -m "Update file via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
-                  git push origin "${{ env.DIGEST_UPDATER_BRANCH }}"
-              else
-                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
+              img=$(jq -r '.metadata.image_name' "${path}")
+              name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
+              py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]*')
+              # Handling specific cases
+              if [[ $name == tensorflow* ]]; then
+                name="cuda-$name"
+              elif [[ $name == ubi* ]]; then
+                name="minimal-$name"
               fi
+              registry=$(echo "$img" | cut -d '@' -f1)
+              regex="^runtime-$name-$py_version-${{ env.RELEASE_VERSION_N }}-\d+-${{ steps.hash-n.outputs.HASH_N }}\$"
+              latest_tag=$(skopeo inspect --retry-times 3 "docker://$img" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+              echo "CHECKING: ${latest_tag}"
+              if [[ -z "${latest_tag}" ]]; then
+                echo "No matching tag found"
+                exit 1
+              fi
+              digest=$(skopeo inspect --retry-times 3 "docker://$registry:$latest_tag" | jq .Digest | tr -d '"')
+              output="${registry}@${digest}"
+              echo "NEW: ${output}"
+              jq --arg output "$output" '.metadata.image_name = $output' "$path" > "$path.tmp" && mv "$path.tmp" "$path"
+            done
+
+            if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+              git fetch origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
+                git pull origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
+                git add jupyter/datascience/* && \
+                git commit -m "Update file via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                git push origin "${{ env.DIGEST_UPDATER_BRANCH }}"
+            else
+              echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
+            fi
 
   open-pull-request:
     needs: [update-runtimes]
@@ -125,7 +126,6 @@ jobs:
             Created by `/.github/workflows/runtime-digest-updater.yaml`
 
             This PR updates the following files:
-
             - All the runtime images across `/jupyter/datascience/ubi*-python-*/runtime-images/*.json` paths
 
             :exclamation: **IMPORTANT NOTE**: Remember to delete the ` ${{ env.DIGEST_UPDATER_BRANCH }}` branch after merging the changes

--- a/.github/workflows/runtimes-digest-updater.yaml
+++ b/.github/workflows/runtimes-digest-updater.yaml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   DIGEST_UPDATER_BRANCH: digest-updater-${{ github.run_id }}
   BRANCH_NAME: ${{ github.event.inputs.branch || 'main' }}
-  RELEASE_VERSION_N: 2024a
+  RELEASE_VERSION_N: 2024b
 jobs:
   initialize:
     runs-on: ubuntu-latest
@@ -92,7 +92,7 @@ jobs:
 
                 img=$(cat ${path} | jq -r '.metadata.image_name')
                 name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
-                py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]')
+                py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]*')
                 # Handling specific cases
                 if [[ $name == tensorflow* ]]; then
                     name="cuda-$name"

--- a/.github/workflows/runtimes-digest-updater.yaml
+++ b/.github/workflows/runtimes-digest-updater.yaml
@@ -66,31 +66,12 @@ jobs:
 
       - name: Update Runtimes
         run: |
-              echo Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N}}
-              PATHS=("jupyter/datascience/anaconda-python-3.8/runtime-images/datascience-ubi8-py38.json"
-              "jupyter/datascience/anaconda-python-3.8/runtime-images/pytorch-ubi8-py38.json"
-              "jupyter/datascience/anaconda-python-3.8/runtime-images/tensorflow-ubi8-py38.json"
-              "jupyter/datascience/anaconda-python-3.8/runtime-images/ubi8-py38.json"
-              "jupyter/datascience/ubi8-python-3.8/runtime-images/datascience-ubi8-py38.json"
-              "jupyter/datascience/ubi8-python-3.8/runtime-images/pytorch-ubi8-py38.json"
-              "jupyter/datascience/ubi8-python-3.8/runtime-images/tensorflow-ubi8-py38.json"
-              "jupyter/datascience/ubi8-python-3.8/runtime-images/ubi8-py38.json"
-              "jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json"
-              "jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json"
-              "jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json"
-              "jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json"
-              "jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json"
-              "jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json")
+              echo "Latest commit is: ${{ steps.hash-n.outputs.HASH_N }} on ${{ env.RELEASE_VERSION_N }}"
 
-              for ((i=0;i<${#PATHS[@]};++i)); do
-                path=${PATHS[$i]}
+              find . -name runtime-images -type d -exec find {} -type f -print \; | while read -r path; do
+                echo "Processing the '${path}' file."
 
-                if [[ ! -f "$path" ]]; then
-                  echo "File $path does not exist. Skipping..."
-                  continue
-                fi
-
-                img=$(cat ${path} | jq -r '.metadata.image_name')
+                img=$(jq -r '.metadata.image_name' "${path}")
                 name=$(echo "$path" | sed 's#.*runtime-images/\(.*\)-py.*#\1#')
                 py_version=$(echo "$path" | grep -o 'python-[0-9]\.[0-9]*')
                 # Handling specific cases
@@ -99,23 +80,27 @@ jobs:
                 elif [[ $name == ubi* ]]; then
                     name="minimal-$name"
                 fi
-                registry=$(echo $img | cut -d '@' -f1)
-                regex="runtime-$name-$py_version-${{ env.RELEASE_VERSION_N}}-\d+-${{ steps.hash-n.outputs.HASH_N }}"
-                latest_tag=$(skopeo inspect docker://$img | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
-                echo "CHECKING: "  $latest_tag
-                if [[ -z "$latest_tag" ]]; then
+                registry=$(echo "$img" | cut -d '@' -f1)
+                regex="runtime-$name-$py_version-${{ env.RELEASE_VERSION_N }}-\d+-${{ steps.hash-n.outputs.HASH_N }}"
+                latest_tag=$(skopeo inspect "docker://$img" | jq -r --arg regex "$regex" '.RepoTags | map(select(. | test($regex))) | .[0]')
+                echo "CHECKING: ${latest_tag}"
+                if [[ -z "${latest_tag}" ]]; then
                   echo "No matching tag found"
                   exit 1
                 fi
-                digest=$(skopeo inspect docker://$registry:$latest_tag | jq .Digest | tr -d '"')
-                output=$registry@$digest
-                echo "NEW: " $output
+                digest=$(skopeo inspect "docker://$registry:$latest_tag" | jq .Digest | tr -d '"')
+                output="${registry}@${digest}"
+                echo "NEW: ${output}"
                 jq --arg output "$output" '.metadata.image_name = $output' "$path" > "$path.tmp" && mv "$path.tmp" "$path"
               done
               if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
-                git fetch origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git pull origin  ${{ env.DIGEST_UPDATER_BRANCH }} && git add jupyter/datascience/* && git commit -m "Update file via  ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && git push origin  ${{ env.DIGEST_UPDATER_BRANCH }}
+                git fetch origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
+                  git pull origin "${{ env.DIGEST_UPDATER_BRANCH }}" && \
+                  git add jupyter/datascience/* && \
+                  git commit -m "Update file via ${{ env.DIGEST_UPDATER_BRANCH }} GitHub action" && \
+                  git push origin "${{ env.DIGEST_UPDATER_BRANCH }}"
               else
-                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N}}"
+                echo "There were no changes detected in the images for the ${{ env.RELEASE_VERSION_N }}"
               fi
 
   open-pull-request:
@@ -131,7 +116,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: ${{ env.DIGEST_UPDATER_BRANCH }}
-          destination_branch: ${{ env.BRANCH_NAME}}
+          destination_branch: ${{ env.BRANCH_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_label: "automated pr"
           pr_title: "[Digest Updater Action] Update Runtime Images"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images
-RELEASE	 		 ?= 2024a
+RELEASE	 		 ?= 2024b
 # additional user-specified caching parameters for $(CONTAINER_ENGINE) build
 CONTAINER_BUILD_CACHE_ARGS ?= --no-cache
 # whether to build all dependent images or just the one specified


### PR DESCRIPTION
This updates the digest updater GHA scripts for both regular workbench images and also runtime images.

On top of that, the runtime images GHA script was a bit enhanced and cleaned of a couple of shellcheck warnings (I can put it as a separate PR if it will be preferred).

https://issues.redhat.com/browse/RHOAIENG-12621

The relevant upstream changes are in opendatahub-io/notebooks#716.

## How Has This Been Tested?
Started relevant GHA via https://github.com/jstourac/notebooks/actions

Standard workbench images:
* https://github.com/jstourac/notebooks/actions/runs/11057100656
* Resulting PR - TBD

Runtime images:
* https://github.com/jstourac/notebooks/actions/runs/11057072140
* Resulting PR - TBD

---

The GHAs failed as we don't have any 2024b builds in https://quay.io/repository/opendatahub/workbench-images?tab=tags&tag=latest --- will re-run once we have some.