### PR TITLE
[RHOAIENG-14520] Change supervisord files location for rhel images

### DIFF
--- a/rstudio/rhel9-python-3.11/supervisord/supervisord.conf
+++ b/rstudio/rhel9-python-3.11/supervisord/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [program:fcgiwrap]
 command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket

--- a/rstudio/rhel9-python-3.9/supervisord/supervisord.conf
+++ b/rstudio/rhel9-python-3.9/supervisord/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [program:fcgiwrap]
 command=/usr/sbin/fcgiwrap -s unix:/var/run/fcgiwrap.socket


### PR DESCRIPTION
This is a completition change for the opendathub-io/notebooks#747 (merged into this downstream in 15952132114f926a21c5d17c99bf8b8abc50d70c). We missed these two files because we don't have rhel based images in the upstream repository.

https://issues.redhat.com/browse/RHOAIENG-14520