### PR TITLE
[2.22] update `setuptools` to version 78.1.1 in RStudio Pipfiles; run `dnf install` to reduce fixable base image vulnerabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,8 @@ BASE_DIRS := jupyter/minimal/ubi9-python-$(PYTHON_VERSION) \
 		jupyter/rocm/tensorflow/ubi9-python-$(PYTHON_VERSION) \
 		jupyter/rocm/pytorch/ubi9-python-$(PYTHON_VERSION) \
 		codeserver/ubi9-python-$(PYTHON_VERSION) \
+		rstudio/rhel9-python-$(PYTHON_VERSION) \
+		rstudio/c9s-python-$(PYTHON_VERSION) \
 		runtimes/minimal/ubi9-python-$(PYTHON_VERSION) \
 		runtimes/datascience/ubi9-python-$(PYTHON_VERSION) \
 		runtimes/pytorch/ubi9-python-$(PYTHON_VERSION) \

--- a/rstudio/c9s-python-3.11/Dockerfile.cpu
+++ b/rstudio/c9s-python-3.11/Dockerfile.cpu
@@ -11,7 +11,11 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]"
 # OS Packages needs to be installed as root
 USER root
 
-# Install usefull OS packages
+# upgrade first to avoid fixable vulnerabilities
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+
+# Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user

--- a/rstudio/c9s-python-3.11/Dockerfile.cuda
+++ b/rstudio/c9s-python-3.11/Dockerfile.cuda
@@ -11,7 +11,11 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]"
 # OS Packages needs to be installed as root
 USER root
 
-# Install usefull OS packages
+# upgrade first to avoid fixable vulnerabilities
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+
+# Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user

--- a/rstudio/c9s-python-3.11/Pipfile
+++ b/rstudio/c9s-python-3.11/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 # Base packages
 wheel = "~=0.45.1"
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 
 [requires]
 python_version = "3.11"

--- a/rstudio/c9s-python-3.11/Pipfile.lock
+++ b/rstudio/c9s-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d0ef0c3e47575d974a1623e3b51b0660a71d6f6a3e47ce0a6eb989a3323f2bcd"
+            "sha256": "9c691e9160fbfc0609d97a6005f8e18e11f91a839a2f443c44f30fed33b28130"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,12 +18,12 @@
     "default": {
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "wheel": {
             "hashes": [

--- a/rstudio/c9s-python-3.11/requirements.txt
+++ b/rstudio/c9s-python-3.11/requirements.txt
@@ -4,9 +4,9 @@
 #
 # Default dependencies
 #
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 wheel==0.45.1; python_version >= '3.8' \
     --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \
     --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -11,7 +11,11 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]"
 # OS Packages needs to be installed as root
 USER root
 
-# Install usefull OS packages
+# upgrade first to avoid fixable vulnerabilities
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+
+# Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -11,7 +11,11 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]"
 # OS Packages needs to be installed as root
 USER root
 
-# Install usefull OS packages
+# upgrade first to avoid fixable vulnerabilities
+RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
+    && dnf clean all -y
+
+# Install useful OS packages
 RUN dnf install -y mesa-libGL skopeo && dnf clean all && rm -rf /var/cache/yum
 
 # Other apps and tools installed as default user

--- a/rstudio/rhel9-python-3.11/Pipfile
+++ b/rstudio/rhel9-python-3.11/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 # Base packages
-setuptools = "~=75.8.2"
+setuptools = "~=78.1.1"
 wheel = "~=0.45.1"
 
 [requires]

--- a/rstudio/rhel9-python-3.11/Pipfile.lock
+++ b/rstudio/rhel9-python-3.11/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d0ef0c3e47575d974a1623e3b51b0660a71d6f6a3e47ce0a6eb989a3323f2bcd"
+            "sha256": "9c691e9160fbfc0609d97a6005f8e18e11f91a839a2f443c44f30fed33b28130"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,12 +18,12 @@
     "default": {
         "setuptools": {
             "hashes": [
-                "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2",
-                "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==75.8.2"
+            "version": "==78.1.1"
         },
         "wheel": {
             "hashes": [

--- a/rstudio/rhel9-python-3.11/requirements.txt
+++ b/rstudio/rhel9-python-3.11/requirements.txt
@@ -4,9 +4,9 @@
 #
 # Default dependencies
 #
-setuptools==75.8.2; python_version >= '3.9' \
-    --hash=sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2 \
-    --hash=sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f
+setuptools==78.1.1; python_version >= '3.9' \
+    --hash=sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561 \
+    --hash=sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d
 wheel==0.45.1; python_version >= '3.8' \
     --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \
     --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248


### PR DESCRIPTION
Running Pipfile.locks action at
* https://github.com/jiridanek/notebooks/actions/runs/16601955824
* forgot to type in branch, rerunning https://github.com/jiridanek/notebooks/actions/runs/16606301599

* https://github.com/opendatahub-io/notebooks/pull/1545