### PR TITLE
RHAIENG-2610 Update minimal cuda to 13 but based on 3.3 tag

### DIFF
--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,6 +1,6 @@
 # Base Image   : RHEL 9.6 with Python 3.12
-# CUDA Version : 12.9
+# CUDA Version : 13.0
 # Architectures: linux/arm64, linux/x86_64
 # Source       : https://quay.io/repository/aipcc/base-images/cuda
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-12.9-el9.6:3.3.0-1768412345
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.3.0-1770996761
 PYLOCK_FLAVOR=cuda


### PR DESCRIPTION
Update minimal cuda to 13 but based on 3.3 tag

## Description

https://issues.redhat.com/browse/RHAIENG-2610

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
