### PR TITLE
[2.24] RHOAIENG-33414: build code-server from sources and replace dnf with rpm2cpio in to handle unsigned RPM errors in Konflux

### DIFF
--- a/ci/cached-builds/gha_lvm_overlay.sh
+++ b/ci/cached-builds/gha_lvm_overlay.sh
@@ -10,7 +10,8 @@ set -Eeuo pipefail
 # root_reserve_mb=2048 was running out of disk space building cuda images
 root_reserve_mb=4096
 temp_reserve_mb=100
-swap_size_mb=256
+# compilation from sources needs memory, for now that's codeserver
+swap_size_mb=4096
 
 build_mount_path="${HOME}/.local/share/containers"
 build_mount_path_ownership="runner:runner"

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -1,4 +1,25 @@
 ####################
+# rpm-base         #
+####################
+FROM registry.access.redhat.com/ubi9/python-312:latest AS rpm-base
+
+USER root
+WORKDIR /root
+
+ENV HOME=/root
+
+ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
+
+ARG NODE_VERSION=20
+
+ARG CODESERVER_VERSION=v4.98.0
+
+COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
+
+# create dummy file to ensure this stage is awaited before installing rpm
+RUN ./get_code_server_rpm.sh && touch /tmp/control
+
+####################
 # base             #
 ####################
 FROM registry.access.redhat.com/ubi9/python-312:latest AS base
@@ -58,13 +79,23 @@ WORKDIR /opt/app-root/bin
 # Install useful OS packages
 RUN dnf install -y jq git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
 
+# wait for rpm-base stage
+COPY --from=rpm-base /tmp/control /dev/null
+
 # Install code-server
-RUN yum install -y "https://github.com/coder/code-server/releases/download/${CODESERVER_VERSION}/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm" && \
-    yum -y clean all --enablerepo='*'
+# Note: Use cache mounts, bind mounts fail on konflux
+# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1755628065772589?thread_ts=1755597929.335999&cid=C04PZ7H0VA8
+RUN --mount=type=cache,from=rpm-base,source=/tmp/,target=/code-server-rpm/,rw \
+    # EXPLANATION: dnf installation produces an "unsigned rpm" error from Konflux (Conforma)
+    #  since we're building rpm from source, we will simply unpack it over /
+    # dnf install -y "/code-server-rpm/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm"
+    # dnf -y clean all --enablerepo='*'
+    dnf install -y cpio && dnf -y clean all && \
+    cd / && rpm2cpio "/code-server-rpm/code-server-${CODESERVER_VERSION/v/}-${TARGETARCH}.rpm" | cpio -idmv
 
 COPY --chown=1001:0 ${CODESERVER_SOURCE_CODE}/utils utils/
 
-# Create and intall the extensions though build-time on a temporary directory. Later this directory will copied on the `/opt/app-root/src/.local/share/code-server/extensions` via run-code-server.sh file when it starts up.
+# Create and install the extensions though build-time on a temporary directory. Later this directory will copied on the `/opt/app-root/src/.local/share/code-server/extensions` via run-code-server.sh file when it starts up.
 RUN mkdir -p /opt/app-root/extensions-temp && \
     code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.2.0.vsix --extensions-dir /opt/app-root/extensions-temp && \
     code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.2.0.vsix --extensions-dir /opt/app-root/extensions-temp

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euxo pipefail
+
+##############################################################################
+# This script is expected to be run as `root`                                #
+# It builds code-server rpm for `ppc64le`                                    #
+# For other architectures, the rpm is downloaded from the available releases #
+##############################################################################
+
+
+# Mapping of `uname -m` values to equivalent GOARCH values
+declare -A UNAME_TO_GOARCH
+UNAME_TO_GOARCH["x86_64"]="amd64"
+UNAME_TO_GOARCH["aarch64"]="arm64"
+UNAME_TO_GOARCH["ppc64le"]="ppc64le"
+UNAME_TO_GOARCH["s390x"]="s390x"
+
+ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
+
+if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" || "$ARCH" == "ppc64le" ]]; then
+
+	export MAX_JOBS=${MAX_JOBS:-$(nproc)}
+	export NODE_VERSION=${NODE_VERSION:-20}
+	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.98.0}
+
+	export NVM_DIR=/root/.nvm VENV=/opt/.venv
+	export PATH=${VENV}/bin:$PATH
+
+	export ELECTRON_SKIP_BINARY_DOWNLOAD=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+	# install build dependencies
+#	dnf install -y \
+#	    git gcc-toolset-13 automake libtool rsync krb5-devel libX11-devel gettext jq patch
+        dnf install -y jq libtool gcc-toolset-13
+
+	. /opt/rh/gcc-toolset-13/enable
+
+	# build libxkbfile
+	git clone https://gitlab.freedesktop.org/xorg/util/macros.git
+	cd macros/
+	./autogen.sh && make install -j ${MAX_JOBS}
+	export ACLOCAL_PATH=/usr/local/share/aclocal/
+	cd .. && rm -rf macros
+	git clone https://gitlab.freedesktop.org/xorg/lib/libxkbfile.git
+	cd libxkbfile/
+	./autogen.sh && make install -j ${MAX_JOBS}
+	cd .. && rm -rf libxkbfile
+        export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
+
+	# install nfpm to build rpm
+	NFPM_VERSION=$(curl -s "https://api.github.com/repos/goreleaser/nfpm/releases/latest" | jq -r '.tag_name') \
+	    && dnf install -y https://github.com/goreleaser/nfpm/releases/download/${NFPM_VERSION}/nfpm-${NFPM_VERSION:1}-1.$(uname -m).rpm
+
+	# install node
+	NVM_VERSION=$(curl -s "https://api.github.com/repos/nvm-sh/nvm/releases/latest" | jq -r '.tag_name') \
+	    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash \
+	    && source ${NVM_DIR}/nvm.sh && nvm install ${NODE_VERSION}
+
+	# build codeserver
+	git clone --depth 1 --branch "${CODESERVER_VERSION}" --recurse-submodules --shallow-submodules https://github.com/coder/code-server.git
+	cd code-server
+	source ${NVM_DIR}/nvm.sh
+	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
+	# https://github.com/microsoft/vscode/issues/243708#issuecomment-2750733077
+	patch -p1 <<'EOF'
+diff --git i/package.json w/package.json
+index 925462fb087..dfff96eb051 100644
+--- code-server.orig/lib/vscode/package.json
++++ code-server/lib/vscode/package.json
+@@ -32,7 +32,7 @@
+     "watch-extensionsd": "deemon npm run watch-extensions",
+     "kill-watch-extensionsd": "deemon --kill npm run watch-extensions",
+     "precommit": "node build/hygiene.js",
+-    "gulp": "node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js",
++    "gulp": "node --max-old-space-size=16384 --optimize-for-size ./node_modules/gulp/bin/gulp.js",
+     "electron": "node build/lib/electron",
+     "7z": "7z",
+     "update-grammars": "node build/npm/update-all-grammars.mjs",
+EOF
+	nvm use ${NODE_VERSION}
+	npm install
+	npm run build
+	# https://github.com/coder/code-server/pull/7418
+	# node: --optimize-for-size is not allowed in NODE_OPTIONS
+	export NODE_OPTIONS="--max-old-space-size=16384"
+	export TERSER_PARALLEL=2
+	VERSION=${CODESERVER_VERSION/v/} npm run build:vscode
+	npm run release
+	npm run release:standalone
+
+	# build codeserver rpm
+	VERSION=${CODESERVER_VERSION/v/} npm run package
+	mv release-packages/code-server-${CODESERVER_VERSION/v/}-${ARCH}.rpm /tmp/
+
+else
+
+  # we shall not download rpm for other architectures
+  echo "Unsupported architecture: $ARCH" >&2
+  exit 1
+
+fi


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-33414

* https://github.com/opendatahub-io/notebooks/pull/2356

- Added a script to build code-server RPM.
- Adjusted swap size in CI for build memory requirements.
- Updated Dockerfile to include RPM build process and installation from source.