### PR TITLE
[rhoai-2.18] RHOAIENG-20569: Fix the ImageStream manifests with the correct software versions

### DIFF
--- a/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-datascience-notebook-imagestream.yaml
@@ -63,7 +63,7 @@ spec:
           [
             {"name": "Boto3", "version": "1.34"},
             {"name": "Kafka-Python", "version": "2.0"},
-            {"name": "Kfp", "version": "2.8"},
+            {"name": "Kfp", "version": "2.11"},
             {"name": "Matplotlib", "version": "3.8"},
             {"name": "Numpy", "version": "1.26"},
             {"name": "Pandas", "version": "2.2"},

--- a/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -72,7 +72,7 @@ spec:
             {"name": "Tensorboard", "version": "2.16"},
             {"name": "Boto3", "version": "1.34"},
             {"name": "Kafka-Python", "version": "2.0"},
-            {"name": "Kfp", "version": "2.8"},
+            {"name": "Kfp", "version": "2.11"},
             {"name": "Matplotlib", "version": "3.8"},
             {"name": "Numpy", "version": "1.26"},
             {"name": "Pandas", "version": "2.2"},

--- a/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/manifests/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -69,7 +69,7 @@ spec:
             {"name": "TrustyAI", "version": "0.6"},
             {"name": "Boto3", "version": "1.34"},
             {"name": "Kafka-Python", "version": "2.0"},
-            {"name": "Kfp", "version": "2.8"},
+            {"name": "Kfp", "version": "2.11"},
             {"name": "Matplotlib", "version": "3.6"},
             {"name": "Numpy", "version": "1.24"},
             {"name": "Pandas", "version": "1.5"},


### PR DESCRIPTION
This is a backport of the things relevant to the images mentioned in the KB article

* https://access.redhat.com/articles/rhoai-supported-configs

from

* https://github.com/opendatahub-io/notebooks/pull/925