### PR TITLE
RHAIENG-948: rebase cpu images to pull from aipcc base images

### DIFF
--- a/codeserver/ubi9-python-3.12/build-args/cpu.conf
+++ b/codeserver/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : UBI 9 with Python 3.12
+# Base Image   : RHEL 9.6 with Python 3.12
 # Architectures: linux/arm64, linux/ppc64le, linux/x86_64, linux/s360x
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1761580156

--- a/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : UBI 9 with Python 3.12
+# Base Image   : RHEL 9.6 with Python 3.12
 # Architectures: linux/arm64, linux/ppc64le, linux/x86_64, linux/s360x
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1761580156

--- a/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : UBI 9 with Python 3.12
+# Base Image   : RHEL 9.6 with Python 3.12
 # Architectures: linux/arm64, linux/ppc64le, linux/x86_64, linux/s360x
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1761580156

--- a/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
+++ b/jupyter/trustyai/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : UBI 9 with Python 3.12
+# Base Image   : RHEL 9.6 with Python 3.12
 # Architectures: linux/arm64, linux/ppc64le, linux/x86_64, linux/s360x
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1761580156

--- a/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/datascience/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : UBI 9 with Python 3.12
+# Base Image   : RHEL 9.6 with Python 3.12
 # Architectures: linux/arm64, linux/ppc64le, linux/x86_64, linux/s360x
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1761580156

--- a/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
+++ b/runtimes/minimal/ubi9-python-3.12/build-args/cpu.conf
@@ -1,3 +1,3 @@
-# Base Image   : UBI 9 with Python 3.12
+# Base Image   : RHEL 9.6 with Python 3.12
 # Architectures: linux/arm64, linux/ppc64le, linux/x86_64, linux/s360x
-BASE_IMAGE=registry.access.redhat.com/ubi9/python-312:latest
+BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.0-1761580156


### PR DESCRIPTION
Rebase cpu images to pull from aipcc base images

## Description

https://issues.redhat.com/browse/RHAIENG-948

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
