### PR TITLE
NO-JIRA: ci(gha): fix `gemini-pr-review.yml` to handle `pull_request_target` trigger and add instructions for non-comment triggers

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -90,10 +90,10 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
-      - name: 'Get PR details (pull_request & workflow_dispatch)'
+      - name: 'Get PR details (pull_request & pull_request_target & workflow_dispatch)'
         id: 'get_pr'
         if: |-
-          ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+          ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
           EVENT_NAME: '${{ github.event_name }}'
@@ -109,6 +109,9 @@ jobs:
           fi
 
           echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+          # No additional instructions for non-comment triggers
+          echo "additional_instructions=" >> "${GITHUB_OUTPUT}"
 
           # Get PR details
           PR_DATA="$(gh pr view "${PR_NUMBER}" --json title,body,additions,deletions,changedFiles,baseRefName,headRefName)"


### PR DESCRIPTION
Follow up on
* https://github.com/red-hat-data-services/notebooks/pull/1489

Without it, Gemini goes into existential crisis

> Okay, I will start by gathering the PR information.Got it. Repository is `red-hat-data-services/notebooks`. Now, fetching PR data.Okay, repository is known. PR data is missing. Getting changed files now.Okay, I have the repo owner and name. PR data and files are empty. Getting the PR number now.I have the repo owner/name, but no PR data, changed files, or PR number. I'll try fetching the diff, but without a PR number, I doubt it will work. I'm missing key information for a review.I have the repo owner and name, but no PR data, changed files, number, or instructions. I'll try `gh pr diff ""` to get the diff, but I expect it to fail. If it does, I'll notify the user that I can't proceed.I've followed all instructions to gather PR info, but everything's empty except the repository. The environment variables seem unset, preventing me from proceeding with the review. I'm stuck: I can't perform a review without data, but I'm also told not to ask for it. I'll try one last thing: `gh pr list` to see if I can
Okay, I will start by gathering the PR information.Got it. Repository is `red-hat-data-services/notebooks`. Now, fetching PR data.Okay, repository is known. PR data is missing. Getting changed files now.Okay, I have the repo owner and name. PR data and files are empty. Getting the PR number now.I have the repo owner/name, but no PR data, changed files, or PR number. I'll try fetching the diff, but without a PR number, I doubt it will work. I'm missing key information for a review.I have the repo owner and name, but no PR data, changed files, number, or instructions. I'll try `gh pr diff ""` to get the diff, but I expect it to fail. If it does, I'll notify the user that I can't proceed.I've followed all instructions to gather PR info, but everything's empty except the repository. The environment variables seem unset, preventing me from proceeding with the review. I'm stuck: I can't perform a review without data, but I'm also told not to ask for it. I'll try one last thing: `gh pr list` to see if I can find the
Error: Process completed with exit code 1.
