### PR TITLE
feat(rstudio): update R/RStudio for 2025a

### DIFF
--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -66,7 +66,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     --auto-attach; \
   fi
 
-ENV R_VERSION=4.4.1
+ENV R_VERSION=4.4.3
 
 # Install R
 RUN yum install -y yum-utils && \
@@ -80,30 +80,33 @@ RUN yum install -y yum-utils && \
     yum -y clean all --enablerepo='*'
 
 # set R library to default (used in install.r from littler)
-RUN chmod -R a+w /usr/lib64/R/library
 ENV LIBLOC=/usr/lib64/R/library
-
-# set User R Library path
-RUN mkdir -p /opt/app-root/bin/Rpackages/4.4 && chmod -R a+w /opt/app-root/bin/Rpackages/4.4
 ENV R_LIBS_USER=/opt/app-root/bin/Rpackages/4.4
+
+RUN chmod -R a+w ${LIBLOC} && \
+    # create User R Library path
+    mkdir -p ${R_LIBS_USER} && \
+    chmod -R a+w ${R_LIBS_USER}
 
 WORKDIR /tmp/
 
 # Install RStudio
-RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum install -y rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    rm rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum -y clean all  --enablerepo='*'
+ARG RSTUDIO_RPM=rstudio-server-rhel-2024.12.1-563-x86_64.rpm
+RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM} && \
+    yum install -y ${RSTUDIO_RPM} && \
+    rm ${RSTUDIO_RPM} && \
+    yum -y clean all  --enablerepo='*' &&\
+    # Specific RStudio config and fixes \
+    chmod 1777 /var/run/rstudio-server && \
+    mkdir -p /usr/share/doc/R && \
+    # package installation \
+    # install necessary texlive-framed package to make Knit R markup to PDF rendering possible \
+    dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed && \
+    dnf clean all && \
+    rm -rf /var/cache/yum
 
-# Specific RStudio config and fixes
-RUN chmod 1777 /var/run/rstudio-server && \
-    mkdir -p /usr/share/doc/R
 COPY ${RSTUDIO_SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
-# package installation
-# install necessary texlive-framed package to make Knit R markup to PDF rendering possible
-RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed \
-    && dnf clean all && rm -rf /var/cache/yum
 # Install R packages
 RUN R -e "install.packages('Rcpp')"
 

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -216,7 +216,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     --auto-attach; \
   fi
 
-ENV R_VERSION=4.4.1
+ENV R_VERSION=4.4.3
 
 # Install R
 RUN yum install -y yum-utils && \
@@ -230,30 +230,33 @@ RUN yum install -y yum-utils && \
     yum -y clean all --enablerepo='*'
 
 # set R library to default (used in install.r from littler)
-RUN chmod -R a+w /usr/lib64/R/library
 ENV LIBLOC=/usr/lib64/R/library
-
-# set User R Library path
-RUN mkdir -p /opt/app-root/bin/Rpackages/4.4 && chmod -R a+w /opt/app-root/bin/Rpackages/4.4
 ENV R_LIBS_USER=/opt/app-root/bin/Rpackages/4.4
+
+RUN chmod -R a+w ${LIBLOC} && \
+    # create User R Library path
+    mkdir -p ${R_LIBS_USER} && \
+    chmod -R a+w ${R_LIBS_USER}
 
 WORKDIR /tmp/
 
 # Install RStudio
-RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum install -y rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    rm rstudio-server-rhel-2024.04.2-764-x86_64.rpm && \
-    yum -y clean all  --enablerepo='*'
+ARG RSTUDIO_RPM=rstudio-server-rhel-2024.12.1-563-x86_64.rpm
+RUN wget --progress=dot:giga https://download2.rstudio.org/server/rhel9/x86_64/${RSTUDIO_RPM} && \
+    yum install -y ${RSTUDIO_RPM} && \
+    rm ${RSTUDIO_RPM} && \
+    yum -y clean all  --enablerepo='*' &&\
+    # Specific RStudio config and fixes \
+    chmod 1777 /var/run/rstudio-server && \
+    mkdir -p /usr/share/doc/R && \
+    # package installation \
+    # install necessary texlive-framed package to make Knit R markup to PDF rendering possible \
+    dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed && \
+    dnf clean all && \
+    rm -rf /var/cache/yum
 
-# Specific RStudio config and fixes
-RUN chmod 1777 /var/run/rstudio-server && \
-    mkdir -p /usr/share/doc/R
 COPY ${RSTUDIO_SOURCE_CODE}/rsession.conf /etc/rstudio/rsession.conf
 
-# package installation
-# install necessary texlive-framed package to make Knit R markup to PDF rendering possible
-RUN dnf install -y libsodium-devel.x86_64 libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed \
-    && dnf clean all && rm -rf /var/cache/yum
 # Install R packages
 RUN R -e "install.packages('Rcpp')"
 

--- a/rstudio/rhel9-python-3.11/Pipfile
+++ b/rstudio/rhel9-python-3.11/Pipfile
@@ -7,8 +7,8 @@ verify_ssl = true
 
 [packages]
 # Base packages
-wheel = "~=0.44.0"
-setuptools = "~=74.1.2"
+setuptools = "~=75.8.2"
+wheel = "~=0.45.1"
 
 [requires]
 python_version = "3.11"

--- a/rstudio/rhel9-python-3.11/Pipfile.lock
+++ b/rstudio/rhel9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f1c9618c7ab256174b2bdae019c9e06708e135c0376603eb554fb05c12175e4"
+            "sha256": "d0ef0c3e47575d974a1623e3b51b0660a71d6f6a3e47ce0a6eb989a3323f2bcd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,21 +18,21 @@
     "default": {
         "setuptools": {
             "hashes": [
-                "sha256:1cfd66bfcf197bce344da024c8f5b35acc4dcb7ca5202246a75296b4883f6851",
-                "sha256:fbb126f14b0b9ffa54c4574a50ae60673bbe8ae0b1645889d10b3b14f5891d28"
+                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
+                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==74.1.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==75.8.2"
         },
         "wheel": {
             "hashes": [
-                "sha256:2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f",
-                "sha256:a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49"
+                "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729",
+                "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==0.44.0"
+            "version": "==0.45.1"
         }
     },
     "develop": {}

--- a/rstudio/rhel9-python-3.11/kustomize/components/accelerator/kustomization.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/components/accelerator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: pod-patch.yaml

--- a/rstudio/rhel9-python-3.11/kustomize/components/accelerator/pod-patch.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/components/accelerator/pod-patch.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  containers:
+    - name: rstudio
+      resources:
+        limits:
+          memory: 6Gi
+        requests:
+          memory: 6Gi
+      volumeMounts:
+        - mountPath: /opt/app-root/src
+          name: tmp-volume
+  volumes:
+    - name: tmp-volume
+      emptyDir:
+        medium: Memory

--- a/rstudio/rhel9-python-3.11/kustomize/overlays/accelerator/cuda/kustomization.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/overlays/accelerator/cuda/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+resources:
+  - ../../../base
+
+components:
+  - ../../../components/accelerator
+
+patches:
+  - path: pod-patch.yaml

--- a/rstudio/rhel9-python-3.11/kustomize/overlays/accelerator/cuda/pod-patch.yaml
+++ b/rstudio/rhel9-python-3.11/kustomize/overlays/accelerator/cuda/pod-patch.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  nodeSelector:
+    accelerator: cuda
+  containers:
+    - name: rstudio
+      resources:
+        limits:
+          nvidia.com/gpu: '1'

--- a/rstudio/rhel9-python-3.11/requirements.txt
+++ b/rstudio/rhel9-python-3.11/requirements.txt
@@ -4,9 +4,9 @@
 #
 # Default dependencies
 #
-setuptools==74.1.3; python_version >= '3.8' \
-    --hash=sha256:1cfd66bfcf197bce344da024c8f5b35acc4dcb7ca5202246a75296b4883f6851 \
-    --hash=sha256:fbb126f14b0b9ffa54c4574a50ae60673bbe8ae0b1645889d10b3b14f5891d28
-wheel==0.44.0; python_version >= '3.8' \
-    --hash=sha256:2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f \
-    --hash=sha256:a29c3f2817e95ab89aa4660681ad547c0e9547f20e75b0562fe7723c9a2a9d49
+setuptools==75.8.2; python_version >= '3.9' \
+    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
+    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+wheel==0.45.1; python_version >= '3.8' \
+    --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \
+    --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248


### PR DESCRIPTION
This commit is related to the ongoing work to release the `2025a` software upgrade - specific to `red-hat-data-services`.

Upgrades:
- `R`
	- `4.4.1` -> `4.4.3`
- `RStudio`
	- rstudio-server-rhel-2024.04.2-764-x86_64.rpm -> rstudio-server-rhel-2024.12.1-563-x86_64.rpm

A couple other "quality of life" improvements were included:
- Refactored `Dockerfile` to combine `RUN` statements where obvious/low-risk
- Better use of `ARG` references to reduce copy-pasta in `Dockerfile` instructions
- Added `kustomize` `cuda` `overlay`

Related-to: https://issues.redhat.com/browse/RHOAIENG-19484