### PR TITLE
RHAIENG-540: Bump mongocli to 2.0.4 across all Dockerfiles

### DIFF
--- a/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.11/Dockerfile.cpu
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.11/Dockerfile.cuda
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.11/Dockerfile.cuda
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.11/Dockerfile.rocm
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.11/Dockerfile.cuda
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.11/Dockerfile.cpu
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -3,7 +3,7 @@
 ######################################################
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
 
-ARG MONGOCLI_VERSION=2.0.3
+ARG MONGOCLI_VERSION=2.0.4
 
 WORKDIR /tmp/
 RUN curl -Lo mongodb-cli-mongocli-v${MONGOCLI_VERSION}.zip https://github.com/mongodb/mongodb-cli/archive/refs/tags/mongocli/v${MONGOCLI_VERSION}.zip


### PR DESCRIPTION
Just merging the work from @atheo89 

<!--- Provide a general summary of your changes in the Title above -->
Related to: https://issues.redhat.com/browse/RHAIENG-540

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated MongoDB CLI to v2.0.4 across Jupyter images to ensure consistency and latest improvements.
  - Applies to Python 3.11 and 3.12 variants for CPU, CUDA, and ROCm builds, including:
    - Datascience
    - PyTorch (standard and with LLM Compressor)
    - TensorFlow
    - ROCm PyTorch and ROCm TensorFlow
    - TrustyAI
  - No other build steps or behaviors changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->