### PR TITLE
update runtime-image of commit 9d2af21 with codeflare-sdk changes

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -5,7 +5,7 @@
       "datascience"
     ],
     "display_name": "Datascience with Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:d107b3a514c5df24a5640a4c4d51a580a83cddac2659da2e3855c4a5e9987e1c",
+    "image_name": "quay.io/modh/runtime-images@sha256:c5563e20a1d94cea26391a4e0cca6ef79b953571b3ce65f77a568014cbb4fb82",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -5,7 +5,7 @@
       "pytorch"
     ],
     "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:cee154f6db15de27929362f91baa128fc4f79b9c1930ab0f27561174d39aadfa",
+    "image_name": "quay.io/modh/runtime-images@sha256:3eefa5d7e49bc762070bfbe8ce2025350b335146b8338589148585e939fe313c",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -5,7 +5,7 @@
       "tensorflow"
     ],
     "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:1186ac6c9026d1091f707fe8cedfcc1ea12d1ec46edd9e8d56bb4b12ba048630",
+    "image_name": "quay.io/modh/runtime-images@sha256:59cce2371639b81a6b4f114da91da31f968b3c76a9110d0cf53e8863970e18e9",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -5,7 +5,7 @@
       "minimal"
     ],
     "display_name": "Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:32b5ba616c5dfdb4c5ea7f7f552a810663c0f37b0cbf23c546d269101ede626b",
+    "image_name": "quay.io/modh/runtime-images@sha256:51e478d83ea31f495c2f89e7b4527376b3d5a56c2e1eda87cfd60440477b593b",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"


### PR DESCRIPTION
Update runtime-image of commit 9d2af21 with codeflare-sdk changes
Follow-up: #406 
Related-to: JIRA: https://issues.redhat.com/browse/RHOAIENG-14201

This is required so that runtime images have the same codeflare-sdk upgrade.