### PR TITLE
skip PDF export for s390x in jupyter minimal (3.11/3.12)

### DIFF
--- a/ci/cached-builds/gen_gha_matrix_jobs.py
+++ b/ci/cached-builds/gen_gha_matrix_jobs.py
@@ -31,6 +31,8 @@ ARM64_COMPATIBLE = {
 S390X_COMPATIBLE = {
     "runtime-minimal-ubi9-python-3.11",
     "runtime-minimal-ubi9-python-3.12",
+    "jupyter-minimal-ubi9-python-3.11",
+    "jupyter-minimal-ubi9-python-3.12",
     # add more here
 }
 

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -17,6 +17,12 @@ if [[ -z "${ARCH:-}" ]]; then
     exit 1
 fi
 
+# Skip PDF export installation for s390x architecture
+if [[ "${ARCH}" == "s390x" ]]; then
+    echo "PDF export functionality is not supported on s390x architecture. Skipping installation."
+    exit 0
+fi
+
 # tex live installation
 echo "Installing TexLive to allow PDf export from Notebooks"
 curl -fL https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -o install-tl-unx.tar.gz

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -58,6 +58,14 @@ class TestJupyterLabImage:
     @allure.description("Check that PDF export is working correctly")
     def test_pdf_export(self, jupyterlab_image: conftest.Image) -> None:
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
+        # Skip if we're running on s390x architecture
+        container.start(wait_for_readiness=False)
+        try:
+            exit_code, arch_output = container.exec(["uname", "-m"])
+            if exit_code == 0 and arch_output.decode().strip() == "s390x":
+                pytest.skip("PDF export functionality is not supported on s390x architecture")
+        finally:
+            docker_utils.NotebookContainer(container).stop(timeout=0)
         test_file_name = "test.ipybn"
         test_file_content = """{
                 "cells": [


### PR DESCRIPTION
Summary
This PR disables PDF export functionality for s390x (IBM Z) architecture in Jupyter Minimal images for both Python 3.11 and 3.12 versions due to known compatibility issues with this feature on s390x.

Changes Made
- Modified jupyter/utils/install_pdf_deps.sh
- Added early exit for s390x architecture detection using uname -m
- PDF export dependencies (TexLive and Pandoc) are now skipped for s390x
Updated ci/cached-builds/gen_gha_matrix_jobs.py
- Added jupyter-minimal-ubi9-python-3.11 and jupyter-minimal-ubi9-python-3.12 to S390X_COMPATIBLE set
- Enables s390x builds for these minimal Jupyter images in CI pipeline
Modified tests/containers/workbenches/jupyterlab/jupyterlab_test.py
- Added architecture detection to test_pdf_export test
- Test now skips PDF export functionality for s390x architecture
- Prevents test failures on s390x where PDF export is intentionally disabled