### PR TITLE
[rhoai-2.25] RHAIENG-2645: add loop to retry package installation when it fails

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -68,6 +68,7 @@ EOF
 # upgrade first to avoid fixable vulnerabilities end
 
 # Install useful OS packages
+COPY jupyter/utils utils/
 RUN --mount=type=cache,target=/var/cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Building for architecture: ${TARGETARCH}"
@@ -80,7 +81,7 @@ else
     PACKAGES=(perl mesa-libGL skopeo)
 fi
 echo "Installing: ${PACKAGES[*]}"
-dnf install -y "${PACKAGES[@]}"
+./utils/install_with_retry.sh dnf-install "${PACKAGES[@]}"
 dnf clean all && rm -rf /var/cache/yum
 EOF
 
@@ -163,8 +164,7 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     # Install build dependencies (shared for pyarrow and onnx)
     # ninja-build is required by scikit-build-core (pyarrow's PEP 517 build backend) to drive
     # the CMake build; `python -m build` fails with "Missing dependencies: ninja>=1.5" without it.
-    dnf install -y cmake make gcc-c++ pybind11-devel wget ninja-build
-    dnf clean all
+    /opt/app-root/bin/utils/install_with_retry.sh dnf-install cmake make gcc-c++ pybind11-devel wget ninja-build
     # Build and collect pyarrow wheel
     git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git
     cd arrow/cpp
@@ -235,8 +235,7 @@ USER root
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip
-    dnf clean all
+    /opt/app-root/bin/utils/install_with_retry.sh dnf-install gcc-toolset-13 cmake ninja-build git wget unzip
 else
     echo "Skipping common-builder package install on non-Power"
 fi
@@ -307,7 +306,8 @@ COPY ${MINIMAL_SOURCE_CODE}/start-notebook.sh ./
 USER 0
 
 # Dependencies for PDF export begin
-RUN ./utils/install_pdf_deps.sh
+RUN ./utils/install_with_retry.sh texlive-install
+ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001
@@ -341,11 +341,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-dnf install -y jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat
-dnf clean all && rm -rf /var/cache/yum
-EOF
+RUN ./utils/install_with_retry.sh dnf-install jq unixODBC unixODBC-devel postgresql git-lfs libsndfile libxcrypt-compat
 
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/jupyter/utils/install_with_retry.sh
+++ b/jupyter/utils/install_with_retry.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Shared install script with retry logic for dnf, texlive (install_pdf_deps), and npm.
+# Usage:
+#   ./install_with_retry.sh dnf-install <package> [package ...]
+#   ./install_with_retry.sh texlive-install
+#   ./install_with_retry.sh npm-install
+
+set -Eeuxo pipefail
+
+readonly MAX_RETRIES="${MAX_RETRIES:-3}"
+readonly RETRY_DELAY="${RETRY_DELAY:-30}"
+
+# Runs a command with retry logic.
+# Optional: set CLEANUP_CMD to a shell command (e.g. "dnf clean metadata") to run between retries.
+# Returns 0 on success, exits 1 after MAX_RETRIES failures.
+run_with_retry() {
+    local retry_count=0
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        retry_count=$((retry_count + 1))
+        if [ "$retry_count" -ge "$MAX_RETRIES" ]; then
+            echo "ERROR: Command failed after $MAX_RETRIES attempts" >&2
+            exit 1
+        fi
+        echo "Command failed (attempt $retry_count/$MAX_RETRIES), retrying in ${RETRY_DELAY} seconds..."
+        if [ -n "${CLEANUP_CMD:-}" ]; then
+            $CLEANUP_CMD || true
+        fi
+        sleep "$RETRY_DELAY"
+    done
+}
+
+dnf_install() {
+    local packages=("$@")
+    if [ ${#packages[@]} -eq 0 ]; then
+        echo "Usage: $0 dnf-install <package> [package ...]" >&2
+        exit 1
+    fi
+    CLEANUP_CMD="dnf clean metadata" run_with_retry dnf install -y ${DNF_EXTRA_OPTS:-} "${packages[@]}"
+    dnf clean all
+    rm -rf /var/cache/yum
+}
+
+texlive_install() {
+    local script_dir
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    CLEANUP_CMD= run_with_retry "$script_dir/install_pdf_deps.sh"
+}
+
+npm_install() {
+    CLEANUP_CMD="rm -rf node_modules" run_with_retry npm install
+}
+
+main() {
+    case "${1:-}" in
+        dnf-install)
+            shift
+            dnf_install "$@"
+            ;;
+        texlive-install)
+            texlive_install
+            ;;
+        npm-install)
+            npm_install
+            ;;
+        *)
+            echo "Usage: $0 {dnf-install|texlive-install|npm-install} [args...]" >&2
+            echo "  dnf-install <package> [package ...]  Install RPM packages with retry" >&2
+            echo "  texlive-install                       Run install_pdf_deps.sh with retry" >&2
+            echo "  npm-install                           Run npm install with retry" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# Only run main when this script is executed directly (not when sourced by run-code-server.sh)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
This PR addresses intermittent build failures (flakiness) caused by transient network issues during dnf install commands.

* This PR aims to fix the network issues only in the `rhoai-2.25` branch, not going forward to ODH main or RHDS main / stable as the team already has in the work hermetic builds to solve this kind of issue in newer versions;
* This fix has also be applied to `rhoai-3.3`;
* The fix involved the creation of a shell script that acts as a wrapper, by receives arguments and parameters, to then create a loop section and run all commands under the loop to avoid flakiness;
* This PR follows the same coding style as other PR, since the functionality aims to do the same thing:
    * #2897

## Description
Here is a summary of the changes proposed in this PR:

- **Shell Script Wrapper:** Creation of a shell script to ease the retry loops functionality;
- **Implemented Retry Loops:** Wrapped retry loops on important commands that can cause flakiness, like `dnf install` or `texlive-install` (install_pdf_deps)
- **Fail-Safe Mechanism:** Added a `MAX_RETRIES` limit (default: 3) with a 30-second `sleep` between attempts to allow network congestion or CDN hiccups to clear.
- **Metadata Reset:** Ensure `dnf clean metadata` within the retry block for subsequent attempts to start with a fresh SSL/OCSP state.
- **Adopted "Strict Mode":** Introduced `set -Eeuxo pipefail` in Heredoc blocks to ensure the build fails immediately and loudly if a non-retryable error occurs.
- **Optimized Caching:** Leveraged `RUN --mount=type=cache` to ensure partial downloads are preserved between retries, reducing bandwidth and build time.

The logic ensures that commands return an exit code of 0 (success). If a command returns a non-zero exit code after 3 attempts, the script will explicitly exit 1, preventing the creation of a "poisoned" or incomplete Docker image.

Here is an example of the working code in the codeserver build steps:

```
--> 4fc54495ca15
...
[3/6] STEP 6/10: RUN --mount=type=cache,target=/var/cache/dnf /bin/bash <<'EOF' (set -Eeuxo pipefail...)
+ MAX_RETRIES=3
+ RETRY_COUNT=0
+ dnf install -y perl mesa-libGL skopeo
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.
...
```

Due to architectural differences between images, the retry logic was implemented individually to accommodate unique package requirements. Each image has been manually verified through local builds to ensure the proposed changes are stable and reliable.

## How Has This Been Tested?
These images have been built manually to ensure that the commands are running properly, with the following instructions to build and test:

> Before running the following commands, please, set the environment USER to your username: `export USER="myuser"`

<details>
<summary>&nbsp;codeserver (cpu)</summary>

<br /> To build the image:

```bash
make codeserver-ubi9-python-3.12 \
        -e RELEASE="2025b" \
        -e IMAGE_REGISTRY="quay.io/$USER/workbench-images" \
        -e RELEASE_PYTHON_VERSION="3.12" \
        -e CONTAINER_BUILD_CACHE_ARGS="--no-cache" \
        -e PUSH_IMAGES="no"
```

To run the image:

```bash
export IMG=$(podman images --format "{{.Repository}}:{{.Tag}}" | grep "codeserver-ubi9-python-3.12" | sort -r | head -n1) && \
    (until curl -s localhost:8787 > /dev/null; do sleep 1; done && open http://localhost:8787 &) && \
    podman run --rm --platform linux/amd64 -p 8787:8787 "$IMG"
```
</details>

<details>
<summary>&nbsp;jupyter/datascience (cpu)</summary>

<br /> To build the image:

```bash
make jupyter-datascience-ubi9-python-3.12 \
        -e RELEASE="2025b" \
        -e IMAGE_REGISTRY="quay.io/$USER/workbench-images" \
        -e RELEASE_PYTHON_VERSION="3.12" \
        -e CONTAINER_BUILD_CACHE_ARGS="--no-cache" \
        -e PUSH_IMAGES="no"
```

To run the image:

```bash
export IMG=$(podman images --format "{{.Repository}}:{{.Tag}}" | grep "jupyter-datascience-ubi9-python-3.12" | sort -r | head -n1) && \
    (until podman logs jupyter_test 2>&1 | grep -q "token="; do sleep 1; done && \
    open $(podman logs jupyter_test 2>&1 | grep -o "http://localhost:[0-9]*/lab?token=[a-zA-Z0-9]*" | head -n1) &) && \
    podman run --rm --name jupyter_test --platform linux/amd64 -p 8888:8888 "$IMG"
```
</details>

<hr />

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of environment setup by automatically retrying package installations after transient failures.
  * Added cleanup between failed attempts to help installations recover successfully.
  * Preserved architecture-specific dependency support during setup.

* **New Features**
  * Added PDF-generation tooling, including TeX Live and Pandoc, to the available environment tools.
  * Improved validation and handling of required packages during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->