### PR TITLE
Update and sync rhoai-2.23 branch based the latest changes for rocm-runtime-tensorflow py312 image

### DIFF
--- a/manifests/base/commit-latest.env
+++ b/manifests/base/commit-latest.env
@@ -27,4 +27,3 @@ odh-pipeline-runtime-minimal-cpu-py312-ubi9-commit-n=fcf1deb
 odh-pipeline-runtime-datascience-cpu-py312-ubi9-commit-n=50d4a77
 odh-pipeline-runtime-pytorch-cuda-py312-ubi9-commit-n=d5ee94f
 odh-pipeline-runtime-pytorch-rocm-py312-ubi9-commit-n=d5ee94f
-odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-commit-n=d5ee94f

--- a/manifests/base/params-latest.env
+++ b/manifests/base/params-latest.env
@@ -28,4 +28,3 @@ odh-pipeline-runtime-datascience-cpu-py312-ubi9-n=quay.io/modh/odh-pipeline-runt
 odh-pipeline-runtime-pytorch-cuda-py312-ubi9-n=quay.io/modh/odh-pipeline-runtime-pytorch-cuda-py312-ubi9@sha256:b6af3f8f2c8e3fa1b8ff44efb78b463bef489bc772e80c9cb7a71e82fad011c6
 odh-pipeline-runtime-pytorch-rocm-py312-ubi9-n=quay.io/modh/odh-pipeline-runtime-pytorch-rocm-py312-ubi9@sha256:07c20fc12a71288699bf5bb87c633fecf1e87f76af9135354bf9e99b00d92a17
 odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-n=quay.io/modh/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9@sha256:8176e9f60f6b888e1dd2f2a363d3b63fc8ebbfe28fcb2eac979c3f9c707f9b11
-odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-n=quay.io/modh/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9@sha256:00f1841caaf7021dfbb92bf5d80e3aab9e6879e83ee44d66a4b499ffa8972090


### PR DESCRIPTION
Update and sync rhoai-2.23 branch based the latest changes for rocm-runtime-tensorflow py312 image