### PR TITLE
RHOAIENG-17774: ref(manifests): add some newlines and indentation into the json strings with package version information

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -27,8 +27,18 @@ spec:
   tags:
     - name: latest
       annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"12.4"},{"name":"R","version":"v4.4"},{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"2024.04.2"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"12.4"},
+            {"name":"R","version":"v4.4"},
+            {"name":"Python","version":"v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"rstudio-server","version":"2024.04.2"}
+          ]
       referencePolicy:
         type: Source
 ---

--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -86,8 +86,30 @@ spec:
         type: Source
     # N-2 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.13"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"Boto3","version":"1.28"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.3"},
+            {"name":"Scipy","version":"1.11"},
+            {"name":"Elyra","version":"3.15"},
+            {"name":"PyMongo","version":"4.5"},
+            {"name":"Pyodbc","version":"4.0"},
+            {"name":"Codeflare-SDK","version":"0.13"},
+            {"name":"Sklearn-onnx","version":"1.15"},
+            {"name":"Psycopg","version":"3.1"},
+            {"name":"MySQL Connector/Python","version":"8.0"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-generic-data-science-notebook-image-commit-n-2)
@@ -99,8 +121,24 @@ spec:
         type: Source
     # N-3 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"Boto3","version":"1.26"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.2"},
+            {"name":"Scipy","version":"1.10"},
+            {"name":"Elyra","version":"3.15"}
+            ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-generic-data-science-notebook-image-commit-n-3)
@@ -112,8 +150,22 @@ spec:
         type: Source
     # N-4 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.8"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"Boto3","version":"1.17"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Matplotlib","version":"3.4"},
+            {"name":"Numpy","version":"1.19"},
+            {"name":"Pandas","version":"1.2"},
+            {"name":"Scikit-learn","version":"0.24"},
+            {"name":"Scipy","version":"1.6"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-generic-data-science-notebook
         opendatahub.io/image-tag-outdated: 'true'
         opendatahub.io/notebook-build-commit: $(odh-generic-data-science-notebook-image-commit-n-4)

--- a/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -62,8 +62,18 @@ spec:
         type: Source
     # N-2 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.6"},{"name":"Notebook","version":"6.5"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.8"},
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"JupyterLab","version":"3.6"},
+            {"name":"Notebook","version":"6.5"}
+          ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-minimal-gpu-notebook-image-commit-n-2)
@@ -75,8 +85,18 @@ spec:
         type: Source
     # N-3 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.8"},
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"JupyterLab","version":"3.5"},
+            {"name":"Notebook","version":"6.5"}
+          ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-minimal-gpu-notebook-image-commit-n-3)
@@ -88,8 +108,18 @@ spec:
         type: Source
     # N-4 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2"},{"name":"Notebook","version":"6.4"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.4"},
+            {"name":"Python","version":"v3.8"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"JupyterLab","version":"3.2"},
+            {"name":"Notebook","version":"6.4"}
+          ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: 'true'
         opendatahub.io/notebook-build-commit: $(odh-minimal-gpu-notebook-image-commit-n-4)

--- a/manifests/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-minimal-notebook-imagestream.yaml
@@ -59,8 +59,17 @@ spec:
         type: Source
     # N-2 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.6"}, {"name": "Notebook","version": "6.5"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"JupyterLab","version": "3.6"},
+            {"name": "Notebook","version": "6.5"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-minimal-notebook-image-commit-n-2)
@@ -72,8 +81,17 @@ spec:
         type: Source
     # N-3 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.5"}, {"name": "Notebook","version": "6.5"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"JupyterLab","version": "3.5"},
+            {"name": "Notebook","version": "6.5"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-minimal-notebook-image-commit-n-3)
@@ -85,8 +103,17 @@ spec:
         type: Source
     # N-4 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.2"}, {"name": "Notebook","version": "6.4"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.8"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"JupyterLab","version": "3.2"},
+            {"name": "Notebook","version": "6.4"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-minimal-notebook-container
         opendatahub.io/image-tag-outdated: 'true'
         opendatahub.io/notebook-build-commit: $(odh-minimal-notebook-image-commit-n-4)

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -96,8 +96,34 @@ spec:
         type: Source
     # N-2 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"2.2"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"2.2"},{"name":"Tensorboard","version":"2.13"},{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.14"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.8"},
+            {"name":"Python","version":"v3.9"},
+            {"name":"PyTorch","version":"2.2"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"PyTorch","version":"2.2"},
+            {"name":"Tensorboard","version":"2.13"},
+            {"name":"Boto3","version":"1.28"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.3"},
+            {"name":"Scipy","version":"1.11"},
+            {"name":"Elyra","version":"3.15"},
+            {"name":"PyMongo","version":"4.5"},
+            {"name":"Pyodbc","version":"4.0"},
+            {"name":"Codeflare-SDK","version":"0.14"},
+            {"name":"Sklearn-onnx","version":"1.15"},
+            {"name":"Psycopg","version":"3.1"},
+            {"name":"MySQL Connector/Python","version":"8.0"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-pytorch-gpu-notebook-image-commit-n-2)
@@ -109,8 +135,28 @@ spec:
         type: Source
     # N-3 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.8"},
+            {"name":"Python","version":"v3.9"},
+            {"name":"PyTorch","version":"1.13"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"PyTorch","version":"1.13"},
+            {"name":"Tensorboard","version":"2.11"},
+            {"name":"Boto3","version":"1.26"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.2"},
+            {"name":"Scipy","version":"1.10"},
+            {"name":"Elyra","version":"3.15"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-pytorch-gpu-notebook-image-commit-n-3)
@@ -122,8 +168,26 @@ spec:
         type: Source
     # N-4 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.4"},
+            {"name":"Python","version":"v3.8"},
+            {"name":"PyTorch","version":"1.8"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"PyTorch","version":"1.8"},
+            {"name":"Tensorboard","version":"2.6"},
+            {"name":"Boto3","version":"1.17"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Matplotlib","version":"3.4"},
+            {"name":"Numpy","version":"1.19"},
+            {"name":"Pandas","version":"1.2"},
+            {"name":"Scikit-learn","version":"0.24"},
+            {"name":"Scipy","version":"1.6"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-pytorch-notebook
         opendatahub.io/image-tag-outdated: 'true'
         opendatahub.io/notebook-build-commit: $(odh-pytorch-gpu-notebook-image-commit-n-4)

--- a/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -96,8 +96,34 @@ spec:
         type: Source
     # N-2 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.13"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.13"},{"name":"Tensorboard","version":"2.13"},{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.13"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.8"},
+            {"name":"Python","version":"v3.9"},
+            {"name":"TensorFlow","version":"2.13"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"TensorFlow","version":"2.13"},
+            {"name":"Tensorboard","version":"2.13"},
+            {"name":"Boto3","version":"1.28"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.3"},
+            {"name":"Scipy","version":"1.11"},
+            {"name":"Elyra","version":"3.15"},
+            {"name":"PyMongo","version":"4.5"},
+            {"name":"Pyodbc","version":"4.0"},
+            {"name":"Codeflare-SDK","version":"0.13"},
+            {"name":"Sklearn-onnx","version":"1.15"},
+            {"name":"Psycopg","version":"3.1"},
+            {"name":"MySQL Connector/Python","version":"8.0"}
+          ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-tensorflow-gpu-notebook-image-commit-n-2)
@@ -109,8 +135,28 @@ spec:
         type: Source
     # N-3 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.8"},
+            {"name":"Python","version":"v3.9"},
+            {"name":"TensorFlow","version":"2.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"TensorFlow","version":"2.11"},
+            {"name":"Tensorboard","version":"2.11"},
+            {"name":"Boto3","version":"1.26"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.2"},
+            {"name":"Scipy","version":"1.10"},
+            {"name":"Elyra","version":"3.15"}
+          ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-tensorflow-gpu-notebook-image-commit-n-3)
@@ -122,8 +168,26 @@ spec:
         type: Source
     # N-4 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"CUDA","version":"11.4"},
+            {"name":"Python","version":"v3.8"},
+            {"name":"TensorFlow","version":"2.7"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"TensorFlow","version":"2.7"},
+            {"name":"Tensorboard","version":"2.6"},
+            {"name":"Boto3","version":"1.17"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Matplotlib","version":"3.4"},
+            {"name":"Numpy","version":"1.19"},
+            {"name":"Pandas","version":"1.2"},
+            {"name":"Scikit-learn","version":"0.24"},
+            {"name":"Scipy","version":"1.6"}
+          ]
         openshift.io/imported-from: quay.io/modh/cuda-notebooks
         opendatahub.io/image-tag-outdated: 'true'
         opendatahub.io/notebook-build-commit: $(odh-tensorflow-gpu-notebook-image-commit-n-4)

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -92,8 +92,31 @@ spec:
         type: Source
     # N-2 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.6"},{"name":"Boto3","version":"1.28"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.3"},{"name":"Scipy","version":"1.11"},{"name":"Elyra","version":"3.15"},{"name":"PyMongo","version":"4.5"},{"name":"Pyodbc","version":"4.0"}, {"name":"Codeflare-SDK","version":"0.14"}, {"name":"Sklearn-onnx","version":"1.15"}, {"name":"Psycopg","version":"3.1"}, {"name":"MySQL Connector/Python","version":"8.0"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"TrustyAI","version":"0.6"},
+            {"name":"Boto3","version":"1.28"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.3"},
+            {"name":"Scipy","version":"1.11"},
+            {"name":"Elyra","version":"3.15"},
+            {"name":"PyMongo","version":"4.5"},
+            {"name":"Pyodbc","version":"4.0"},
+            {"name":"Codeflare-SDK","version":"0.14"},
+            {"name":"Sklearn-onnx","version":"1.15"},
+            {"name":"Psycopg","version":"3.1"},
+            {"name":"MySQL Connector/Python","version":"8.0"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-trustyai-notebook-image-commit-n-2)
@@ -105,8 +128,25 @@ spec:
         type: Source
     # N-3 Version of the image
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.3"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"},{"name":"Elyra","version":"3.15"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"Python","version":"v3.9"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"TrustyAI","version":"0.3"},
+            {"name":"Boto3","version":"1.26"},
+            {"name":"Kafka-Python","version":"2.0"},
+            {"name":"Kfp-tekton","version":"1.5"},
+            {"name":"Matplotlib","version":"3.6"},
+            {"name":"Numpy","version":"1.24"},
+            {"name":"Pandas","version":"1.5"},
+            {"name":"Scikit-learn","version":"1.2"},
+            {"name":"Scipy","version":"1.10"},
+            {"name":"Elyra","version":"3.15"}
+          ]
         openshift.io/imported-from: quay.io/modh/odh-trustyai-notebook
         opendatahub.io/image-tag-outdated: "true"
         opendatahub.io/notebook-build-commit: $(odh-trustyai-notebook-image-commit-n-3)

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -14,8 +14,17 @@ spec:
   tags:
     - name: latest
       annotations:
-        opendatahub.io/notebook-software: '[{"name":"R","version":"v4.4"},{"name":"Python","version":"v3.11"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"rstudio-server","version":"2024.04.2"}]'
+        # language=json
+        opendatahub.io/notebook-software: |
+          [
+            {"name":"R","version":"v4.4"},
+            {"name":"Python","version":"v3.11"}
+          ]
+        # language=json
+        opendatahub.io/notebook-python-dependencies: |
+          [
+            {"name":"rstudio-server","version":"2024.04.2"}
+          ]
       referencePolicy:
         type: Source
 ---


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17774

Followup to
* https://github.com/opendatahub-io/notebooks/pull/760

that applies the same change to manifests entries that are only present in red-hat-data-services/notebooks.

Previously, we used to have every json string on a single line, which meant we had long hard-to-read lines in our manifests. Now there is some human-friendly indentation in the files so it should be easier to read.

This is to nave no impact on the data stored, it is a code formatting change only.