### PR TITLE
RHAIENG-2345: fix location for tlnet artifacts downloads

### DIFF
--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -28,7 +28,7 @@ echo "Installing TexLive to allow PDf export from Notebooks"
 curl -fL https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz -o install-tl-unx.tar.gz
 zcat < install-tl-unx.tar.gz | tar xf -
 cd install-tl-2*
-perl ./install-tl --no-interaction --scheme=scheme-small --texdir=/usr/local/texlive
+perl ./install-tl --no-interaction --scheme=scheme-small --texdir=/usr/local/texlive --repository https://mirror.ctan.org/systems/texlive/tlnet
 mv /usr/local/texlive/bin/"$(uname -m)-linux" /usr/local/texlive/bin/linux
 cd /usr/local/texlive/bin/linux
 ./tlmgr install tcolorbox pdfcol adjustbox titling enumitem soul ucs collection-fontsrecommended


### PR DESCRIPTION
https://issues.redhat.com/browse/RHAIENG-2345

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
