### PR TITLE
[rhoai-2.25] cuda images should be amd64 only

### DIFF
--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -44,7 +44,6 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
-    - linux/ppc64le
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://redhat-internal.slack.com/archives/C09B6R3Q0KU/p1758551588797189?thread_ts=1757439783.679909&cid=C09B6R3Q0KU
