### PR TITLE
revert habana with removal of label opendatahub.image

### DIFF
--- a/manifests/base/jupyter-habana-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-habana-notebook-imagestream.yaml
@@ -1,0 +1,43 @@
+---
+# This Image is Deprecated and will not be displayed on the Dashboard
+# Keeping this here for satisfying upgrade requirements
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/habana"
+    opendatahub.io/notebook-image-name: "HabanaAI"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of habana libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
+    opendatahub.io/notebook-image-order: "70"
+    opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
+  name: habana-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # 1.13.0 Version of the image n
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.13"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.34"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.7"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"2.0"},{"name":"Scikit-learn","version":"1.3"},{"name":"Codeflare-SDK","version":"0.16"},{"name":"Scipy","version":"1.10"},{"name":"TensorFlow","version":"2.13"},{"name":"PyTorch","version":"2.1"},{"name":"ODH-Elyra","version":"3.16"}]'
+        openshift.io/imported-from: quay.io/modh/odh-habana-notebooks
+        opendatahub.io/workbench-image-recommended: "true"
+        opendatahub.io/notebook-build-commit: b5a8318
+      from:
+        kind: DockerImage
+        name: quay.io/modh/odh-habana-notebooks@sha256:4317c67037e1150fc62f8c688696d3210e4151d6ed4415dd969e60850e871c64
+      name: "2024.1"
+      referencePolicy:
+        type: Source
+    # 1.10.0 Version of the image n-1
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"Habana","version":"1.10"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.23"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"TensorFlow","version":"2.12"},{"name":"PyTorch","version":"2.0"},{"name":"Elyra","version":"3.15"}]'
+        openshift.io/imported-from: quay.io/modh/odh-habana-notebooks
+        opendatahub.io/workbench-image-recommended: "false"
+        opendatahub.io/notebook-build-commit: 76a016f
+      from:
+        kind: DockerImage
+        name: quay.io/modh/odh-habana-notebooks@sha256:6923f084d66bf6b9b2bf87edfb9b3c1f8f9a5f2005482fbcc060c9872db8d28a
+      name: "2023.2"
+      referencePolicy:
+        type: Source

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - jupyter-minimal-notebook-imagestream.yaml
   - jupyter-datascience-notebook-imagestream.yaml
+  - jupyter-habana-notebook-imagestream.yaml
   - jupyter-minimal-gpu-notebook-imagestream.yaml
   - jupyter-pytorch-notebook-imagestream.yaml
   - jupyter-tensorflow-notebook-imagestream.yaml


### PR DESCRIPTION
Fixes for https://issues.redhat.com/browse/RHOAIENG-13415 

Linking to https://github.com/red-hat-data-services/notebooks/pull/384

Reverting because we would no longer want to upgrade Habana images but continue to keep them in the manifest with removal of label so that it does not show up on UI 