### PR TITLE
[rhds] NO-JIRA: remove obsolete `cuda-nvprof` environment variables from Dockerfiles across environments

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -35,9 +35,6 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base-amd64
 ENV NVARCH=x86_64
-# cuda-nvprof only gets installed on amd64 currently
-ENV NV_NVPROF_VERSION=12.6.80-1
-ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-6-${NV_NVPROF_VERSION}
 
 FROM base AS cuda-base-arm64
 ENV NVARCH=sbsa

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -48,9 +48,6 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base-amd64
 ENV NVARCH=x86_64
-# cuda-nvprof only gets installed on amd64 currently
-ENV NV_NVPROF_VERSION=12.6.80-1
-ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-6-${NV_NVPROF_VERSION}
 
 FROM base AS cuda-base-arm64
 ENV NVARCH=sbsa

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -48,9 +48,6 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base-amd64
 ENV NVARCH=x86_64
-# cuda-nvprof only gets installed on amd64 currently
-ENV NV_NVPROF_VERSION=12.6.80-1
-ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-6-${NV_NVPROF_VERSION}
 
 FROM base AS cuda-base-arm64
 ENV NVARCH=sbsa

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -35,9 +35,6 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base-amd64
 ENV NVARCH=x86_64
-# cuda-nvprof only gets installed on amd64 currently
-ENV NV_NVPROF_VERSION=12.6.80-1
-ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-6-${NV_NVPROF_VERSION}
 
 FROM base AS cuda-base-arm64
 ENV NVARCH=sbsa

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -35,9 +35,6 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 ####################
 FROM base AS cuda-base-amd64
 ENV NVARCH=x86_64
-# cuda-nvprof only gets installed on amd64 currently
-ENV NV_NVPROF_VERSION=12.6.80-1
-ENV NV_NVPROF_DEV_PACKAGE=cuda-nvprof-12-6-${NV_NVPROF_VERSION}
 
 FROM base AS cuda-base-arm64
 ENV NVARCH=sbsa


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/pull/2078