### PR TITLE
[RHOAIENG-15710] fix the version of codeflare-sdk shown for 2024.1

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -70,7 +70,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -79,7 +79,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -80,7 +80,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -76,7 +76,7 @@ spec:
             {"name": "Odh-Elyra", "version": "3.16"},
             {"name": "PyMongo", "version": "4.6"},
             {"name": "Pyodbc", "version": "5.1"},
-            {"name": "Codeflare-SDK", "version": "0.19"},
+            {"name": "Codeflare-SDK", "version": "0.21"},
             {"name": "Sklearn-onnx", "version": "1.16"},
             {"name": "Psycopg", "version": "3.1"},
             {"name": "MySQL Connector/Python", "version": "8.3"}


### PR DESCRIPTION
Fix the Codeflare-SDK version for the 2024.1 images.

* [1] https://issues.redhat.com/browse/RHOAIENG-15710

(cherry picked from commit 9eba86551158c1890d16934e81bcba46d41876fc) (opendatahub-io/notebooks#771)