### PR TITLE
RHOAIENG-28184: apply runtime image via the params-latest.env using kustomize

### DIFF
--- a/manifests/base/runtime-datascience-imagestream.yaml
+++ b/manifests/base/runtime-datascience-imagestream.yaml
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/modh/runtime-images
       from:
         kind: DockerImage
-        name: quay.io/modh/runtime-images@sha256:e6544a6024bbe12ad108b9d36b529cdcf9283327d1b2c7d08e699fa3cb22392c
+        name: odh-pipeline-runtime-datascience-cpu-py311-ubi9-n_PLACEHOLDER
       name: "datascience"
       referencePolicy:
         type: Source

--- a/manifests/base/runtime-minimal-imagestream.yaml
+++ b/manifests/base/runtime-minimal-imagestream.yaml
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/modh/runtime-images
       from:
         kind: DockerImage
-        name: quay.io/modh/runtime-images@sha256:c938190b9e562f995cced83465c3ab809099301107664170e9cddb1554c9912c
+        name: odh-pipeline-runtime-minimal-cpu-py311-ubi9-n_PLACEHOLDER
       name: "minimal"
       referencePolicy:
         type: Source

--- a/manifests/base/runtime-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-pytorch-imagestream.yaml
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/modh/runtime-images
       from:
         kind: DockerImage
-        name: quay.io/modh/runtime-images@sha256:fd101db0d5b3cd5158ab733c0df8af0a121515a823e66ceff4387e22c29dbe92
+        name: odh-pipeline-runtime-pytorch-cuda-py311-ubi9-n_PLACEHOLDER
       name: "pytorch"
       referencePolicy:
         type: Source

--- a/manifests/base/runtime-rocm-pytorch-imagestream.yaml
+++ b/manifests/base/runtime-rocm-pytorch-imagestream.yaml
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/modh/runtime-images
       from:
         kind: DockerImage
-        name: quay.io/modh/runtime-images@sha256:15652f6c1b6e048c77d8384220a13c5339135eec59233082c5f4b305ce5ffb01
+        name: odh-pipeline-runtime-pytorch-rocm-py311-ubi9-n_PLACEHOLDER
       name: "rocm-pytorch"
       referencePolicy:
         type: Source

--- a/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-rocm-tensorflow-imagestream.yaml
@@ -33,7 +33,7 @@ spec:
         openshift.io/imported-from: quay.io/modh/runtime-images
       from:
         kind: DockerImage
-        name: quay.io/modh/runtime-images@sha256:f63eb3e5b356954d740f5c074221624c7b22bd3eab8aa9f43f30de468e22a0d2
+        name: odh-pipeline-runtime-tensorflow-rocm-py311-ubi9-n_PLACEHOLDER
       name: "rocm-tensorflow"
       referencePolicy:
         type: Source

--- a/manifests/base/runtime-tensorflow-imagestream.yaml
+++ b/manifests/base/runtime-tensorflow-imagestream.yaml
@@ -33,7 +33,7 @@ spec:
         openshift.io/imported-from: quay.io/modh/runtime-images
       from:
         kind: DockerImage
-        name: quay.io/modh/runtime-images@sha256:7a1274d4c4b8bbf5554466e5427b88428954522c1652c27044e6f6f1d87b85fd
+        name: odh-pipeline-runtime-tensorflow-cuda-py311-ubi9-n_PLACEHOLDER
       name: "tensorflow"
       referencePolicy:
         type: Source


### PR DESCRIPTION
Apply runtime image via the params-latest.env using kustomize
Blocker-fix: [RHOAIENG-28184](https://issues.redhat.com/browse/RHOAIENG-28184)