### PR TITLE
RHOAIENG-26264: switch `GITHUB_TOKEN` to `GH_ACCESS_TOKEN` in `instant-merge.yaml` and remove unused permissions

### DIFF
--- a/.github/workflows/instant-merge.yaml
+++ b/.github/workflows/instant-merge.yaml
@@ -8,13 +8,6 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - manifests/base/params-latest.env
 
-permissions:
-  contents: write
-  pull-requests: write
-  checks: write
-  security-events: write
-  statuses: write
-
 jobs:
   instant-merge:
     runs-on: ubuntu-latest
@@ -22,6 +15,6 @@ jobs:
       - name: instant-merge
         if: ${{ github.event.sender.login == 'red-hat-konflux[bot]' && ( contains(github.event.pull_request.title, 'Update odh-workbench-jupyter-') || contains(github.event.pull_request.title, 'Update odh-workbench-codeserver-') || contains(github.event.pull_request.title, 'Update odh-pipeline-runtime-') ) }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
           gh pr merge --merge --admin ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHOAIENG-26264?focusedId=27434800&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27434800

Added PR

* https://github.com/jiridanek/notebooks/pull/12

action triggered and instamerged it

* https://github.com/jiridanek/notebooks/actions/runs/15774617408

And then the gha to update commit-latest.env also autotriggered

* https://github.com/jiridanek/notebooks/actions/runs/15774638270

So it looks like it is working.