### PR TITLE
Revert "RHOAIENG-26264: switch `GITHUB_TOKEN` to `GH_ACCESS_TOKEN` in `instant-merge.yaml` and remove unused permissions"

### DIFF
--- a/.github/workflows/instant-merge.yaml
+++ b/.github/workflows/instant-merge.yaml
@@ -8,6 +8,13 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - manifests/base/params-latest.env
 
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+  security-events: write
+  statuses: write
+
 jobs:
   instant-merge:
     runs-on: ubuntu-latest
@@ -15,6 +22,6 @@ jobs:
       - name: instant-merge
         if: ${{ github.event.sender.login == 'red-hat-konflux[bot]' && ( contains(github.event.pull_request.title, 'Update odh-workbench-jupyter-') || contains(github.event.pull_request.title, 'Update odh-workbench-codeserver-') || contains(github.event.pull_request.title, 'Update odh-pipeline-runtime-') ) }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh pr merge --merge --admin ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
* Reverts red-hat-data-services/notebooks#935

This thing did work, as documented on https://issues.redhat.com/browse/RHOAIENG-26264, but there are some trouble with accounts and permissions remaining, that I am unable to resolve on my own or with the help of other IDE team members. Therefore, I strongly believe it's best to back off for now and try again later.