### PR TITLE
updating runtime-minimal konflux image for ppc64le

### DIFF
--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.konflux.cpu
@@ -12,7 +12,7 @@ USER 0
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \
     PACKAGES="mesa-libGL skopeo" && \
-    if [ "$ARCH" = "s390x" ]; then \
+    if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then \
         PACKAGES="$PACKAGES gcc g++ make openssl-devel autoconf automake libtool cmake"; \
     fi && \
     dnf install -y $PACKAGES && \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -12,7 +12,7 @@ USER 0
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \
     PACKAGES="mesa-libGL skopeo" && \
-    if [ "$ARCH" = "s390x" ]; then \
+    if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then \
         PACKAGES="$PACKAGES gcc g++ make openssl-devel autoconf automake libtool cmake"; \
     fi && \
     dnf install -y $PACKAGES && \


### PR DESCRIPTION
For building runtime-minimal konflux images on ppc64le, these changes are required. These changes are already merged in opendatahub-io/notebooks repository and have also passed konflux related checks: 
for python3.12: https://github.com/opendatahub-io/notebooks/pull/1632
for python3.11: https://github.com/opendatahub-io/notebooks/pull/1175

Have also raised similar PR in this repository against `rhoai-2.23-multi-arch-poc` branch: 
https://github.com/red-hat-data-services/notebooks/pull/1330