### PR TITLE
Manual sync to unblock https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/15137374657/job/42552299174

### DIFF
--- a/manifests/base/cuda-rstudio-buildconfig.yaml
+++ b/manifests/base/cuda-rstudio-buildconfig.yaml
@@ -42,7 +42,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.20
+      ref: rhoai-2.21
   strategy:
     type: Docker
     dockerStrategy:

--- a/manifests/base/rstudio-buildconfig.yaml
+++ b/manifests/base/rstudio-buildconfig.yaml
@@ -39,7 +39,7 @@ spec:
     type: Git
     git:
       uri: "https://github.com/red-hat-data-services/notebooks"
-      ref: rhoai-2.20
+      ref: rhoai-2.21
   strategy:
     type: Docker
     dockerStrategy:


### PR DESCRIPTION
Manual sync to unblock https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/15137374657/job/42552299174

```
Unmerged paths:
  (use "git add <file>..." to mark resolution)
	both modified:   manifests/base/cuda-rstudio-buildconfig.yaml
	both modified:   manifests/base/rstudio-buildconfig.yaml
```

* RStudio build configs - bump the branch reference to 2.21

(cherry picked from commit 0d294cc95343c78125a7b82deaa66d1e41e16813)

## Details from Slack

yeah we have diff between downstream and upstream on these files

rhds:

rhoai-2.20 https://github.com/red-hat-data-services/notebooks/blob/main/manifests/base/cuda-rstudio-buildconfig.yaml#L45

odh-io:

rhoai-2.21 https://github.com/opendatahub-io/notebooks/blob/main/manifests/base/cuda-rstudio-buildconfig.yaml#L45