### PR TITLE
RHOAIENG-16520: update setuptools to 70.0.0 for CVE fixes

### DIFF
--- a/base/rhel9-python-3.9/Pipfile
+++ b/base/rhel9-python-3.9/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 # Base packages
 wheel = "~=0.41.2"
-setuptools = "~=68.1.2"
+setuptools = "~=70.0.0"
 
 [requires]
 python_version = "3.9"

--- a/base/rhel9-python-3.9/Pipfile.lock
+++ b/base/rhel9-python-3.9/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "54af5308fe912f4e39360fc1fa1d2fa9f9233d975a2e1ab42265db7c82aab4fa"
+            "sha256": "749fc0c4364798ed77d3e68d28df97a123cb8ad14370fd44d23c92a0bdf7a8ed"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,12 @@
     "default": {
         "setuptools": {
             "hashes": [
-                "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d",
-                "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"
+                "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4",
+                "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"
             ],
             "index": "pypi",
-            "version": "==68.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==70.0.0"
         },
         "wheel": {
             "hashes": [
@@ -30,6 +31,7 @@
                 "sha256:4d4987ce51a49370ea65c0bfd2234e8ce80a12780820d9dc462597a6e60d0841"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==0.41.3"
         }
     },


### PR DESCRIPTION
Fixes for https://issues.redhat.com/browse/RHOAIENG-16520 & https://issues.redhat.com/browse/RHOAIENG-16955

updating setuptools to 70.0.0 to fix a few CVEs 