### PR TITLE
Updated the runtime-images for 2024a with commit 2e29fc6

### DIFF
--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/datascience-ubi9-py39.json
@@ -5,7 +5,7 @@
       "datascience"
     ],
     "display_name": "Datascience with Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:c5563e20a1d94cea26391a4e0cca6ef79b953571b3ce65f77a568014cbb4fb82",
+    "image_name": "quay.io/modh/runtime-images@sha256:682af2e8f52f2e2a5313851891e8e1d4909c81322e5afcff1b2d139ee8610b51",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/pytorch-ubi9-py39.json
@@ -5,7 +5,7 @@
       "pytorch"
     ],
     "display_name": "Pytorch with CUDA and Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:3eefa5d7e49bc762070bfbe8ce2025350b335146b8338589148585e939fe313c",
+    "image_name": "quay.io/modh/runtime-images@sha256:c89f94f00baee8bbb930c3c1bd077acf10e707c898942daf34729ae53da77c11",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-pytorch-ubi9-py39.json
@@ -5,7 +5,7 @@
       "rocm-pytorch"
     ],
     "display_name": "Pytorch with ROCm and Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:59cce2371639b81a6b4f114da91da31f968b3c76a9110d0cf53e8863970e18e9",
+    "image_name": "quay.io/modh/runtime-images@sha256:34192c2201c9459256ac84a59e05b57b1f458bc51a82dd1d6c85b2992029a4dc",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/rocm-tensorflow-ubi9-py39.json
@@ -5,7 +5,7 @@
       "rocm-tensorflow"
     ],
     "display_name": "TensorFlow with ROCm and Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:d4804691693c9a172d205fcf16eab3ef9fb4d4edb03d0665cb571189eeb3300f",
+    "image_name": "quay.io/modh/runtime-images@sha256:5f1fb177ca4f444815f438ff942e8c2c7e55fc74db52780c9dd2c92b5ac6be29",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/tensorflow-ubi9-py39.json
@@ -5,7 +5,7 @@
       "tensorflow"
     ],
     "display_name": "TensorFlow with CUDA and Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:59cce2371639b81a6b4f114da91da31f968b3c76a9110d0cf53e8863970e18e9",
+    "image_name": "quay.io/modh/runtime-images@sha256:c6efdc6b33cac19d260d6e216d09297b78ade8cf85d1ba90de1f2f57047a2a79",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"

--- a/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
+++ b/jupyter/datascience/ubi9-python-3.9/runtime-images/ubi9-py39.json
@@ -5,7 +5,7 @@
       "minimal"
     ],
     "display_name": "Python 3.9 (UBI9)",
-    "image_name": "quay.io/modh/runtime-images@sha256:51e478d83ea31f495c2f89e7b4527376b3d5a56c2e1eda87cfd60440477b593b",
+    "image_name": "quay.io/modh/runtime-images@sha256:803e2b9810c86a7fd014f4ed54a45e338b6285e11b77529f3c1566fb8fa9cae5",
     "pull_policy": "IfNotPresent"
   },
   "schema_name": "runtime-image"


### PR DESCRIPTION
Updated the runtime-images for 2024a with commit 2e29fc6
Failed: https://github.com/red-hat-data-services/notebooks/actions/runs/11748063740