### PR TITLE
Add TeX Live and Pandoc installation for ppc64le

### DIFF
--- a/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.11/Dockerfile.cpu
@@ -1,3 +1,21 @@
+############################
+# Stage 1: PDF Tool Build #
+############################
+FROM registry.access.redhat.com/ubi9/python-311:latest AS pdf-builder
+
+WORKDIR /opt/app-root/bin
+
+# OS Packages needs to be installed as root
+USER 0
+
+# Copy scripts
+COPY jupyter/utils/install_texlive.sh ./install_texlive.sh
+COPY jupyter/utils/install_pandoc.sh ./install_pandoc.sh
+RUN chmod +x install_texlive.sh install_pandoc.sh
+
+RUN ./install_texlive.sh
+RUN ./install_pandoc.sh
+
 ####################
 # base             #
 ####################
@@ -47,8 +65,10 @@ COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
-# Dependencies for PDF export
-RUN ./utils/install_pdf_deps.sh
+# Copy built TeXLive and Pandoc binaries only (no build deps)
+COPY --from=pdf-builder /usr/local/texlive /usr/local/texlive
+COPY --from=pdf-builder /usr/local/pandoc /usr/local/pandoc
+
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
@@ -74,3 +94,4 @@ RUN echo "Installing softwares and packages" && \
 WORKDIR /opt/app-root/src
 
 ENTRYPOINT ["start-notebook.sh"]
+

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -1,3 +1,21 @@
+############################
+# Stage 1: PDF Tool Build #
+############################
+FROM registry.access.redhat.com/ubi9/python-312:latest AS pdf-builder
+
+WORKDIR /opt/app-root/bin
+
+# OS Packages needs to be installed as root
+USER 0
+
+# Copy scripts
+COPY jupyter/utils/install_texlive.sh ./install_texlive.sh
+COPY jupyter/utils/install_pandoc.sh ./install_pandoc.sh
+RUN chmod +x install_texlive.sh install_pandoc.sh
+
+RUN ./install_texlive.sh
+RUN ./install_pandoc.sh
+
 ####################
 # base             #
 ####################
@@ -47,8 +65,10 @@ COPY ${JUPYTER_REUSABLE_UTILS} utils/
 
 USER 0
 
-# Dependencies for PDF export
-RUN ./utils/install_pdf_deps.sh
+# Copy built TeXLive and Pandoc binaries only (no build deps)
+COPY --from=pdf-builder /usr/local/texlive /usr/local/texlive
+COPY --from=pdf-builder /usr/local/pandoc /usr/local/pandoc
+
 ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001

--- a/jupyter/utils/install_pandoc.sh
+++ b/jupyter/utils/install_pandoc.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Mapping of `uname -m` values to equivalent GOARCH values
+declare -A UNAME_TO_GOARCH
+UNAME_TO_GOARCH["x86_64"]="amd64"
+UNAME_TO_GOARCH["aarch64"]="arm64"
+UNAME_TO_GOARCH["ppc64le"]="ppc64le"
+UNAME_TO_GOARCH["s390x"]="s390x"
+
+ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
+
+if [[ "$ARCH" == "ppc64le" ]]; then
+  # Install Pandoc from source
+  dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  dnf install -y cabal-install ghc gmp-devel
+
+  # Set version
+  PANDOC_VERSION=3.7.0.2
+
+  cd /tmp
+  git clone --recurse-submodules https://github.com/jgm/pandoc.git
+  cd pandoc
+  git checkout ${PANDOC_VERSION}
+  git submodule update --init --recursive
+
+  cabal update
+  cd pandoc-cli
+  cabal build -j"$(nproc)"
+  mkdir -p /usr/local/pandoc/bin
+  cabal install \
+    --installdir=/usr/local/pandoc/bin \
+    --overwrite-policy=always \
+    --install-method=copy
+
+  # Clean up Haskell build system
+  rm -rf ~/.cabal ~/.ghc /tmp/pandoc
+  dnf remove -y cabal-install ghc gmp-devel
+  dnf clean all && rm -rf /var/cache/dnf
+
+  /usr/local/pandoc/bin/pandoc --version
+
+elif [[ "$ARCH" == "amd64" ]]; then
+  # pandoc installation
+  curl -fL "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-linux-${ARCH}.tar.gz"  -o /tmp/pandoc.tar.gz
+  mkdir -p /usr/local/pandoc
+  tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/pandoc/
+  rm -f /tmp/pandoc.tar.gz
+
+else
+  echo "Unsupported architecture: $ARCH" >&2
+  exit 1
+fi

--- a/jupyter/utils/install_texlive.sh
+++ b/jupyter/utils/install_texlive.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Mapping of `uname -m` values to equivalent GOARCH values
+declare -A UNAME_TO_GOARCH
+UNAME_TO_GOARCH["x86_64"]="amd64"
+UNAME_TO_GOARCH["aarch64"]="arm64"
+UNAME_TO_GOARCH["ppc64le"]="ppc64le"
+UNAME_TO_GOARCH["s390x"]="s390x"
+
+ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
+
+if [[ "$ARCH" == "ppc64le" ]]; then
+  echo "Installing TeX Live from source for $ARCH..."
+
+  # Install build dependencies
+  dnf install -y gcc-toolset-13 perl make libX11-devel libXt-devel \
+    zlib-devel freetype-devel libpng-devel ncurses-devel \
+    gd-devel libtool wget tar xz bison flex libXaw-devel
+
+  # Step 1: Download and extract the TeX Live source
+  wget https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/texlive-20250308-source.tar.xz
+  tar -xf texlive-20250308-source.tar.xz
+  cd texlive-20250308-source
+
+  # Enable newer GCC toolchain
+  source /opt/rh/gcc-toolset-13/enable
+
+  # Create build directory and build
+  mkdir ../texlive-build
+  cd ../texlive-build
+  ../texlive-20250308-source/configure --prefix=/usr/local/texlive
+  make -j"$(nproc)"
+  make install
+
+  # Symlink for pdflatex
+  ln -sf pdftex /usr/local/texlive/bin/powerpc64le-unknown-linux-gnu/pdflatex
+  
+  # Cleanup sources to reduce image size
+  rm -rf /texlive-20250308-source /texlive-build
+
+  # Step 2: Run TeX Live installer for runtime tree setup
+  cd /
+  wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+  tar -xzf install-tl-unx.tar.gz
+  cd install-tl-2*/
+
+  # Create a custom install profile
+  TEXLIVE_INSTALL_PREFIX="/usr/local/texlive"
+  cat <<EOF > texlive.profile
+selected_scheme scheme-small
+TEXDIR $TEXLIVE_INSTALL_PREFIX
+TEXMFCONFIG ~/.texlive2025/texmf-config
+TEXMFVAR ~/.texlive2025/texmf-var
+option_doc 0
+option_src 0
+EOF
+
+  ./install-tl --profile=texlive.profile --custom-bin=$TEXLIVE_INSTALL_PREFIX/bin/powerpc64le-unknown-linux-gnu
+
+# TeX Live binary directory
+TEX_BIN_DIR="/usr/local/texlive/bin/powerpc64le-unknown-linux-gnu"
+
+# Create standard symlink 'linux' → arch-specific folder
+ln -sf "$TEX_BIN_DIR" /usr/local/texlive/bin/linux
+
+
+  # Set up environment
+  export PATH="$TEXLIVE_INSTALL_PREFIX/bin/linux:$PATH"
+  pdflatex --version
+  tlmgr --version
+
+elif [[ "$ARCH" == "amd64" ]]; then
+  # tex live installation
+  echo "Installing TexLive to allow PDf export from Notebooks"
+  curl -fL https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -o install-tl-unx.tar.gz
+  zcat < install-tl-unx.tar.gz | tar xf -
+  cd install-tl-2*
+  perl ./install-tl --no-interaction --scheme=scheme-small --texdir=/usr/local/texlive
+  mv /usr/local/texlive/bin/"$(uname -m)-linux" /usr/local/texlive/bin/linux
+  cd /usr/local/texlive/bin/linux
+  ./tlmgr install tcolorbox pdfcol adjustbox titling enumitem soul ucs collection-fontsrecommended
+
+else
+  echo "Unsupported architecture: $ARCH" >&2
+  exit 1
+
+fi
+


### PR DESCRIPTION
This PR adds support for installing TeX Live and Pandoc in the Jupyter notebook image for the ppc64le (IBM Power) architecture to enable PDF export functionality.

Key Changes:
Updated Dockerfile.cpu to:
Set the appropriate TeX Live path for Power
Validate pdflatex availability post-install
Ensured existing x86_64 logic is not affected.