### PR TITLE
Backport: Remove s390x labels for codeserver and trustyai (#615)

### DIFF
--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -46,7 +46,6 @@ spec:
     - linux-extra-fast/amd64
     - linux-m2xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -44,7 +44,6 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
-    - linux/s390x
     - linux/ppc64le
   - name: image-expires-after
     value: 5d


### PR DESCRIPTION
This PR backports commit from the `main` branch to `rhoai-2.25`.

It removes the `s390x` build platform label from the following PipelineRuns:
- codeserver
- trustyai

Original PR:
https://github.com/red-hat-data-services/konflux-central/pull/615
