### PR TITLE
Fix the annotation for ROCm in tensorflow image

### DIFF
--- a/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-rocm-tensorflow-notebook-imagestream.yaml
@@ -9,7 +9,7 @@ metadata:
     opendatahub.io/notebook-image-name: "ROCm-TensorFlow"
     opendatahub.io/notebook-image-desc: "Jupyter ROCm optimized TensorFlow notebook image for ODH notebooks."
     opendatahub.io/notebook-image-order: "92"
-    opendatahub.io/recommended-accelerators: '[amd.com/gpu"]'
+    opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
   name: jupyter-rocm-tensorflow
 spec:
   lookupPolicy:


### PR DESCRIPTION
Fix the annotation for ROCm in tensorflow image
Related-to: https://issues.redhat.com/browse/RHOAIENG-13409