### PR TITLE
RHAIENG-2860: dnf install openshift-clients, instead of download tar.gz

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -224,8 +224,8 @@ RUN touch /tmp/control
 # cpu-base: Runtime base image with OS packages, tools (oc, micropipenv, uv)
 #
 # [HERMETIC] Previously this stage ran `subscription-manager refresh`, `dnf upgrade --refresh`,
-# and `curl` to download the oc client. Now all packages come from prefetched RPMs and
-# the oc client is extracted from a prefetched tarball.
+# and `curl` to download the oc client. Now all packages come from prefetched RPMs;
+# the oc client is installed via the openshift-clients RPM (see rpms.in.yaml).
 ############################################################################################
 FROM ${BASE_IMAGE} AS cpu-base
 
@@ -256,10 +256,11 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
 # [HERMETIC] Install Node.js runtime from prefetched RPMs.
 RUN dnf install -y nodejs npm && dnf clean all
 
-# Install useful OS packages (runtime dependencies)
+# Install useful OS packages (runtime dependencies); oc from openshift-clients RPM.
+# compat-openssl11 provides libcrypto.so.1.1 for openshift-clients on EL9 (check-payload FIPS scan).
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y tar perl mesa-libGL skopeo
+dnf install -y tar perl mesa-libGL skopeo compat-openssl11 openshift-clients
 dnf clean all
 rm -rf /var/cache/dnf
 EOF
@@ -275,13 +276,6 @@ EOF
 
 # Install micropipenv and uv from cachi2 pip cache
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.9.28"
-
-# Install the oc client from prefetched tarball (see artifacts.in.yaml)
-RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-ARCH=$(uname -m)
-tar -xzvf /cachi2/output/deps/generic/openshift-client-linux-${ARCH}.tar.gz oc
-EOF
 
 # Other apps and tools installed as default user
 USER 1001

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -224,8 +224,8 @@ RUN touch /tmp/control
 # cpu-base: Runtime base image with OS packages, tools (oc, micropipenv, uv)
 #
 # [HERMETIC] Previously this stage ran `subscription-manager refresh`, `dnf upgrade --refresh`,
-# and `curl` to download the oc client. Now all packages come from prefetched RPMs and
-# the oc client is extracted from a prefetched tarball.
+# and `curl` to download the oc client. Now all packages come from prefetched RPMs;
+# the oc client is installed via the openshift-clients RPM (see rpms.in.yaml).
 ############################################################################################
 FROM ${BASE_IMAGE} AS cpu-base
 
@@ -256,10 +256,11 @@ RUN if [ "${LOCAL_BUILD}" = "true" ]; then \
 # [HERMETIC] Install Node.js runtime from prefetched RPMs.
 RUN dnf install -y nodejs npm && dnf clean all
 
-# Install useful OS packages (runtime dependencies)
+# Install useful OS packages (runtime dependencies); oc from openshift-clients RPM.
+# compat-openssl11 provides libcrypto.so.1.1 for openshift-clients on EL9 (check-payload FIPS scan).
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y tar perl mesa-libGL skopeo
+dnf install -y tar perl mesa-libGL skopeo compat-openssl11 openshift-clients
 dnf clean all
 rm -rf /var/cache/dnf
 EOF
@@ -275,13 +276,6 @@ EOF
 
 # Install micropipenv and uv from cachi2 pip cache
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.9.28"
-
-# Install the oc client from prefetched tarball (see artifacts.in.yaml)
-RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-ARCH=$(uname -m)
-tar -xzvf /cachi2/output/deps/generic/openshift-client-linux-${ARCH}.tar.gz oc
-EOF
 
 # Other apps and tools installed as default user
 USER 1001

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.in.yaml
@@ -24,16 +24,7 @@ input:
       filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     # argon2: not prefetched; builds from source via node-gyp (gcc-toolset-14 in rpm-base).
     # The npm package is in the lockfile; when the mirror has no prebuild, it falls back to compile.
-
-    # OpenShift oc client (one per target arch; filenames use uname -m convention)
-    - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-x86_64.tar.gz
-    - url: https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-aarch64.tar.gz
-    - url: https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-ppc64le.tar.gz
-    - url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-s390x.tar.gz
+    # OpenShift oc client: installed via dnf (openshift-clients RPM in rpms.in.yaml), not prefetched here.
 
     # VSCode marketplace extensions (built-in extensions bundled with code-server)
     - url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/artifacts.lock.yaml
@@ -17,18 +17,6 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
     filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:0e9e38f64f8f39767ffe946bd0e6c59645296d9070b201eee7f7af9559116014
-    filename: openshift-client-linux-x86_64.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:7a495ce67dd236bdc10b696249f5d0979153333188e4820c269c88e2657fbcb9
-    filename: openshift-client-linux-aarch64.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:7c4a3f3dda8a5bd0a23557c689efe8053e621695c6043e2125f1801dceeb1f1a
-    filename: openshift-client-linux-ppc64le.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:2162b0a596f5f29fbd290382b52ccf60bf6e9739346b52698a55ac77396989d9
-    filename: openshift-client-linux-s390x.tar.gz
   - download_url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
     checksum: sha256:7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93
     filename: ms-vscode.js-debug-companion.1.1.3.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.in.yaml
@@ -15,6 +15,7 @@ contentOrigin:
     # ODH (upstream) — uses UBI + CentOS Stream public repos (no subscription needed)
     - ../repos/ubi.repo
     - ../repos/centos.repo
+    - ../repos/openshift-clients.repo
 
 context:
   bare: true
@@ -137,3 +138,8 @@ packages:
   # (node-gyp native addon in lib/vscode)
   - libxkbfile-devel
   - qhull-devel
+
+  # ── OpenShift Clients (mirror.openshift.com — 4.22) ──────────────────
+  # compat-openssl11: provides libcrypto.so.1.1 / libssl.so.1.1 for openshift-clients on EL9 (check-payload FIPS scan).
+  - compat-openssl11
+  - openshift-clients

--- a/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/odh/rpms.lock.yaml
@@ -74,6 +74,13 @@ arches:
     name: checkpolicy
     evr: 3.6-1.el9
     sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.aarch64.rpm
+    repoid: ubi-9-for-aarch64-appstream-rpms
+    size: 1437140
+    checksum: sha256:4d62a8fe879ba1da792cc23451678608e37b7a5107c6063a8a18c0dd98b0c5b5
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/appstream/os/Packages/c/criu-3.19-3.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-appstream-rpms
     size: 555523
@@ -1985,6 +1992,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 1072208
@@ -4841,6 +4855,13 @@ arches:
     name: qhull-devel
     evr: 1:7.2.1-11.el9
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
+  - url: https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.aarch64.rpm
+    repoid: openshift-4-12
+    size: 46412656
+    checksum: sha256:7fb967cfdf194b386dc06b7180c1a0d918081596c04c29235d3899d740371f6c
+    name: openshift-clients
+    evr: 4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8
+    sourcerpm: openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.src.rpm
   source: []
   module_metadata:
   - url: https://composes.stream.centos.org/production/CentOS-Stream-9-20260217.0/compose/AppStream/aarch64/os/repodata/e1a9188bff6eb85e2a054de2e42029d9d2053dcc66708735cc0903b585957c7a-modules.yaml.gz
@@ -4919,6 +4940,13 @@ arches:
     name: checkpolicy
     evr: 3.6-1.el9
     sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-appstream-rpms
+    size: 1592980
+    checksum: sha256:cc4e307266401ba58b33127e54459d7384b4f6f143204f1e9688a14db94d273f
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/appstream/os/Packages/c/criu-3.19-3.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-appstream-rpms
     size: 603115
@@ -6837,6 +6865,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 1072208
@@ -9721,6 +9756,13 @@ arches:
     name: qhull-devel
     evr: 1:7.2.1-11.el9
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
+  - url: https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202301312133.p0.gb05f7d4.assembly.stream.el8.ppc64le.rpm
+    repoid: openshift-4-12
+    size: 41652072
+    checksum: sha256:d157e464ad4c4bb4efed1bf68bbfaac5daba8b4450a533204e8b716b65262c27
+    name: openshift-clients
+    evr: 4.12.0-202301312133.p0.gb05f7d4.assembly.stream.el8
+    sourcerpm: openshift-clients-4.12.0-202301312133.p0.gb05f7d4.assembly.stream.el8.src.rpm
   source: []
   module_metadata:
   - url: https://composes.stream.centos.org/production/CentOS-Stream-9-20260217.0/compose/AppStream/ppc64le/os/repodata/3d16e89520ac23356dc6446a1cff1a49233b375209cca55043ce1a5dcb5ce9ca-modules.yaml.gz
@@ -9799,6 +9841,13 @@ arches:
     name: checkpolicy
     evr: 3.6-1.el9
     sourcerpm: checkpolicy-3.6-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 1524135
+    checksum: sha256:e4573a2f07756624a20d93e967f840d5aee748965827067a7516ce0670a13031
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/criu-3.19-3.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 569988
@@ -11724,6 +11773,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/c/ca-certificates-2025.2.80_v9.0.305-91.el9.noarch.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 1072208
@@ -14608,6 +14664,13 @@ arches:
     name: qhull-devel
     evr: 1:7.2.1-11.el9
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
+  - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rpms/4.12-el8-beta/openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.x86_64.rpm
+    repoid: openshift-4-12
+    size: 48103288
+    checksum: sha256:65ca7e4ab4deea83a8010e07acc7a6a854682cf15e1647e260ad77121091b49e
+    name: openshift-clients
+    evr: 4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8
+    sourcerpm: openshift-clients-4.12.0-202312200531.p0.gd4c9e3c.assembly.stream.el8.src.rpm
   source: []
   module_metadata:
   - url: https://composes.stream.centos.org/production/CentOS-Stream-9-20260217.0/compose/AppStream/x86_64/os/repodata/677a49b2e0726fb3afee7a5c18a14c3eba91f922041a49e99b9120009925553d-modules.yaml.gz

--- a/codeserver/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo
+++ b/codeserver/ubi9-python-3.12/prefetch-input/repos/openshift-clients.repo
@@ -1,0 +1,7 @@
+[openshift-4-12]
+name=OpenShift 4.12 Public - $basearch
+# Note: el8, because that is the only available option for ppc64le and s390x, but it is compatible with el9.
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/dependencies/rpms/4.12-el8-beta/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=True

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.in.yaml
@@ -25,16 +25,6 @@ input:
     # argon2: not prefetched; builds from source via node-gyp (gcc-toolset-14 in rpm-base).
     # The npm package is in the lockfile; when the mirror has no prebuild, it falls back to compile.
 
-    # OpenShift oc client (one per target arch; filenames use uname -m convention)
-    - url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-x86_64.tar.gz
-    - url: https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-aarch64.tar.gz
-    - url: https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-ppc64le.tar.gz
-    - url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-      filename: openshift-client-linux-s390x.tar.gz
-
     # VSCode marketplace extensions (built-in extensions bundled with code-server)
     - url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
       filename: ms-vscode.js-debug-companion.1.1.3.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/artifacts.lock.yaml
@@ -17,18 +17,6 @@ artifacts:
   - download_url: https://github.com/microsoft/ripgrep-prebuilt/releases/download/v13.0.0-13/ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
     checksum: sha256:555983c74789d553b107c5a2de90b883727b3e43d680f0cd289a07407efb2755
     filename: ripgrep-v13.0.0-13-s390x-unknown-linux-gnu.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:0e9e38f64f8f39767ffe946bd0e6c59645296d9070b201eee7f7af9559116014
-    filename: openshift-client-linux-x86_64.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:7a495ce67dd236bdc10b696249f5d0979153333188e4820c269c88e2657fbcb9
-    filename: openshift-client-linux-aarch64.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:7c4a3f3dda8a5bd0a23557c689efe8053e621695c6043e2125f1801dceeb1f1a
-    filename: openshift-client-linux-ppc64le.tar.gz
-  - download_url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/4.18.33/openshift-client-linux.tar.gz
-    checksum: sha256:2162b0a596f5f29fbd290382b52ccf60bf6e9739346b52698a55ac77396989d9
-    filename: openshift-client-linux-s390x.tar.gz
   - download_url: https://github.com/microsoft/vscode-js-debug-companion/releases/download/v1.1.3/ms-vscode.js-debug-companion.1.1.3.vsix
     checksum: sha256:7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93
     filename: ms-vscode.js-debug-companion.1.1.3.vsix

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.in.yaml
@@ -143,3 +143,8 @@ packages:
   # -- Missing these in RHEL AIPCC ----
   - patch
   - rsync
+
+  # ── OpenShift Clients (rhocp / mirror) ──────────────────
+  # compat-openssl11: provides libcrypto.so.1.1 / libssl.so.1.1 for openshift-clients on EL9 (check-payload FIPS scan).
+  - compat-openssl11
+  - openshift-clients

--- a/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
+++ b/codeserver/ubi9-python-3.12/prefetch-input/rhds/rpms.lock.yaml
@@ -11,6 +11,13 @@ arches:
     name: containers-common
     evr: 3:1-78.rhaos4.16.el9
     sourcerpm: containers-common-1-78.rhaos4.16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/aarch64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.aarch64.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
+    size: 54080966
+    checksum: sha256:aca8538e130743bdd3aeae1ec02732402ed7d71840d6ac7016bd27cd63c7540c
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/a/annobin-12.92-1.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1106184
@@ -361,6 +368,13 @@ arches:
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.aarch64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1437140
+    checksum: sha256:4d62a8fe879ba1da792cc23451678608e37b7a5107c6063a8a18c0dd98b0c5b5
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.aarch64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 10795955
@@ -3483,6 +3497,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/baseos/os/Packages/b/binutils-2.35.2-63.el9.aarch64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 5023899
@@ -4864,10 +4885,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/repodata/8c529c0af1d53c7ae34edc350309cc9b9c25bac4bdfe08df09b32d216367a775-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/aarch64/appstream/os/repodata/006e812e7f58e5c1211840f071145df075ed994528bc8d2ab3ac112c7657b5b5-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34364
-    checksum: sha256:8c529c0af1d53c7ae34edc350309cc9b9c25bac4bdfe08df09b32d216367a775
+    checksum: sha256:006e812e7f58e5c1211840f071145df075ed994528bc8d2ab3ac112c7657b5b5
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.ppc64le.rpm
@@ -4877,6 +4898,13 @@ arches:
     name: containers-common
     evr: 3:1-78.rhaos4.16.el9
     sourcerpm: containers-common-1-78.rhaos4.16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/ppc64le/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.ppc64le.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
+    size: 51126038
+    checksum: sha256:eadbf175188502377555dc98a03d2359ba7c03ed14bc1b788bbfd3a83cddbab1
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/a/annobin-12.92-1.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1110088
@@ -5227,6 +5255,13 @@ arches:
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1592980
+    checksum: sha256:cc4e307266401ba58b33127e54459d7384b4f6f143204f1e9688a14db94d273f
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.ppc64le.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 9618370
@@ -8370,6 +8405,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/baseos/os/Packages/b/binutils-2.35.2-63.el9.ppc64le.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 5199630
@@ -9765,10 +9807,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/repodata/5b6f42676fc1e04a945f8a63a111e72aaca8bd26d4f69f34abeee1ba6446cb77-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/ppc64le/appstream/os/repodata/ff1f43b72aea2f957c85e6e34c5d6707e8dc5e275284b6c6982980791db735a1-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 32808
-    checksum: sha256:5b6f42676fc1e04a945f8a63a111e72aaca8bd26d4f69f34abeee1ba6446cb77
+    checksum: sha256:ff1f43b72aea2f957c85e6e34c5d6707e8dc5e275284b6c6982980791db735a1
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.s390x.rpm
@@ -9778,6 +9820,13 @@ arches:
     name: containers-common
     evr: 3:1-78.rhaos4.16.el9
     sourcerpm: containers-common-1-78.rhaos4.16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/s390x/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.s390x.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
+    size: 52969532
+    checksum: sha256:f64c95c9dbb421beddef5dcaa741d2765c5303f872e9eb7d19c337a5cda3cd6b
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/a/annobin-12.92-1.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1108217
@@ -10128,6 +10177,13 @@ arches:
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1215996
+    checksum: sha256:67e641c9a86b684e9e3ff85090c23b2a2654bb3287d544c1d7c89ab40ce6bd0a
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.s390x.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 8598616
@@ -13299,6 +13355,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/baseos/os/Packages/b/binutils-2.35.2-63.el9.s390x.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 4761844
@@ -14638,10 +14701,10 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/repodata/618e82350683be2d774e2cbe542232caaff48f4fce79c01ff56b40112bf0b571-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/s390x/appstream/os/repodata/478aef54553af08c03eca4a999564439c8567318cbeb273ca4626a9b3a27f217-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 33005
-    checksum: sha256:618e82350683be2d774e2cbe542232caaff48f4fce79c01ff56b40112bf0b571
+    checksum: sha256:478aef54553af08c03eca4a999564439c8567318cbeb273ca4626a9b3a27f217
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/c/containers-common-1-78.rhaos4.16.el9.x86_64.rpm
@@ -14651,6 +14714,13 @@ arches:
     name: containers-common
     evr: 3:1-78.rhaos4.16.el9
     sourcerpm: containers-common-1-78.rhaos4.16.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhocp/4.16/os/Packages/o/openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.x86_64.rpm
+    repoid: rhocp-4.16-for-rhel-9-x86_64-rpms
+    size: 54964214
+    checksum: sha256:ee71ce72f2b9a1804559527a18c68dd2430394425f9ad64e3fe6384fdb28e00b
+    name: openshift-clients
+    evr: 4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9
+    sourcerpm: openshift-clients-4.16.0-202511271316.p2.g6f88b58.assembly.stream.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/a/annobin-12.92-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1106759
@@ -15001,6 +15071,13 @@ arches:
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/c/compat-openssl11-1.1.1k-5.el9_6.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-rpms
+    size: 1524135
+    checksum: sha256:e4573a2f07756624a20d93e967f840d5aee748965827067a7516ce0670a13031
+    name: compat-openssl11
+    evr: 1:1.1.1k-5.el9_6.1
+    sourcerpm: compat-openssl11-1.1.1k-5.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 11229073
@@ -18144,6 +18221,13 @@ arches:
     name: bash
     evr: 5.1.8-9.el9
     sourcerpm: bash-5.1.8-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/bash-completion-2.11-5.el9.noarch.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 469639
+    checksum: sha256:3b4ae87f0e9a13cda47f1c009eb2c63135dc22b2b4dd89a6310f8e8fbb59e30a
+    name: bash-completion
+    evr: 1:2.11-5.el9
+    sourcerpm: bash-completion-2.11-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 4818636
@@ -19546,7 +19630,7 @@ arches:
     sourcerpm: qhull-7.2.1-11.el9.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/repodata/618da00859523e2a4bb67ee62e36cf10b141af12f83bd8e2773dd66f668e1e14-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.6/x86_64/appstream/os/repodata/3d64ab4e2d06abcef8a3a5b642f23cca498fceb3054c5d859914d0b59bc4c38b-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 34742
-    checksum: sha256:618da00859523e2a4bb67ee62e36cf10b141af12f83bd8e2773dd66f668e1e14
+    checksum: sha256:3d64ab4e2d06abcef8a3a5b642f23cca498fceb3054c5d859914d0b59bc4c38b

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -235,9 +235,23 @@ class TestBaseImage:
     def test_oc_command_runs_fake_fips(self, image: str, subtests: pytest_subtests.SubTests):
         """Establishes a best-effort fake FIPS environment and attempts to execute `oc` binary in it.
 
-        Related issue: RHOAIENG-4350 In workbench the oc CLI tool cannot be used on FIPS enabled cluster"""
+        Related issue: RHOAIENG-4350 In workbench the oc CLI tool cannot be used on FIPS enabled cluster.
+
+        When oc is installed via the openshift-clients RPM (dnf), it is FIPS-aware and requires
+        a real FIPS OpenSSL backend when /proc/sys/crypto/fips_enabled is 1. This test only fakes
+        that proc file, so the RPM oc correctly fails with "required OpenSSL backend is unavailable".
+        On real FIPS-enabled RHEL/UBI the backend would be present. We skip the test for RPM-based oc.
+        """
         if utils.is_rstudio_image(image):
             pytest.skip("oc command is not preinstalled in RStudio images.")
+        # Skip when oc comes from openshift-clients RPM: fake FIPS is insufficient for RPM (needs real OpenSSL).
+        with self._test_container(image=image) as container:
+            rpm_ecode, _ = container.exec(["/bin/sh", "-c", "rpm -q openshift-clients 2>/dev/null"])
+        if rpm_ecode == 0:
+            pytest.skip(
+                "oc from openshift-clients RPM: fake FIPS test not applicable "
+                "(RPM requires real FIPS OpenSSL; on real FIPS nodes oc would work)."
+            )
         with tempfile.TemporaryDirectory() as tmp_crypto:
             # Ubuntu does not even have /proc/sys/crypto directory, unless FIPS is activated and machine
             #  is rebooted, see https://ubuntu.com/security/certifications/docs/fips-enablement


### PR DESCRIPTION
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): dnf install openshift-clients, instead of download tar.gz

## Description
[RHAIENG-2860](https://issues.redhat.com/browse/RHAIENG-2860): dnf install openshift-clients, instead of download tar.gz

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


[RHAIENG-2860]: https://redhat.atlassian.net/browse/RHAIENG-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-2860]: https://redhat.atlassian.net/browse/RHAIENG-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ