### PR TITLE
update runtime-minimal konflux images for ppc64le

### DIFF
--- a/runtimes/minimal/ubi9-python-3.11/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.11/Dockerfile.konflux.cpu
@@ -17,7 +17,7 @@ RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_d
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \
     PACKAGES="mesa-libGL skopeo" && \
-    if [ "$ARCH" = "s390x" ]; then \
+    if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then \
         PACKAGES="$PACKAGES gcc g++ make openssl-devel autoconf automake libtool cmake"; \
     fi && \
     dnf install -y $PACKAGES && \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -17,7 +17,7 @@ RUN dnf -y upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_d
 RUN ARCH=$(uname -m) && \
     echo "Detected architecture: $ARCH" && \
     PACKAGES="mesa-libGL skopeo" && \
-    if [ "$ARCH" = "s390x" ]; then \
+    if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then \
         PACKAGES="$PACKAGES gcc g++ make openssl-devel autoconf automake libtool cmake"; \
     fi && \
     dnf install -y $PACKAGES && \


### PR DESCRIPTION
Fixing the `runtime-minimal` Dockerfile.konflux.cpu files for ppc64le, as the image build is failing due to pyzmq installation issues without these changes.
 
Similar Changes are already present in [rhoai-2.24](https://github.com/red-hat-data-services/notebooks/blob/rhoai-2.24/runtimes/minimal/ubi9-python-3.11/Dockerfile.konflux.cpu) branch as well as in [opendatahub-io/notebooks](https://github.com/opendatahub-io/notebooks/blob/main/runtimes/minimal/ubi9-python-3.11/Dockerfile.cpu) repository. 