### PR TITLE
[rhds] RHAIENG-304: switch from `Pipfile.lock` to `pylock.toml` for package management across all relevant Dockerfiles

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -130,13 +130,14 @@ ENV PYTHONPATH=/opt/app-root/bin/python3
 
 USER 1001
 
-# Install useful packages from Pipfile.lock
-COPY ${CODESERVER_SOURCE_CODE}/Pipfile.lock ./
+# Install useful packages from requirements.txt
+COPY ${CODESERVER_SOURCE_CODE}/pylock.toml ./
 
 # Install packages and cleanup
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -98,14 +98,15 @@ ENV PATH="$PATH:/opt/mssql-tools18/bin"
 # Other apps and tools installed as default user
 USER 1001
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages and Jupyterlab extensions from requirements.txt
+COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra setup to utils so that it's sourced at startup
 COPY ${DATASCIENCE_SOURCE_CODE}/setup-elyra.sh ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     mkdir /opt/app-root/pipeline-runtimes && \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -88,12 +88,13 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -163,12 +163,13 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
-# Install Python dependencies from Pipfile.lock file
+# Install Python dependencies from requirements.txt file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -85,12 +85,13 @@ ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 
 USER 1001
 
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
+COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 
 # Install Python dependencies from Pipfile.lock file
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Disable announcement plugin of jupyterlab \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -215,12 +215,13 @@ ARG PYTORCH_SOURCE_CODE=jupyter/pytorch/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages and Jupyterlab extensions from requirements.txt
+COPY ${PYTORCH_SOURCE_CODE}/pylock.toml ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -148,11 +148,12 @@ ARG PYTORCH_SOURCE_CODE=jupyter/rocm/pytorch/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
+COPY ${PYTORCH_SOURCE_CODE}/pylock.toml ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -159,13 +159,13 @@ ARG TENSORFLOW_SOURCE_CODE=jupyter/rocm/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
+COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 
 RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # Not using --build-constraints=./requirements.txt because error: Unnamed requirements are not allowed as constraints (found: `https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -220,12 +220,13 @@ ARG TENSORFLOW_SOURCE_CODE=jupyter/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages and Jupyterlab extensions from requirements.txt
+COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install --dev && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -120,12 +120,13 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 
 USER 1001
 
-# Install Python packages and Jupyterlab extensions from Pipfile.lock
-COPY ${TRUSTYAI_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages and Jupyterlab extensions from requirements.txt
+COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # setup path for runtime configuration
     mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -39,14 +39,15 @@ ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
-COPY ${DATASCIENCE_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages from requirements.txt
+COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -46,14 +46,15 @@ ARG MINIMAL_SOURCE_CODE=runtimes/minimal/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
-COPY ${MINIMAL_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages from requirements.txt
+COPY ${MINIMAL_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${MINIMAL_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -141,14 +141,15 @@ ARG PYTORCH_SOURCE_CODE=runtimes/pytorch/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages from requirements.txt
+COPY ${PYTORCH_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -73,16 +73,17 @@ ARG PYTORCH_SOURCE_CODE=runtimes/rocm-pytorch/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
-COPY ${PYTORCH_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages from requirements.txt
+COPY ${PYTORCH_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${PYTORCH_SOURCE_CODE}/utils ./utils/
 # Copy utility script
 COPY ${PYTORCH_SOURCE_CODE}/de-vendor-torch.sh ./
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # De-vendor the ROCm libs that are embedded in Pytorch \
     ./de-vendor-torch.sh && \
     rm ./de-vendor-torch.sh && \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -74,7 +74,7 @@ ARG TENSORFLOW_SOURCE_CODE=runtimes/rocm-tensorflow/ubi9-python-3.12
 WORKDIR /opt/app-root/bin
 
 # Install Python packages from requirements.txt
-COPY ${TENSORFLOW_SOURCE_CODE}/requirements.txt ./
+COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
@@ -82,7 +82,7 @@ RUN echo "Installing softwares and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # Not using --build-constraints=./requirements.txt because error: Unnamed requirements are not allowed as constraints (found: `https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./requirements.txt && \
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -146,14 +146,15 @@ ARG TENSORFLOW_SOURCE_CODE=runtimes/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
-# Install Python packages from Pipfile.lock
-COPY ${TENSORFLOW_SOURCE_CODE}/Pipfile.lock ./
+# Install Python packages from requirements.txt
+COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment
 COPY ${TENSORFLOW_SOURCE_CODE}/utils ./utils/
 
 RUN echo "Installing softwares and packages" && \
-    micropipenv install && \
-    rm -f ./Pipfile.lock && \
+    # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml && \
     # Fix permissions to support pip in Openshift environments \
     chmod -R g+w /opt/app-root/lib/python3.12/site-packages && \
     fix-permissions /opt/app-root -P


### PR DESCRIPTION
This propagates to rhds the changes done in
* https://github.com/opendatahub-io/notebooks/pull/2145