### PR TITLE
Set opendatahub.io/notebook-image to false instead of removing it

### DIFF
--- a/manifests/base/jupyter-habana-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-habana-notebook-imagestream.yaml
@@ -4,6 +4,9 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
+  labels:
+    # This label specifies whether the workbench image should be displayed in the UI. Setting it to 'false' disables the image
+    opendatahub.io/notebook-image: "false"
   annotations:
     opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/notebooks/tree/main/habana"
     opendatahub.io/notebook-image-name: "HabanaAI"


### PR DESCRIPTION
follow up for this: https://github.com/red-hat-data-services/notebooks/pull/404 

Set `opendatahub.io/notebook-image` to `false` instead of removing it completely, otherwise we confuse the operator while the reconciliation upgrade.  

Related to https://issues.redhat.com/browse/RHOAIENG-14573