### PR TITLE
Update PyTorch ROCm from version 6.2.4 to 6.3

### DIFF
--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -4210,26 +4210,26 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e
 
 [[packages]]
 name = "torch"
-version = "2.7.1+rocm6.2.4"
+version = "2.7.1+rocm6.3"
 wheels = [
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "9749832807614e852e1cab5e0166d7bd6264bfad09fccac24b6ad21ccfa40f5e" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "9b3ce5b725ea7fcdc448e291a97f78223df83c0a3938775a5cdc9923f6af109a" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "fd38689b185f0c384bf5863dba4f5f785cd79d814be1b45ee7ef1322d0142bfb" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "e290f4382dbf0e1dcf2afc6ca0c9d713040068544aca3837896dcc604b936049" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "173ef12611407340330b5d550094ff01068962121156963d6a8d69d005101fdc" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "66a734ec759da3bf5a389bca0ad9e35f78b00e78c294b084452c3fce25d388c8" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "23890206702342b89bff0e022bc77b9d6c11522ed27a2c6b562cd81cbbb74cb6" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "73b7eb3777ffe6b73bf9881686dd659bd71231ac87ac3696d2477e2fe0c036fc" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "b0c10342f64a34998ae8d5084aa1beae7e11defa46a4e05fe9aa6f09ffb0db37" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "1650ff47f4cd45e5ba222e943e6e0697eb5f1cff15045ffdafe4feb8c279cb93" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "adfc55a2704c7b58a3475a409fe6ff619bbc4abbe28127fbcf12cc17e441fd1a" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "eb068a01ab18af2e24b3a7015bf5153d8435356bcf3e11aa6dff73c135e94e70" } },
 ]
 
 [[packages]]
 name = "torchvision"
-version = "0.22.1+rocm6.2.4"
+version = "0.22.1+rocm6.3"
 wheels = [
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "95689de1880af70420aeed85bd0dc5f3810e919deb1a1e03e08790e89a34728c" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "2b5ebaaec1c2a0fafd5b7ade30bf77156f7bc99503f78eb78727d4d28a513aa4" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "d19ad0391b228d9e1fdfbe96d291918a202c675e2a6c0bc5f7a6d70713e2746b" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "96c1a5315b15133c61d34f427fd7fd325f897ea1704a2dd659556fdb3e5d75c6" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "8b2fc487e8e0881ae8c1e712ab6dbad7e4b1799fd405b43895ef828d76ef4da7" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "9406abd59ff30a4c5676bc984c0a28b02a82c9bf643d753b95ebddd0a6665953" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "35b6e1ba34b009042e9dc00ed3f82a2b1700b738bd942615e68cd5e41faadb99" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "c150162c2e1de371e5a52c0eb4a98541f307e01716cfe5c850f25c7caa3d3fc4" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "0dce205fb04d9eb2f6feb74faf17cba9180aff70a8c8ac084912ce41b2dc0ab7" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "565ace3680d37c7d39ec8da758333fa13fafb30317b6d4c3b389d46430f11a2b" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "c377ae873066de8441fe9f7783b3ff88ced7996df7e3556ef32b95fd977fb351" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "99559b4c4af12e4ecc0e2df553fdbad0dab5eedbabea803ae95f8d41759156ff" } },
 ]
 
 [[packages]]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -6,8 +6,8 @@ requires-python = "==3.12.*"
 dependencies = [
     # ROCm PyTorch packages
     "tensorboard~=2.20.0",
-    "torch==2.7.1+rocm6.2.4",
-    "torchvision==0.22.1+rocm6.2.4", # https://pytorch.org/get-started/previous-versions/#linux-and-windows-1
+    "torch==2.7.1+rocm6.3",
+    "torchvision==0.22.1+rocm6.3", # https://pytorch.org/get-started/previous-versions/#linux-and-windows-1
     "pytorch-triton-rocm~=3.3.1",
 
     # Datascience and useful extensions
@@ -61,7 +61,7 @@ pytorch-triton-rocm = { index = "pytorch-rocm" }
 # Please keep in sync with rocm/ubi9-python-3.12/Dockerfile
 [[tool.uv.index]]
 name = "pytorch-rocm"
-url = "https://download.pytorch.org/whl/rocm6.2.4"
+url = "https://download.pytorch.org/whl/rocm6.3"
 explicit = true
 
 [tool.uv]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -3605,26 +3605,26 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e
 
 [[packages]]
 name = "torch"
-version = "2.7.1+rocm6.2.4"
+version = "2.7.1+rocm6.3"
 wheels = [
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "9749832807614e852e1cab5e0166d7bd6264bfad09fccac24b6ad21ccfa40f5e" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "9b3ce5b725ea7fcdc448e291a97f78223df83c0a3938775a5cdc9923f6af109a" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "fd38689b185f0c384bf5863dba4f5f785cd79d814be1b45ee7ef1322d0142bfb" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "e290f4382dbf0e1dcf2afc6ca0c9d713040068544aca3837896dcc604b936049" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "173ef12611407340330b5d550094ff01068962121156963d6a8d69d005101fdc" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.1%2Brocm6.2.4-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "66a734ec759da3bf5a389bca0ad9e35f78b00e78c294b084452c3fce25d388c8" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "23890206702342b89bff0e022bc77b9d6c11522ed27a2c6b562cd81cbbb74cb6" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "73b7eb3777ffe6b73bf9881686dd659bd71231ac87ac3696d2477e2fe0c036fc" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "b0c10342f64a34998ae8d5084aa1beae7e11defa46a4e05fe9aa6f09ffb0db37" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "1650ff47f4cd45e5ba222e943e6e0697eb5f1cff15045ffdafe4feb8c279cb93" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "adfc55a2704c7b58a3475a409fe6ff619bbc4abbe28127fbcf12cc17e441fd1a" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torch-2.7.1%2Brocm6.3-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "eb068a01ab18af2e24b3a7015bf5153d8435356bcf3e11aa6dff73c135e94e70" } },
 ]
 
 [[packages]]
 name = "torchvision"
-version = "0.22.1+rocm6.2.4"
+version = "0.22.1+rocm6.3"
 wheels = [
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "95689de1880af70420aeed85bd0dc5f3810e919deb1a1e03e08790e89a34728c" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "2b5ebaaec1c2a0fafd5b7ade30bf77156f7bc99503f78eb78727d4d28a513aa4" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "d19ad0391b228d9e1fdfbe96d291918a202c675e2a6c0bc5f7a6d70713e2746b" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "96c1a5315b15133c61d34f427fd7fd325f897ea1704a2dd659556fdb3e5d75c6" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "8b2fc487e8e0881ae8c1e712ab6dbad7e4b1799fd405b43895ef828d76ef4da7" } },
-    { url = "https://download.pytorch.org/whl/rocm6.2.4/torchvision-0.22.1%2Brocm6.2.4-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "9406abd59ff30a4c5676bc984c0a28b02a82c9bf643d753b95ebddd0a6665953" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp310-cp310-manylinux_2_28_x86_64.whl", hashes = { sha256 = "35b6e1ba34b009042e9dc00ed3f82a2b1700b738bd942615e68cd5e41faadb99" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp311-cp311-manylinux_2_28_x86_64.whl", hashes = { sha256 = "c150162c2e1de371e5a52c0eb4a98541f307e01716cfe5c850f25c7caa3d3fc4" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp312-cp312-manylinux_2_28_x86_64.whl", hashes = { sha256 = "0dce205fb04d9eb2f6feb74faf17cba9180aff70a8c8ac084912ce41b2dc0ab7" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp313-cp313-manylinux_2_28_x86_64.whl", hashes = { sha256 = "565ace3680d37c7d39ec8da758333fa13fafb30317b6d4c3b389d46430f11a2b" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp313-cp313t-manylinux_2_28_x86_64.whl", hashes = { sha256 = "c377ae873066de8441fe9f7783b3ff88ced7996df7e3556ef32b95fd977fb351" } },
+    { url = "https://download.pytorch.org/whl/rocm6.3/torchvision-0.22.1%2Brocm6.3-cp39-cp39-manylinux_2_28_x86_64.whl", hashes = { sha256 = "99559b4c4af12e4ecc0e2df553fdbad0dab5eedbabea803ae95f8d41759156ff" } },
 ]
 
 [[packages]]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -6,8 +6,8 @@ requires-python = "==3.12.*"
 dependencies = [
     # ROCm PyTorch packages
     "tensorboard~=2.20.0",
-    "torch==2.7.1+rocm6.2.4",
-    "torchvision==0.22.1+rocm6.2.4", # https://pytorch.org/get-started/previous-versions/#linux-and-windows-1
+    "torch==2.7.1+rocm6.3",
+    "torchvision==0.22.1+rocm6.3", # https://pytorch.org/get-started/previous-versions/#linux-and-windows-1
     "pytorch-triton-rocm~=3.3.1",
 
     # Datascience and useful extensions
@@ -63,7 +63,7 @@ pytorch-triton-rocm = { index = "pytorch-rocm" }
 # Please keep in sync with rocm/ubi9-python-3.12/Dockerfile
 [[tool.uv.index]]
 name = "pytorch-rocm"
-url = "https://download.pytorch.org/whl/rocm6.2.4"
+url = "https://download.pytorch.org/whl/rocm6.3"
 explicit = true
 
 [tool.uv]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -278,8 +278,8 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
         ("setuptools", ("~=80.9.0", "==80.9.0")),
         ("wheel", ("==0.45.1", "~=0.45.1")),
         ("tensorboard", ("~=2.18.0", "~=2.20.0")),
-        ("torch", ("==2.7.1", "==2.7.1+cu128", "==2.7.1+rocm6.2.4")),
-        ("torchvision", ("==0.22.1", "~=0.22.1", "==0.22.1+cu128", "==0.22.1+rocm6.2.4")),
+        ("torch", ("==2.7.1", "==2.7.1+cu128", "==2.7.1+rocm6.2.4", "==2.7.1+rocm6.3")),
+        ("torchvision", ("==0.22.1", "~=0.22.1", "==0.22.1+cu128", "==0.22.1+rocm6.2.4", "==0.22.1+rocm6.3")),
         (
             "matplotlib",
             ("~=3.10.6",),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -278,7 +278,7 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
         ("setuptools", ("~=80.9.0", "==80.9.0")),
         ("wheel", ("==0.45.1", "~=0.45.1")),
         ("tensorboard", ("~=2.18.0", "~=2.20.0")),
-        ("torch", ("==2.7.1", "==2.7.1+cu128", "==2.7.1+rocm6.2.4", "==2.7.1+rocm6.3")),
+        ("torch", ("==2.7.1", "==2.7.1+cu128", "==2.7.1+rocm6.3")),
         ("torchvision", ("==0.22.1", "~=0.22.1", "==0.22.1+cu128", "==0.22.1+rocm6.3")),
         (
             "matplotlib",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -279,7 +279,7 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
         ("wheel", ("==0.45.1", "~=0.45.1")),
         ("tensorboard", ("~=2.18.0", "~=2.20.0")),
         ("torch", ("==2.7.1", "==2.7.1+cu128", "==2.7.1+rocm6.2.4", "==2.7.1+rocm6.3")),
-        ("torchvision", ("==0.22.1", "~=0.22.1", "==0.22.1+cu128", "==0.22.1+rocm6.2.4", "==0.22.1+rocm6.3")),
+        ("torchvision", ("==0.22.1", "~=0.22.1", "==0.22.1+cu128", "==0.22.1+rocm6.3")),
         (
             "matplotlib",
             ("~=3.10.6",),


### PR DESCRIPTION
The 2025b upgrade should also update PyTorch ROCm package to use ROCm 6.3 instead of ROCm 6.2.4.

## How Has This Been Tested?
`make test`

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
