### PR TITLE
Remove more unnecessary duplicate steps

### DIFF
--- a/codeserver/ubi9-python-3.11/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.11/Dockerfile.konflux.cpu
@@ -145,18 +145,3 @@ LABEL name="rhoai/odh-workbench-codeserver-datascience-cpu-py311-rhel9" \
       description="code-server image with python 3.11 based on UBI9" \
       io.k8s.description="code-server image with python 3.11 based on UBI9" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -145,19 +145,3 @@ LABEL name="rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
       description="code-server image with python 3.12 based on UBI9" \
       io.k8s.description="code-server image with python 3.11 based on UBI9" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.konflux.rocm
@@ -173,24 +173,3 @@ LABEL name="rhoai/odh-workbench-jupyter-pytorch-rocm-py311-rhel9" \
       description="Jupyter ROCm pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -173,24 +173,3 @@ LABEL name="rhoai/odh-workbench-jupyter-pytorch-rocm-py312-rhel9" \
       description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter ROCm pytorch notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.konflux.rocm
@@ -170,24 +170,3 @@ LABEL name="rhoai/odh-workbench-jupyter-tensorflow-rocm-py311-rhel9" \
       description="Jupyter AMD tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter AMD tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.konflux.cuda
@@ -264,24 +264,3 @@ LABEL name="rhoai/odh-workbench-jupyter-tensorflow-cuda-py311-rhel9" \
       description="Jupyter CUDA tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -241,24 +241,3 @@ LABEL name="rhoai/odh-workbench-jupyter-tensorflow-cuda-py312-rhel9" \
       description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.konflux.cpu
@@ -141,24 +141,3 @@ LABEL name="rhoai/odh-workbench-jupyter-trustyai-cpu-py311-rhel9" \
       description="Jupyter trustyai notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter trustyai notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -141,24 +141,3 @@ LABEL name="rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9" \
       description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       io.k8s.description="Jupyter trustyai notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end
-
-# Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
-# Dependencies for PDF export end

--- a/runtimes/datascience/ubi9-python-3.11/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.11/Dockerfile.konflux.cpu
@@ -26,7 +26,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 #######################
 # runtime-datascience #
 #######################
-FROM base AS runtime-datascience  
+FROM base AS runtime-datascience
 
 ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.11
 
@@ -53,18 +53,3 @@ LABEL name="rhoai/odh-pipeline-runtime-datascience-cpu-py311-rhel9" \
       description="Runtime data science notebook image with base Python 3.11 builder image based on UBI9 for ODH notebooks" \
       summary="Runtime data science notebook image for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -53,19 +53,3 @@ LABEL name="rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9" \
       description="Runtime data science notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \
       summary="Runtime data science notebook image for ODH notebooks" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
-
-# upgrade first to avoid fixable vulnerabilities begin
-RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0 --setopt=keepcache=0 \
-    && dnf clean all -y
-# upgrade first to avoid fixable vulnerabilities end
-
-# Install micropipenv and uv to deploy packages from requirements.txt begin
-RUN pip install --no-cache-dir -U "micropipenv[toml]" "uv"
-# Install micropipenv and uv to deploy packages from requirements.txt end
-
-# Install the oc client begin
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz \
-        -o /tmp/openshift-client-linux.tar.gz && \
-    tar -xzvf /tmp/openshift-client-linux.tar.gz oc && \
-    rm -f /tmp/openshift-client-linux.tar.gz
-# Install the oc client end


### PR DESCRIPTION
This is a follow up to PR #1476, to remove more cases of the same problem.

These sections are being added by `bash ci/generate_code.sh`, so they're likely to get added back if someone runs that. If that doesn't run without changes, then the static analysis GH action will fail.