### PR TITLE
[rhoai-3.4-ea.2] run FORCE_LOCKFILES_UPGRADE=1 gmake refresh-lock-files

### DIFF
--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -42,15 +42,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.64-2-py3-none-any.whl", hashes = { sha256 = "2136abdf2b233e1a89b9563874cf7203d2b88439bcc99486cf8881be3c9b599a" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.64-2-py3-none-any.whl", hashes = { sha256 = "f01171e5c1f437649384c7c4fa761562bf4d154a1af9545c09d4553186f40ae6" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
 
 [[packages]]
 name = "certifi"
@@ -200,9 +200,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/filelock-3.25.1-2-py3-none-any.whl", hashes = { sha256 = "d3e0cda4591270f41b9643a2f23776bf464f89be02a8cac4c6da5f57c93e710b" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/filelock-3.25.2-2-py3-none-any.whl", hashes = { sha256 = "ff122a5a2afb7ece0ba72e8f89dd24aba7da0d56683795babad4c5894b37493b" } }]
 
 [[packages]]
 name = "fonttools"
@@ -224,9 +224,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/google_auth-2.49.0-2-py3-none-any.whl", hashes = { sha256 = "d219a78bdadf92759107909dd63dec7d9c17da7f76f7829d055eec45889e794a" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/google_auth-2.49.1-2-py3-none-any.whl", hashes = { sha256 = "486c8e5c1c1f96e4bc8b747a1ee2332330ec750296a984e37716825afa1382fd" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -497,9 +497,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/narwhals-2.17.0-2-py3-none-any.whl", hashes = { sha256 = "7ae0196ed17cda5672a6cb38d18a76ec8de1177c782efcda9a092b80da4b3afd" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/narwhals-2.18.0-2-py3-none-any.whl", hashes = { sha256 = "1bfa66615b62a208b82702830cb2f942c384b607df4a1dce884fd938b8cf186d" } }]
 
 [[packages]]
 name = "nest-asyncio"
@@ -740,9 +740,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.11.0-2-py3-none-any.whl", hashes = { sha256 = "2debd85aa7bb015325bdc5c1d4ca87365125708e1d78e20008cde2df8c93d843" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
 
 [[packages]]
 name = "pyparsing"
@@ -758,9 +758,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/python_discovery-1.1.2-2-py3-none-any.whl", hashes = { sha256 = "36e0131ecbc1f5a41eb39b3892f52eac743ee7d0732382f22d4e4d99809eb5a4" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/python_discovery-1.1.3-2-py3-none-any.whl", hashes = { sha256 = "8767b44c30b725674c19f139eb1fdbc8b46e9b0ca4e58b612b8fdc106fbbae19" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -847,12 +847,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "0f7f8b8dcd9f0fb3cf7289f33ea1744ac4a47fb60581f46932f55b633aaa1ad5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3cd14f655cf15503309f9e3c021571429331f26686278daeee9793f01187fd43" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rsa-4.9.1-2-py3-none-any.whl", hashes = { sha256 = "6fcfed81598bd236377f1079e25a13efc0da53e7c81030a0b9b91c11eb3bb007" } }]
 
 [[packages]]
 name = "s3transfer"
@@ -961,13 +955,13 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "cfbd7badd456905c6923b7a43e85d75ae45587dfeed8262b9e36dd6f27f6cd2e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "9c5ad3cfca1100cf697c7559e64e807710beb0fe11d86e82bc30021ee6cd835d" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "3da1820c3e5ad37c5e5eb40af25bb3d7568320ae382210cf7ee7191ab0e2eb9f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "c6b9e80318e38ad54d6c3c4bbb6b38f9f0190c896e82e7c216b74c2bbddcb1ca" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "1a902b88db666a23eb3df3c8249ab13f459524f6bd7073df6a9b39c1f1b65ee5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "357b777e0d9cc1cb1de849708e59cf79dfc95aeabce42b584ea818005b022d05" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "8c428693b160a32c34a96f954425005f966ce885ecad988134a032f0d3f32cc2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "7c18fd68b9fad8ec2c8dc8ba52641155541478228413244031bfd743b8d965cb" } },
 ]
 
 [[packages]]

--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -30,9 +30,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-26.1.0-2-py3-none-any.whl", hashes = { sha256 = "c05d9d58b0411fa7bcabceef61ac716468836735dbbf39ef17e34e952cea5e31" } }]
 
 [[packages]]
 name = "bigtree"
@@ -42,15 +42,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -643,13 +643,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ca63597a67b36a20819a198590452bb386312d530de4703472a16e88e159975e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "acb45f1a2e516c8d7a44cfbc9046d832d3aa8730e20dd389be3bc0f6f63079cb" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "5a31841ea2079fdfef6821f75b8955847201488945db2049e652aee8fcce77f5" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8bcf60a75dc286cf4d9410de1a2c90c55648a157e12e760bbec2820dfbb8e0d3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -695,6 +693,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "586f08c129ddf7b39041396a6e532d3a8230bb8b7f51e627ae6b10ef557f3cc5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "74159bd221074ba9137e85a4346e19efae57aab9f0f5b7e8612bef79117f9a38" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b27820345f00dcfe4def2b5b8ab07e2011e040c9f9524665a1b977eb997e4b51" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3bdcbc33a9eee499809dcfe1627f8f12af2235445aa41e4d72d970f858f01fc8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c46cbc4c39d68b069d41f0076ca8d342beaeea3f9d6e052ff72bd729ffee84cd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "c42bbe26b956cc1d910daf6935c4ba5370495970d4a9f328c12256f2a08f412d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b90a547f13de65881927ac1b14598f2ddf6e294099caff5eebec0df7d80b2678" } },
 ]
 
 [[packages]]
@@ -740,9 +742,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pyparsing"

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -133,9 +133,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "black"
-version = "26.3.0"
+version = "26.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/black-26.3.0-2-py3-none-any.whl", hashes = { sha256 = "d39d42a68ea1fd52df58a110bde4e85d970aa18c62cc355f80b8b8d9fe5e5cb0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/black-26.3.1-2-py3-none-any.whl", hashes = { sha256 = "b7872af1cab625726d874386ad72767f9ce8511fc94a3696a3ef5a89ff9a2f2a" } }]
 
 [[packages]]
 name = "bleach"
@@ -145,21 +145,21 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "bokeh"
-version = "3.8.2"
+version = "3.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/bokeh-3.8.2-2-py3-none-any.whl", hashes = { sha256 = "f6306e22b596d5736e32ced66099e6acb9dedfca2fdbf4f948fbfa4c6f90033c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/bokeh-3.9.0-2-py3-none-any.whl", hashes = { sha256 = "f69ae6dd791c52d819291029e369dad1b7a06773592a33366d6ce447b5764ef7" } }]
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.64-2-py3-none-any.whl", hashes = { sha256 = "2136abdf2b233e1a89b9563874cf7203d2b88439bcc99486cf8881be3c9b599a" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.64-2-py3-none-any.whl", hashes = { sha256 = "f01171e5c1f437649384c7c4fa761562bf4d154a1af9545c09d4553186f40ae6" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
 
 [[packages]]
 name = "certifi"
@@ -357,9 +357,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/filelock-3.25.1-2-py3-none-any.whl", hashes = { sha256 = "d3e0cda4591270f41b9643a2f23776bf464f89be02a8cac4c6da5f57c93e710b" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/filelock-3.25.2-2-py3-none-any.whl", hashes = { sha256 = "ff122a5a2afb7ece0ba72e8f89dd24aba7da0d56683795babad4c5894b37493b" } }]
 
 [[packages]]
 name = "fonttools"
@@ -421,9 +421,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/google_auth-2.49.0-2-py3-none-any.whl", hashes = { sha256 = "d219a78bdadf92759107909dd63dec7d9c17da7f76f7829d055eec45889e794a" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/google_auth-2.49.1-2-py3-none-any.whl", hashes = { sha256 = "486c8e5c1c1f96e4bc8b747a1ee2332330ec750296a984e37716825afa1382fd" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -667,9 +667,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/jupyterlab-4.5.5-2-py3-none-any.whl", hashes = { sha256 = "8276d2763880f5281238d5860daba2d88362740babd6b0febecce9f816c7c2c1" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/jupyterlab-4.5.6-2-py3-none-any.whl", hashes = { sha256 = "ac6683f5b5a715822116f85d77ef83ab772257173b06f3d433fbf0c37439169d" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -914,9 +914,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/narwhals-2.17.0-2-py3-none-any.whl", hashes = { sha256 = "7ae0196ed17cda5672a6cb38d18a76ec8de1177c782efcda9a092b80da4b3afd" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/narwhals-2.18.0-2-py3-none-any.whl", hashes = { sha256 = "1bfa66615b62a208b82702830cb2f942c384b607df4a1dce884fd938b8cf186d" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1305,9 +1305,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.11.0-2-py3-none-any.whl", hashes = { sha256 = "2debd85aa7bb015325bdc5c1d4ca87365125708e1d78e20008cde2df8c93d843" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1356,9 +1356,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/python_discovery-1.1.2-2-py3-none-any.whl", hashes = { sha256 = "36e0131ecbc1f5a41eb39b3892f52eac743ee7d0732382f22d4e4d99809eb5a4" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/python_discovery-1.1.3-2-py3-none-any.whl", hashes = { sha256 = "8767b44c30b725674c19f139eb1fdbc8b46e9b0ca4e58b612b8fdc106fbbae19" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1496,12 +1496,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "0f7f8b8dcd9f0fb3cf7289f33ea1744ac4a47fb60581f46932f55b633aaa1ad5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3cd14f655cf15503309f9e3c021571429331f26686278daeee9793f01187fd43" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rsa-4.9.1-2-py3-none-any.whl", hashes = { sha256 = "6fcfed81598bd236377f1079e25a13efc0da53e7c81030a0b9b91c11eb3bb007" } }]
 
 [[packages]]
 name = "ruamel-yaml"
@@ -1664,13 +1658,13 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "cfbd7badd456905c6923b7a43e85d75ae45587dfeed8262b9e36dd6f27f6cd2e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "9c5ad3cfca1100cf697c7559e64e807710beb0fe11d86e82bc30021ee6cd835d" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "3da1820c3e5ad37c5e5eb40af25bb3d7568320ae382210cf7ee7191ab0e2eb9f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "c6b9e80318e38ad54d6c3c4bbb6b38f9f0190c896e82e7c216b74c2bbddcb1ca" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "1a902b88db666a23eb3df3c8249ab13f459524f6bd7073df6a9b39c1f1b65ee5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "357b777e0d9cc1cb1de849708e59cf79dfc95aeabce42b584ea818005b022d05" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "8c428693b160a32c34a96f954425005f966ce885ecad988134a032f0d3f32cc2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "7c18fd68b9fad8ec2c8dc8ba52641155541478228413244031bfd743b8d965cb" } },
 ]
 
 [[packages]]
@@ -1711,13 +1705,13 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ujson"
-version = "5.11.0"
+version = "5.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.11.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bbb7c65b0aa49b28e832fe42307bc0b6ba23565921c4fe84f4713c6e31213512" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.11.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "2f4f7ebcb27d704e693f45065f2e0a474d842521fc82480578ba82557e7555b9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.11.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "166f2e092be472a8dd4d100b31143f453083fb6d49b34a67e147420f99352911" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.11.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d70b29a475b8d7c085fe3f5dde43d50469796bec94f62b25045a7c6308fe22d1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.12.0-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "06c72cbfc9ed250b42e8a94d038665e7dd1b740ac29d72b2beba8249453489a8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.12.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "07b4277204a886259b66473c6b47b2ec671f939ea002ccc7f2e33c49f3ac2ee5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.12.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "aa0b26fb8ac0889f9ee36bc47abd25ec55d6f377d4dc38a5cf85ec8bf80d8234" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/ujson-5.12.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3ab39a65b97e1054c499f26fda984851ea6f9e6d4900512a67a8fd671286c0b9" } },
 ]
 
 [[packages]]

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -94,9 +94,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-26.1.0-2-py3-none-any.whl", hashes = { sha256 = "c05d9d58b0411fa7bcabceef61ac716468836735dbbf39ef17e34e952cea5e31" } }]
 
 [[packages]]
 name = "autopep8"
@@ -151,15 +151,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -1179,13 +1179,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ca63597a67b36a20819a198590452bb386312d530de4703472a16e88e159975e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "acb45f1a2e516c8d7a44cfbc9046d832d3aa8730e20dd389be3bc0f6f63079cb" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "5a31841ea2079fdfef6821f75b8955847201488945db2049e652aee8fcce77f5" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8bcf60a75dc286cf4d9410de1a2c90c55648a157e12e760bbec2820dfbb8e0d3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -1237,6 +1235,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "586f08c129ddf7b39041396a6e532d3a8230bb8b7f51e627ae6b10ef557f3cc5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "74159bd221074ba9137e85a4346e19efae57aab9f0f5b7e8612bef79117f9a38" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b27820345f00dcfe4def2b5b8ab07e2011e040c9f9524665a1b977eb997e4b51" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3bdcbc33a9eee499809dcfe1627f8f12af2235445aa41e4d72d970f858f01fc8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c46cbc4c39d68b069d41f0076ca8d342beaeea3f9d6e052ff72bd729ffee84cd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "c42bbe26b956cc1d910daf6935c4ba5370495970d4a9f328c12256f2a08f412d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b90a547f13de65881927ac1b14598f2ddf6e294099caff5eebec0df7d80b2678" } },
 ]
 
 [[packages]]
@@ -1305,9 +1307,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1843,6 +1845,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "71f6065dbf8b8aa60e95fc1c674df2c9b7fb7a3351396dac795f588e9ba89032" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "37b0c4e2e934574aa0338c6a8141aba248dc0ffe7112c1fc3c7d1e12cc8de8a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9b42c797d1a45bb859278d4efd76c476b54244b46f3504678d22d2fdb3429b60" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a220a1801c3d62b6dd716fb3c3d71f94ef41a1853fdbfad819d60f32d1f03d59" } },
 ]
 
 [[packages]]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -70,9 +70,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-26.1.0-2-py3-none-any.whl", hashes = { sha256 = "c05d9d58b0411fa7bcabceef61ac716468836735dbbf39ef17e34e952cea5e31" } }]
 
 [[packages]]
 name = "babel"
@@ -726,4 +726,8 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "71f6065dbf8b8aa60e95fc1c674df2c9b7fb7a3351396dac795f588e9ba89032" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "37b0c4e2e934574aa0338c6a8141aba248dc0ffe7112c1fc3c7d1e12cc8de8a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9b42c797d1a45bb859278d4efd76c476b54244b46f3504678d22d2fdb3429b60" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a220a1801c3d62b6dd716fb3c3d71f94ef41a1853fdbfad819d60f32d1f03d59" } },
 ]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -319,9 +319,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/jupyterlab-4.5.5-2-py3-none-any.whl", hashes = { sha256 = "8276d2763880f5281238d5860daba2d88362740babd6b0febecce9f816c7c2c1" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/jupyterlab-4.5.6-2-py3-none-any.whl", hashes = { sha256 = "ac6683f5b5a715822116f85d77ef83ab772257173b06f3d433fbf0c37439169d" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -648,13 +648,13 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "cfbd7badd456905c6923b7a43e85d75ae45587dfeed8262b9e36dd6f27f6cd2e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "9c5ad3cfca1100cf697c7559e64e807710beb0fe11d86e82bc30021ee6cd835d" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "3da1820c3e5ad37c5e5eb40af25bb3d7568320ae382210cf7ee7191ab0e2eb9f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "c6b9e80318e38ad54d6c3c4bbb6b38f9f0190c896e82e7c216b74c2bbddcb1ca" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "1a902b88db666a23eb3df3c8249ab13f459524f6bd7073df6a9b39c1f1b65ee5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "357b777e0d9cc1cb1de849708e59cf79dfc95aeabce42b584ea818005b022d05" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "8c428693b160a32c34a96f954425005f966ce885ecad988134a032f0d3f32cc2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "7c18fd68b9fad8ec2c8dc8ba52641155541478228413244031bfd743b8d965cb" } },
 ]
 
 [[packages]]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -309,9 +309,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/jupyterlab-4.5.5-8-py3-none-any.whl", hashes = { sha256 = "976d98f4cf889be780e2b6e5df77bdd78514fbb3398a9105590181d09b9d6f95" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/jupyterlab-4.5.6-8-py3-none-any.whl", hashes = { sha256 = "6d21cf3fb039fb28b02b879a7b8efdc4d91d3eba6a3b9d7082ac34083817c2c3" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -624,11 +624,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "65732ce1b6d79c66027b51e62c42ce74ac53048f859f14d0375f8821595b3c87" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "40058a2e6c3dd0f3cbcb5773d331a67662603ecf7dba26772cd8a679cb9930dd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "fea56090c88ce165278058f9a431c49f129a2eaed5817547bcb9d63becda37e3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5b0f3371f487e8e35c146695925dec4657670e5b70817ca77df539a2d447144f" } },
 ]
 
 [[packages]]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -66,9 +66,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "939b24c974a7d22b417cf4b0a9ec2c95114697daedb1cd91de82878857679f3e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "1374a8c285fc9b8fa1e0a20636c8d8d61db48b5ebd96f4d58cc532f202268c74" } }]
 
 [[packages]]
 name = "babel"
@@ -698,4 +698,6 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "38fe3a72af8e5a190d58d09bb05c4be78d7339a0cb0e73b9a9d779145f04894b" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "855f06d0f5857b3e57b2c7ccf1a810c57506ed230ab20bc212e30a5c8b4e39a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "239c073e8a4948bd226818937ad5cae2bcd4dca181683fc29fd776efc2c8eb79" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda13.0-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8f3f5b6502904f26dbe438390e1e2d198359270285e4be6790d3968c82d24b7e" } },
 ]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -60,9 +60,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/attrs-25.4.0-12-py3-none-any.whl", hashes = { sha256 = "392db93a8a91fe1136a04b6e76a66467d78490efa31a9c5bd114287e9ae6a554" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/attrs-26.1.0-12-py3-none-any.whl", hashes = { sha256 = "496a2d1671c1ba87f218a620f4f1861ca94dd41e3f9f1359ae27deb925501437" } }]
 
 [[packages]]
 name = "babel"
@@ -656,4 +656,7 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "yarl"
 version = "1.23.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5ba0e1455750dafb8e86f8ac487adc3ba035a6fcdde3d683a4a78ac111c34d19" } },
+]

--- a/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/minimal/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -294,9 +294,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/jupyterlab-4.5.5-12-py3-none-any.whl", hashes = { sha256 = "a5c8d4597144db133603bcc6bcd6432ddf4cef4b6a0b4eef94c1836c07cd6c2f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/jupyterlab-4.5.6-12-py3-none-any.whl", hashes = { sha256 = "64a89bae77943750db27bb2a36e702951432c5dad1665ee9597f8d48e53d1532" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -588,9 +588,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/tornado-6.5.4-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "8a6e25fe75f402b6932c5a2f296ef45c4c138025f664cd9fb086b8f8fe06afa4" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/tornado-6.5.5-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "4a4fa3342ebf8f69a1f439f684fdc8984cadddc6f571fccd71768989d8ab27cb" } }]
 
 [[packages]]
 name = "traitlets"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -126,9 +126,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "black"
-version = "26.3.0"
+version = "26.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/black-26.3.0-8-py3-none-any.whl", hashes = { sha256 = "d7ba52e1cdf10e6498db079fa30dcd0517b9b43bce915b9bdc107bca77828bf3" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/black-26.3.1-8-py3-none-any.whl", hashes = { sha256 = "76b9d439e1b4a3e50d8fe52cdbc5a3e9cd2a5b1e8594a45677199d1497a78bf9" } }]
 
 [[packages]]
 name = "bleach"
@@ -138,21 +138,21 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "bokeh"
-version = "3.8.2"
+version = "3.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/bokeh-3.8.2-8-py3-none-any.whl", hashes = { sha256 = "aec3f27813eb307c5749ccb8a35c70cce685e29226e226bcc1509d82a0b0e833" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/bokeh-3.9.0-8-py3-none-any.whl", hashes = { sha256 = "d53b5f5d870431aee76d7d478628adffecb16d82d80ff98ff904be8b3db62807" } }]
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6253f79dab41e62971026b56b31f04286237cf7439186124166e834dc4a63e1c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6d20b74964f04e1e348018e334856f414f2d5dde1b618e9978344c93519adaa2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
 
 [[packages]]
 name = "certifi"
@@ -354,9 +354,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.1-8-py3-none-any.whl", hashes = { sha256 = "37d177516fc5f3f9f2c115b37b7cae46b5f409d2c2581bef0f66aac23c928ca0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.2-8-py3-none-any.whl", hashes = { sha256 = "1a06237406de68d077f625dd66d1c6ed8948192a5b5e9d509e224613f0cecd1c" } }]
 
 [[packages]]
 name = "fonttools"
@@ -414,9 +414,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.0-8-py3-none-any.whl", hashes = { sha256 = "0b5ee3cd6ef9cffca33f6ae8f49ff83c801a4b05d159bfb816a62243296d8132" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.1-8-py3-none-any.whl", hashes = { sha256 = "66042030906be9d7785567f0eed81d4d335b3e56f54a0c60193eb1d2c7aa7dcc" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -480,11 +480,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "hf-xet"
-version = "1.3.2"
+version = "1.4.2"
 marker = "(implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'arm64' and sys_platform == 'linux') or (implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.3.2-8-cp37-abi3-linux_aarch64.whl", hashes = { sha256 = "5479e1cb25fa7647fa4bd729f48a460117635d2ee3c0f218f302ffc0652ec761" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.3.2-8-cp37-abi3-linux_x86_64.whl", hashes = { sha256 = "6d6185eda4ef6bf61ecb780bd39fd64c5cbe0bc0e8a48309afe1a97b817d5b49" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.4.2-8-cp37-abi3-linux_aarch64.whl", hashes = { sha256 = "fcb089de9e460badbfacdc54316c4d1845fee0c8a98e4e8a9924781c4d7b762c" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.4.2-8-cp37-abi3-linux_x86_64.whl", hashes = { sha256 = "5cd68f6e6bfe271762a59962baa8131221e7d89e31a263a5542749642621592e" } },
 ]
 
 [[packages]]
@@ -672,9 +672,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/jupyterlab-4.5.5-8-py3-none-any.whl", hashes = { sha256 = "0c80f94eb20f59398befcb6aa775f0d99a688bf9f08198351a9e3473da29a6fc" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/jupyterlab-4.5.6-8-py3-none-any.whl", hashes = { sha256 = "65220d916950536d1d725b9ed77d3feddf8ae4042bd419bf6736af4bfe4f2a21" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -933,9 +933,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.17.0-8-py3-none-any.whl", hashes = { sha256 = "913a86059a3560391bd42127c6c92225b5cf34540b8678785ab0913c1937a818" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "b9d649dee7ce11d75a7c24f6d90b6530a4420869c299648e3718fb246ce3ffc2" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1263,9 +1263,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "0591de88e9cf017c9359ba66e0656e29cdae7a57aeaf78947f952aef1b8b9447" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1440,12 +1440,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bdce3b540862098992196b3380a66999bbed37408aecb3bf7ca9dcb1c0feaf93" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d4553438b49e9a3489c3de0415a578064c11fa97b0d222bfe7aa4d2f1af59731" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rsa-4.9.1-8-py3-none-any.whl", hashes = { sha256 = "0f8ea382eb6353c825b5ea44c42b9619551a7e8a67cfaba349f0d35752e1a556" } }]
 
 [[packages]]
 name = "ruamel-yaml"
@@ -1674,11 +1668,11 @@ wheels = [
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "51e6d0644e5fa64d3cab035f92c14b4f3a2af6df5a009d71e3f35abba538bcc9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "42bada2a90c446b1e8dbbc68611d377d35605e769b58c262ef2c5685fe4f49a5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "c0775112cc2ab1a7e944a6a661c06458a4679bcaebfb0a1bd84e2c1dd869a165" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5342d0f38ea598a577533975f33267f962485bcea67828b7e277c22853005e13" } },
 ]
 
 [[packages]]
@@ -1740,11 +1734,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ujson"
-version = "5.11.0"
+version = "5.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.11.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "32dbca5368848f7d879d3a0aff88a2c74d61415c962f11ee88f5915531bd3e6f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.11.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "80fc24ce26059262394cdb129fcf23954cc563331b30bcd5b853e00da4a608f1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.12.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "94649206b8d0c54bc3f8b58fadbd10871661dd4c51ac35cda0adce83e5b9278e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.12.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "69ddb21f0e48a3ced3bdbd9a3f5470c0ca2cac4d609467fe56e81fb0ceaeb8cc" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -96,9 +96,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "126f48fefecb46db4371aee825bd049e82107c22bb69c814341b8a564de9eb0c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "bb70d3307b7c4cc94457649823eae8d5a0fb76d0f67e01ac85362a3261250047" } }]
 
 [[packages]]
 name = "autopep8"
@@ -144,15 +144,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -1158,11 +1158,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "97122b4219fc74d6b9fa6e41b485080ff321a31dd31fd33b2fd8eb36f550045f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "55f92461c32dedd5574daac55f079693dc1ba94c77fe1d4691b3d623a902ef5a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -1199,6 +1199,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5f2aefda93dff508a809f26899c744d276f2d707fdefa473301d0daa3aa156e9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8c9d009aa86f24541e2e481edbaf99cdf31550938f88b05fee0fecb208e25043" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c5b42543b7dafcd57a6eba4f6fe09e0ba672c6cf480fa97d2b8391209f2b4bf2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4da4f6b3301ecc683e732a33d351b6d2b8f3ad8204598248c758f2d1520dd595" } },
 ]
 
 [[packages]]
@@ -1263,9 +1265,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1655,6 +1657,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "21df4468684a214edaf4e90183f44a6f2e15a06b07ac9cae2856bfd04e61082f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "936d3cfdf1394ce2dc66c2521274e6961517418a4ef281bcca669297bde573b9" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a92491706f9b4530549f2df479a4c9ac942b9ae87f79d2afde13d7c2f3096a36" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7ab83dd5a819610d2f3a9a816ad6009d267243ea1c9c006b04554898492c6e70" } },
 ]
 
 [[packages]]
@@ -1868,6 +1872,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7f2378720203f3e878d4c731aef08f5f291f0d01e0db66a0d32c533e43041522" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9d9b2c1ebf19f7f57cb6a17544bc8a920e395eabf15c152480415eec8b1a6ec" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -135,9 +135,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "black"
-version = "26.3.0"
+version = "26.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/black-26.3.0-8-py3-none-any.whl", hashes = { sha256 = "d7ba52e1cdf10e6498db079fa30dcd0517b9b43bce915b9bdc107bca77828bf3" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/black-26.3.1-8-py3-none-any.whl", hashes = { sha256 = "76b9d439e1b4a3e50d8fe52cdbc5a3e9cd2a5b1e8594a45677199d1497a78bf9" } }]
 
 [[packages]]
 name = "bleach"
@@ -147,21 +147,21 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "bokeh"
-version = "3.8.2"
+version = "3.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/bokeh-3.8.2-8-py3-none-any.whl", hashes = { sha256 = "aec3f27813eb307c5749ccb8a35c70cce685e29226e226bcc1509d82a0b0e833" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/bokeh-3.9.0-8-py3-none-any.whl", hashes = { sha256 = "d53b5f5d870431aee76d7d478628adffecb16d82d80ff98ff904be8b3db62807" } }]
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6253f79dab41e62971026b56b31f04286237cf7439186124166e834dc4a63e1c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6d20b74964f04e1e348018e334856f414f2d5dde1b618e9978344c93519adaa2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
 
 [[packages]]
 name = "certifi"
@@ -351,9 +351,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.1-8-py3-none-any.whl", hashes = { sha256 = "37d177516fc5f3f9f2c115b37b7cae46b5f409d2c2581bef0f66aac23c928ca0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.2-8-py3-none-any.whl", hashes = { sha256 = "1a06237406de68d077f625dd66d1c6ed8948192a5b5e9d509e224613f0cecd1c" } }]
 
 [[packages]]
 name = "fonttools"
@@ -411,9 +411,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.0-8-py3-none-any.whl", hashes = { sha256 = "0b5ee3cd6ef9cffca33f6ae8f49ff83c801a4b05d159bfb816a62243296d8132" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.1-8-py3-none-any.whl", hashes = { sha256 = "66042030906be9d7785567f0eed81d4d335b3e56f54a0c60193eb1d2c7aa7dcc" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -654,9 +654,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/jupyterlab-4.5.5-8-py3-none-any.whl", hashes = { sha256 = "0c80f94eb20f59398befcb6aa775f0d99a688bf9f08198351a9e3473da29a6fc" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/jupyterlab-4.5.6-8-py3-none-any.whl", hashes = { sha256 = "65220d916950536d1d725b9ed77d3feddf8ae4042bd419bf6736af4bfe4f2a21" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -897,9 +897,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.17.0-8-py3-none-any.whl", hashes = { sha256 = "913a86059a3560391bd42127c6c92225b5cf34540b8678785ab0913c1937a818" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "b9d649dee7ce11d75a7c24f6d90b6530a4420869c299648e3718fb246ce3ffc2" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1268,9 +1268,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "0591de88e9cf017c9359ba66e0656e29cdae7a57aeaf78947f952aef1b8b9447" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1313,9 +1313,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.2-8-py3-none-any.whl", hashes = { sha256 = "ec835f207587c9cdd6ce59b1d08491e66d4de527385ba0d2595fa0b44c1a4053" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.3-8-py3-none-any.whl", hashes = { sha256 = "0a4f389c3546405adde681661b8bb985b160c126602b868e422fda5f171febf1" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1445,12 +1445,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bdce3b540862098992196b3380a66999bbed37408aecb3bf7ca9dcb1c0feaf93" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d4553438b49e9a3489c3de0415a578064c11fa97b0d222bfe7aa4d2f1af59731" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rsa-4.9.1-8-py3-none-any.whl", hashes = { sha256 = "0f8ea382eb6353c825b5ea44c42b9619551a7e8a67cfaba349f0d35752e1a556" } }]
 
 [[packages]]
 name = "ruamel-yaml"
@@ -1643,11 +1637,11 @@ wheels = [
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "51e6d0644e5fa64d3cab035f92c14b4f3a2af6df5a009d71e3f35abba538bcc9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "42bada2a90c446b1e8dbbc68611d377d35605e769b58c262ef2c5685fe4f49a5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "c0775112cc2ab1a7e944a6a661c06458a4679bcaebfb0a1bd84e2c1dd869a165" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5342d0f38ea598a577533975f33267f962485bcea67828b7e277c22853005e13" } },
 ]
 
 [[packages]]
@@ -1697,11 +1691,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ujson"
-version = "5.11.0"
+version = "5.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.11.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "32dbca5368848f7d879d3a0aff88a2c74d61415c962f11ee88f5915531bd3e6f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.11.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "80fc24ce26059262394cdb129fcf23954cc563331b30bcd5b853e00da4a608f1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.12.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "94649206b8d0c54bc3f8b58fadbd10871661dd4c51ac35cda0adce83e5b9278e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.12.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "69ddb21f0e48a3ced3bdbd9a3f5470c0ca2cac4d609467fe56e81fb0ceaeb8cc" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -96,9 +96,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "126f48fefecb46db4371aee825bd049e82107c22bb69c814341b8a564de9eb0c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "bb70d3307b7c4cc94457649823eae8d5a0fb76d0f67e01ac85362a3261250047" } }]
 
 [[packages]]
 name = "autopep8"
@@ -153,15 +153,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -1152,11 +1152,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "97122b4219fc74d6b9fa6e41b485080ff321a31dd31fd33b2fd8eb36f550045f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "55f92461c32dedd5574daac55f079693dc1ba94c77fe1d4691b3d623a902ef5a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -1204,6 +1204,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5f2aefda93dff508a809f26899c744d276f2d707fdefa473301d0daa3aa156e9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8c9d009aa86f24541e2e481edbaf99cdf31550938f88b05fee0fecb208e25043" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c5b42543b7dafcd57a6eba4f6fe09e0ba672c6cf480fa97d2b8391209f2b4bf2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4da4f6b3301ecc683e732a33d351b6d2b8f3ad8204598248c758f2d1520dd595" } },
 ]
 
 [[packages]]
@@ -1268,9 +1270,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1624,6 +1626,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "21df4468684a214edaf4e90183f44a6f2e15a06b07ac9cae2856bfd04e61082f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "936d3cfdf1394ce2dc66c2521274e6961517418a4ef281bcca669297bde573b9" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a92491706f9b4530549f2df479a4c9ac942b9ae87f79d2afde13d7c2f3096a36" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7ab83dd5a819610d2f3a9a816ad6009d267243ea1c9c006b04554898492c6e70" } },
 ]
 
 [[packages]]
@@ -1825,6 +1829,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7f2378720203f3e878d4c731aef08f5f291f0d01e0db66a0d32c533e43041522" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9d9b2c1ebf19f7f57cb6a17544bc8a920e395eabf15c152480415eec8b1a6ec" } },
 ]
 
 [[packages]]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -126,9 +126,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "black"
-version = "26.3.0"
+version = "26.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/black-26.3.0-12-py3-none-any.whl", hashes = { sha256 = "9251ae3911514c8506f65660032da6e27e7ab4eca594fe4dab8eab6c4c938581" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/black-26.3.1-12-py3-none-any.whl", hashes = { sha256 = "72836dcfa9cf06cb846d3028a2e63da8b25f511c48162881d24ae227aa1733cc" } }]
 
 [[packages]]
 name = "bleach"
@@ -138,21 +138,21 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "bokeh"
-version = "3.8.2"
+version = "3.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/bokeh-3.8.2-12-py3-none-any.whl", hashes = { sha256 = "3b0a2bc3669289f8032f15868a6cf99a90037cba0ad3203fc64c1ab9ac32247e" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/bokeh-3.9.0-12-py3-none-any.whl", hashes = { sha256 = "84100ced164bcc37b100630b4b213e085399e90fa213079d123c07489c53249a" } }]
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/boto3-1.42.64-12-py3-none-any.whl", hashes = { sha256 = "5f2eae2ab95753412fbf53e51937e855302911f20cf301f64371b55ea588a354" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/boto3-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "7b180411b5ed0c06a58ac0d66dffbca9e455a6f8b6854dea61d9af0f5d055351" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/botocore-1.42.64-12-py3-none-any.whl", hashes = { sha256 = "98fa021c39af4d50b5528f39a49b1b93fe6b60cee3a00a2592a30960b3a97b36" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/botocore-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "47b5c6db8619413865aaa66e8bbe796849fbe86150a49a76c3bf54b6229fa84d" } }]
 
 [[packages]]
 name = "certifi"
@@ -330,9 +330,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/filelock-3.25.1-12-py3-none-any.whl", hashes = { sha256 = "e46d8fc0eee73c30215731f024e978b95f5679d90c109cef912700d3326d69fa" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/filelock-3.25.2-12-py3-none-any.whl", hashes = { sha256 = "4d2d1b7e90eed7dd7ef75a3f549869d15da1a0bb41e6e0e69d9e5003f1d97fba" } }]
 
 [[packages]]
 name = "fonttools"
@@ -384,9 +384,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/google_auth-2.49.0-12-py3-none-any.whl", hashes = { sha256 = "9d22eb6e21b0625e4488022ee107cb24cc0b373dc28e45ff9affb6f4b6cc28e5" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/google_auth-2.49.1-12-py3-none-any.whl", hashes = { sha256 = "9e8b54bfea5d6202400a0a7382a6b9ca02512dd9475e47f35fa197ef3584ad63" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -618,9 +618,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/jupyterlab-4.5.5-12-py3-none-any.whl", hashes = { sha256 = "a5c8d4597144db133603bcc6bcd6432ddf4cef4b6a0b4eef94c1836c07cd6c2f" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/jupyterlab-4.5.6-12-py3-none-any.whl", hashes = { sha256 = "64a89bae77943750db27bb2a36e702951432c5dad1665ee9597f8d48e53d1532" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -834,9 +834,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/narwhals-2.17.0-12-py3-none-any.whl", hashes = { sha256 = "fd1ecf6a2ebc05766cb729595b818f3ecc9ba7de81f2afb959f8d716034a632d" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/narwhals-2.18.0-12-py3-none-any.whl", hashes = { sha256 = "a6c0e0fbc4d2e1211b9400534955bb6d5ab9027313a1463d7a19fd14bf944006" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1173,9 +1173,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyjwt-2.11.0-12-py3-none-any.whl", hashes = { sha256 = "ce6ad695a786d30cc5091f0223b3574151614caa2c0484a0f7ff1f7532e45d47" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyjwt-2.12.0-12-py3-none-any.whl", hashes = { sha256 = "c59af40549bc064212f9c92b54c9c5f604882e1cd43f8ab2442ccbc12187f950" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1209,9 +1209,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/python_discovery-1.1.2-12-py3-none-any.whl", hashes = { sha256 = "0a0fa79e44290c7ba4b23645c582eda88e9d34960b9e5be0c7bbe0b2182a0bb2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/python_discovery-1.1.3-12-py3-none-any.whl", hashes = { sha256 = "5e5d9cf9cb56f7fc5e9c85c1658546822d6f7113d479cfa8565355691e64f78a" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1326,12 +1326,6 @@ name = "rpds-py"
 version = "0.30.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/rpds_py-0.30.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "079f16ffe8de26af88c26dff158b9f96a3c1964f10205a0595e59e52000e253f" } }]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/rsa-4.9.1-12-py3-none-any.whl", hashes = { sha256 = "2cdecd651d0b348b91664f8a2bd2e69408ba716174bf47eec465d40add22d85e" } }]
 
 [[packages]]
 name = "ruamel-yaml"
@@ -1509,9 +1503,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/tornado-6.5.4-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "8a6e25fe75f402b6932c5a2f296ef45c4c138025f664cd9fb086b8f8fe06afa4" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/tornado-6.5.5-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "4a4fa3342ebf8f69a1f439f684fdc8984cadddc6f571fccd71768989d8ab27cb" } }]
 
 [[packages]]
 name = "tqdm"
@@ -1557,9 +1551,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ujson"
-version = "5.11.0"
+version = "5.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/ujson-5.11.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5c2d00614add9b5ef2e57bcb4fb0313fbff05cbe124fe7ffa7360768b140f345" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/ujson-5.12.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9e08d2ef2da4ed5db0dcd67db995f9af60bb0e5b060e8456f3d04a73846e567e" } }]
 
 [[packages]]
 name = "uri-template"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -90,9 +90,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/attrs-25.4.0-12-py3-none-any.whl", hashes = { sha256 = "392db93a8a91fe1136a04b6e76a66467d78490efa31a9c5bd114287e9ae6a554" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/attrs-26.1.0-12-py3-none-any.whl", hashes = { sha256 = "496a2d1671c1ba87f218a620f4f1861ca94dd41e3f9f1359ae27deb925501437" } }]
 
 [[packages]]
 name = "autopep8"
@@ -144,15 +144,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/boto3-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "7b180411b5ed0c06a58ac0d66dffbca9e455a6f8b6854dea61d9af0f5d055351" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/botocore-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "47b5c6db8619413865aaa66e8bbe796849fbe86150a49a76c3bf54b6229fa84d" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -1074,9 +1074,12 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/protobuf-6.33.5-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "738ef1273295ef0cfbdd13908c8694339469ce4dc9e62334455c61eaa3b46697" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
+]
 
 [[packages]]
 name = "psutil"
@@ -1115,7 +1118,10 @@ wheels = [
 name = "pyarrow"
 version = "23.0.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyarrow-23.0.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ed608bad6ebd64361ac979923756ba815d0cdf7c9fda3009987b20062c59613a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyarrow-23.0.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ed608bad6ebd64361ac979923756ba815d0cdf7c9fda3009987b20062c59613a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyarrow-23.0.1-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e711139c483e2802c06e6ca2a815f47147d1d6765e579eb754e6175e0645ba5c" } },
+]
 
 [[packages]]
 name = "pyasn1"
@@ -1173,9 +1179,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyjwt-2.12.0-12-py3-none-any.whl", hashes = { sha256 = "c59af40549bc064212f9c92b54c9c5f604882e1cd43f8ab2442ccbc12187f950" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1493,7 +1499,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "torch"
 version = "2.9.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/torch-2.9.1-14-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c6b187493adf0046b2079c563f3ba651e681a7ebbd2c93c394ad4daec5c258bd" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/torch-2.9.1-14-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c6b187493adf0046b2079c563f3ba651e681a7ebbd2c93c394ad4daec5c258bd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/torch-2.9.1-15-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "0fe5962823b7588d826ca51d018b9069c6841d9d167ff9bec8d92378fe0e4258" } },
+]
 
 [[packages]]
 name = "torchvision"
@@ -1667,7 +1676,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "yarl"
 version = "1.23.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5ba0e1455750dafb8e86f8ac487adc3ba035a6fcdde3d683a4a78ac111c34d19" } },
+]
 
 [[packages]]
 name = "yaspin"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -268,6 +268,7 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/47/0b/bdf449df87be3f0
 name = "boto3"
 version = "1.42.76"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+sdist = { url = "https://files.pythonhosted.org/packages/f1/13/33c8b8704d677fcaf5555ba8c6cc39468fc7b9a0c6b6c496e008cd5557fc/boto3-1.42.76.tar.gz", upload-time = 2026-03-25T19:33:25Z, size = 112789, hashes = { sha256 = "aa2b1973eee8973a9475d24bb579b1dee7176595338d4e4f7880b5c6189b8814" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/f0/dc/21b3dfb135125eb7e3a46b9aab0aede847726f239fc8f39474742a87ebb0/boto3-1.42.76-py3-none-any.whl", upload-time = 2026-03-25T19:33:23Z, size = 140557, hashes = { sha256 = "63c6779c814847016b89ae1b72ed968f8a63d80e589ba337511aa6fc1b59585e" } }]
 
 [[packages]]

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -97,10 +97,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5e
 
 [[packages]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", upload-time = 2026-01-06T11:45:21Z, size = 228685, hashes = { sha256 = "41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", upload-time = 2026-01-06T11:45:19Z, size = 113592, hashes = { sha256 = "d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", upload-time = 2026-03-24T12:59:09Z, size = 231622, hashes = { sha256 = "334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", upload-time = 2026-03-24T12:59:08Z, size = 114353, hashes = { sha256 = "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708" } }]
 
 [[packages]]
 name = "appengine-python-standard"
@@ -155,17 +155,17 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b45
 
 [[packages]]
 name = "async-lru"
-version = "2.2.0"
+version = "2.3.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/05/8a/ca724066c32a53fa75f59e0f21aa822fdaa8a0dffa112d223634e3caabf9/async_lru-2.2.0.tar.gz", upload-time = 2026-02-20T19:11:43Z, size = 14654, hashes = { sha256 = "80abae2a237dbc6c60861d621619af39f0d920aea306de34cb992c879e01370c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/13/5c/af990f019b8dd11c5492a6371fe74a5b0276357370030b67254a87329944/async_lru-2.2.0-py3-none-any.whl", upload-time = 2026-02-20T19:11:42Z, size = 7890, hashes = { sha256 = "e2c1cf731eba202b59c5feedaef14ffd9d02ad0037fcda64938699f2c380eafe" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", upload-time = 2026-03-19T01:04:32Z, size = 16332, hashes = { sha256 = "89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", upload-time = 2026-03-19T01:04:30Z, size = 8403, hashes = { sha256 = "eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315" } }]
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", upload-time = 2025-10-06T13:54:44Z, size = 934251, hashes = { sha256 = "16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", upload-time = 2025-10-06T13:54:43Z, size = 67615, hashes = { sha256 = "adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", upload-time = 2026-03-19T14:22:25Z, size = 952055, hashes = { sha256 = "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", upload-time = 2026-03-19T14:22:23Z, size = 67548, hashes = { sha256 = "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309" } }]
 
 [[packages]]
 name = "autopep8"
@@ -240,14 +240,14 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df2
 
 [[packages]]
 name = "black"
-version = "26.3.0"
+version = "26.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/11/5f/25b7b149b8b7d3b958efa4faa56446560408c0f2651108a517526de0320a/black-26.3.0.tar.gz", upload-time = 2026-03-06T17:42:33Z, size = 664127, hashes = { sha256 = "4d438dfdba1c807c6c7c63c4f15794dda0820d2222e7c4105042ac9ddfc5dd0b" } }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", upload-time = 2026-03-12T03:36:03Z, size = 666155, hashes = { sha256 = "2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/8b/712a3ae8f17c1f3cd6f9ac2fffb167a27192f5c7aba68724e8c4ab8474ad/black-26.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T17:46:28Z, size = 1794844, hashes = { sha256 = "5b6c5f734290803b7b26493ffd734b02b72e6c90d82d45ac4d5b862b9bdf7720" } },
-    { url = "https://files.pythonhosted.org/packages/a2/dd/da980b2f512441375b73cb511f38a2c3db4be83ccaa1302b8d39c9fa2dff/black-26.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T17:46:36Z, size = 1793741, hashes = { sha256 = "6f7b3e653a90ca1ef4e821c20f8edaee80b649c38d2532ed2e9073a9534b14a7" } },
-    { url = "https://files.pythonhosted.org/packages/00/b1/5c0bf29fe5b43fcc6f3e8480c6566d21a02d4e702b3846944e7daa06dea9/black-26.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T17:46:43Z, size = 1787676, hashes = { sha256 = "cc6ac0ea5dd5fa6311ca82edfa3620cba0ed0426022d10d2d5d39aedbf3e1958" } },
-    { url = "https://files.pythonhosted.org/packages/39/d7/7360654ba4f8b41afcaeb5aca973cfea5591da75aff79b0a8ae0bb8883f6/black-26.3.0-py3-none-any.whl", upload-time = 2026-03-06T17:42:31Z, size = 206848, hashes = { sha256 = "e825d6b121910dff6f04d7691f826d2449327e8e71c26254c030c4f3d2311985" } },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-12T03:40:17Z, size = 1794994, hashes = { sha256 = "0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7" } },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-12T03:40:25Z, size = 1793557, hashes = { sha256 = "f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56" } },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-12T03:40:33Z, size = 1787824, hashes = { sha256 = "b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f" } },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", upload-time = 2026-03-12T03:36:01Z, size = 207542, hashes = { sha256 = "2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b" } },
 ]
 
 [[packages]]
@@ -259,24 +259,23 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d
 
 [[packages]]
 name = "bokeh"
-version = "3.8.2"
+version = "3.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/e4/31/7ee0c4dfd0255631b0624ce01be178704f91f763f02a1879368eb109befd/bokeh-3.8.2.tar.gz", upload-time = 2026-01-06T00:20:06Z, size = 6529251, hashes = { sha256 = "8e7dcacc21d53905581b54328ad2705954f72f2997f99fc332c1de8da53aa3cc" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl", upload-time = 2026-01-06T00:20:04Z, size = 7207131, hashes = { sha256 = "5e2c0d84f75acb25d60efb9e4d2f434a791c4639b47d685534194c4e07bd0111" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/0d/fabb70707646217e4b0e3943e05730eab8c1f7b7e7485145f8594b52e606/bokeh-3.9.0.tar.gz", upload-time = 2026-03-11T17:58:34Z, size = 5740345, hashes = { sha256 = "775219714a8496973ddbae16b1861606ba19fe670a421e4d43267b41148e07a3" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/47/0b/bdf449df87be3f07b23091ceafee8c3ef569cf6d2fb7edec6e3b12b3faa4/bokeh-3.9.0-py3-none-any.whl", upload-time = 2026-03-11T17:58:31Z, size = 6396068, hashes = { sha256 = "b252bfb16a505f0e0c57d532d0df308ae1667235bafc622aa9441fe9e7c5ce4a" } }]
 
 [[packages]]
 name = "boto3"
-version = "1.42.65"
+version = "1.42.76"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1e/c9/8ff8a901cf62374f1289cf36391f855e1702c70f545c28d1b57608a84ff2/boto3-1.42.65.tar.gz", upload-time = 2026-03-10T19:44:58Z, size = 112805, hashes = { sha256 = "c740af6bdaebcc1a00f3827a5729050bf6fc820ee148bf7d06f28db11c80e2a1" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/46/bb/ace5921655df51e3c9b787b3f0bd6aa25548e5cf1dabae02e53fa88f2d98/boto3-1.42.65-py3-none-any.whl", upload-time = 2026-03-10T19:44:55Z, size = 140556, hashes = { sha256 = "cc7f2e0aec6c68ee5b10232cf3e01326acf6100bc785a770385b61a0474b31f4" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/f0/dc/21b3dfb135125eb7e3a46b9aab0aede847726f239fc8f39474742a87ebb0/boto3-1.42.76-py3-none-any.whl", upload-time = 2026-03-25T19:33:23Z, size = 140557, hashes = { sha256 = "63c6779c814847016b89ae1b72ed968f8a63d80e589ba337511aa6fc1b59585e" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.65"
+version = "1.42.76"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/2e/81/2c832e2117d24da4fe800861e8ddd19bbaa308623b1198eb2c2cc6fcd3d4/botocore-1.42.65.tar.gz", upload-time = 2026-03-10T19:44:43Z, size = 14970239, hashes = { sha256 = "7d52c148df07f70c375eeda58f99b439c7c7836c25df74cccfba3bb6e12444d2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8e/9e/2ca03a55408c0820d7f0a04ae52bc6dfc7e4fff1f007a90135a68e056c93/botocore-1.42.65-py3-none-any.whl", upload-time = 2026-03-10T19:44:37Z, size = 14644794, hashes = { sha256 = "0283c332ce00cbd1b894e86b7bed89dd624a5ca3a4ee62ec4db3898d16652e98" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/70/62/a982acb81c5e0312f90f841b790abad65622c08aad356eed7008ea3d475b/botocore-1.42.76.tar.gz", upload-time = 2026-03-25T19:33:12Z, size = 15021811, hashes = { sha256 = "c553fa0ae29e36a5c407f74da78b78404b81b74b15fb62bf640a3cd9385f0874" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f5/63/7429d68876b7718ab5c4b8a44414de7907f5ba6bb27ccfad384df14fb277/botocore-1.42.76-py3-none-any.whl", upload-time = 2026-03-25T19:33:07Z, size = 14697736, hashes = { sha256 = "151e714ae3c32f68ea0b4dc60751401e03f84a87c6cf864ea0ee64aa10eb4607" } }]
 
 [[packages]]
 name = "certifi"
@@ -321,47 +320,59 @@ wheels = [
 
 [[packages]]
 name = "charset-normalizer"
-version = "3.4.5"
+version = "3.4.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", upload-time = 2026-03-06T06:03:19Z, size = 134804, hashes = { sha256 = "95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644" } }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", upload-time = 2026-03-15T18:53:25Z, size = 143363, hashes = { sha256 = "1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-06T06:01:16Z, size = 189356, hashes = { sha256 = "0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54" } },
-    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-06T06:01:17Z, size = 206369, hashes = { sha256 = "dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467" } },
-    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-06T06:01:19Z, size = 203285, hashes = { sha256 = "ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60" } },
-    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T06:01:20Z, size = 196274, hashes = { sha256 = "7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d" } },
-    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", upload-time = 2026-03-06T06:01:22Z, size = 184715, hashes = { sha256 = "a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e" } },
-    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-06T06:01:23Z, size = 193426, hashes = { sha256 = "754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f" } },
-    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-06T06:01:25Z, size = 191780, hashes = { sha256 = "0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc" } },
-    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", upload-time = 2026-03-06T06:01:26Z, size = 185805, hashes = { sha256 = "c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95" } },
-    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-06T06:01:27Z, size = 208342, hashes = { sha256 = "d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a" } },
-    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", upload-time = 2026-03-06T06:01:29Z, size = 193661, hashes = { sha256 = "19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac" } },
-    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", upload-time = 2026-03-06T06:01:30Z, size = 204819, hashes = { sha256 = "4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1" } },
-    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-06T06:01:31Z, size = 198080, hashes = { sha256 = "a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98" } },
-    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-06T06:01:38Z, size = 188890, hashes = { sha256 = "165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8" } },
-    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-06T06:01:40Z, size = 206136, hashes = { sha256 = "28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d" } },
-    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-06T06:01:41Z, size = 202551, hashes = { sha256 = "d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce" } },
-    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T06:01:43Z, size = 195572, hashes = { sha256 = "0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819" } },
-    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", upload-time = 2026-03-06T06:01:44Z, size = 184438, hashes = { sha256 = "c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d" } },
-    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-06T06:01:46Z, size = 193035, hashes = { sha256 = "e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763" } },
-    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-06T06:01:47Z, size = 191340, hashes = { sha256 = "e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9" } },
-    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", upload-time = 2026-03-06T06:01:48Z, size = 185464, hashes = { sha256 = "597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c" } },
-    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-06T06:01:50Z, size = 208014, hashes = { sha256 = "5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67" } },
-    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", upload-time = 2026-03-06T06:01:51Z, size = 193297, hashes = { sha256 = "2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3" } },
-    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", upload-time = 2026-03-06T06:01:53Z, size = 204321, hashes = { sha256 = "65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf" } },
-    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-06T06:01:56Z, size = 197509, hashes = { sha256 = "c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6" } },
-    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-06T06:02:02Z, size = 189688, hashes = { sha256 = "a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f" } },
-    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-06T06:02:05Z, size = 206833, hashes = { sha256 = "a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4" } },
-    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-06T06:02:06Z, size = 202879, hashes = { sha256 = "d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee" } },
-    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T06:02:08Z, size = 195764, hashes = { sha256 = "01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66" } },
-    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", upload-time = 2026-03-06T06:02:10Z, size = 183728, hashes = { sha256 = "b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362" } },
-    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-06T06:02:11Z, size = 192937, hashes = { sha256 = "e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7" } },
-    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-06T06:02:13Z, size = 192040, hashes = { sha256 = "4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d" } },
-    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", upload-time = 2026-03-06T06:02:14Z, size = 184107, hashes = { sha256 = "d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6" } },
-    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-06T06:02:16Z, size = 208310, hashes = { sha256 = "30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39" } },
-    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", upload-time = 2026-03-06T06:02:18Z, size = 192918, hashes = { sha256 = "d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6" } },
-    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", upload-time = 2026-03-06T06:02:19Z, size = 204615, hashes = { sha256 = "c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94" } },
-    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-06T06:02:21Z, size = 197784, hashes = { sha256 = "1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e" } },
-    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", upload-time = 2026-03-06T06:03:17Z, size = 55455, hashes = { sha256 = "9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0" } },
+    { url = "https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:50:52Z, size = 199191, hashes = { sha256 = "a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21" } },
+    { url = "https://files.pythonhosted.org/packages/6c/92/9934d1bbd69f7f398b38c5dae1cbf9cc672e7c34a4adf7b17c0a9c17d15d/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:50:54Z, size = 218674, hashes = { sha256 = "836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2" } },
+    { url = "https://files.pythonhosted.org/packages/af/90/25f6ab406659286be929fd89ab0e78e38aa183fc374e03aa3c12d730af8a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:50:55Z, size = 215259, hashes = { sha256 = "f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff" } },
+    { url = "https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:50:57Z, size = 207276, hashes = { sha256 = "0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5" } },
+    { url = "https://files.pythonhosted.org/packages/f7/72/d0426afec4b71dc159fa6b4e68f868cd5a3ecd918fec5813a15d292a7d10/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:50:58Z, size = 195161, hashes = { sha256 = "530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0" } },
+    { url = "https://files.pythonhosted.org/packages/bf/18/c82b06a68bfcb6ce55e508225d210c7e6a4ea122bfc0748892f3dc4e8e11/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:51:00Z, size = 203452, hashes = { sha256 = "30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a" } },
+    { url = "https://files.pythonhosted.org/packages/44/d6/0c25979b92f8adafdbb946160348d8d44aa60ce99afdc27df524379875cb/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:51:01Z, size = 202272, hashes = { sha256 = "ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2" } },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/7fea3e8fe84136bebbac715dd1221cc25c173c57a699c030ab9b8900cbb7/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:51:03Z, size = 195622, hashes = { sha256 = "90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5" } },
+    { url = "https://files.pythonhosted.org/packages/57/8a/d6f7fd5cb96c58ef2f681424fbca01264461336d2a7fc875e4446b1f1346/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:51:05Z, size = 220056, hashes = { sha256 = "8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6" } },
+    { url = "https://files.pythonhosted.org/packages/16/50/478cdda782c8c9c3fb5da3cc72dd7f331f031e7f1363a893cdd6ca0f8de0/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:51:06Z, size = 203751, hashes = { sha256 = "695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d" } },
+    { url = "https://files.pythonhosted.org/packages/75/fc/cc2fcac943939c8e4d8791abfa139f685e5150cae9f94b60f12520feaa9b/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:51:08Z, size = 216563, hashes = { sha256 = "231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2" } },
+    { url = "https://files.pythonhosted.org/packages/a8/b7/a4add1d9a5f68f3d037261aecca83abdb0ab15960a3591d340e829b37298/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:51:10Z, size = 209265, hashes = { sha256 = "a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923" } },
+    { url = "https://files.pythonhosted.org/packages/47/7b/20e809b89c69d37be748d98e84dce6820bf663cf19cf6b942c951a3e8f41/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:51:17Z, size = 198527, hashes = { sha256 = "423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843" } },
+    { url = "https://files.pythonhosted.org/packages/37/a6/4f8d27527d59c039dce6f7622593cdcd3d70a8504d87d09eb11e9fdc6062/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:51:18Z, size = 218388, hashes = { sha256 = "d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf" } },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/4770ccb3e491a9bacf1c46cc8b812214fe367c86a96353ccc6daf87b01ec/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:51:20Z, size = 214563, hashes = { sha256 = "d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8" } },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:51:21Z, size = 206587, hashes = { sha256 = "530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9" } },
+    { url = "https://files.pythonhosted.org/packages/7e/70/3def227f1ec56f5c69dfc8392b8bd63b11a18ca8178d9211d7cc5e5e4f27/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:51:23Z, size = 194724, hashes = { sha256 = "a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88" } },
+    { url = "https://files.pythonhosted.org/packages/58/ab/9318352e220c05efd31c2779a23b50969dc94b985a2efa643ed9077bfca5/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:51:25Z, size = 202956, hashes = { sha256 = "34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84" } },
+    { url = "https://files.pythonhosted.org/packages/75/13/f3550a3ac25b70f87ac98c40d3199a8503676c2f1620efbf8d42095cfc40/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:51:26Z, size = 201923, hashes = { sha256 = "5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd" } },
+    { url = "https://files.pythonhosted.org/packages/1b/db/c5c643b912740b45e8eec21de1bbab8e7fc085944d37e1e709d3dcd9d72f/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:51:28Z, size = 195366, hashes = { sha256 = "80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c" } },
+    { url = "https://files.pythonhosted.org/packages/5a/67/3b1c62744f9b2448443e0eb160d8b001c849ec3fef591e012eda6484787c/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:51:29Z, size = 219752, hashes = { sha256 = "92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194" } },
+    { url = "https://files.pythonhosted.org/packages/f6/98/32ffbaf7f0366ffb0445930b87d103f6b406bc2c271563644bde8a2b1093/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:51:30Z, size = 203296, hashes = { sha256 = "613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc" } },
+    { url = "https://files.pythonhosted.org/packages/41/12/5d308c1bbe60cabb0c5ef511574a647067e2a1f631bc8634fcafaccd8293/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:51:32Z, size = 215956, hashes = { sha256 = "2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f" } },
+    { url = "https://files.pythonhosted.org/packages/53/e9/5f85f6c5e20669dbe56b165c67b0260547dea97dba7e187938833d791687/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:51:34Z, size = 208652, hashes = { sha256 = "6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2" } },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:51:42Z, size = 199277, hashes = { sha256 = "ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421" } },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:51:44Z, size = 218758, hashes = { sha256 = "b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2" } },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:51:45Z, size = 215299, hashes = { sha256 = "5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30" } },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:51:47Z, size = 206811, hashes = { sha256 = "7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db" } },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:51:48Z, size = 193706, hashes = { sha256 = "bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8" } },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:51:50Z, size = 202706, hashes = { sha256 = "22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815" } },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:51:52Z, size = 202497, hashes = { sha256 = "7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a" } },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:51:53Z, size = 193511, hashes = { sha256 = "7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43" } },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:51:55Z, size = 220133, hashes = { sha256 = "58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0" } },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:51:56Z, size = 203035, hashes = { sha256 = "419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1" } },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:51:58Z, size = 216321, hashes = { sha256 = "5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f" } },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:51:59Z, size = 208973, hashes = { sha256 = "0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815" } },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:52:08Z, size = 208138, hashes = { sha256 = "f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc" } },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:52:10Z, size = 224679, hashes = { sha256 = "06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e" } },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:52:11Z, size = 223475, hashes = { sha256 = "e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077" } },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:52:13Z, size = 215230, hashes = { sha256 = "95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f" } },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:52:14Z, size = 199045, hashes = { sha256 = "7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e" } },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:52:16Z, size = 211658, hashes = { sha256 = "172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484" } },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:52:17Z, size = 210769, hashes = { sha256 = "4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7" } },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:52:19Z, size = 201328, hashes = { sha256 = "79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff" } },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:52:21Z, size = 225302, hashes = { sha256 = "87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e" } },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:52:22Z, size = 211127, hashes = { sha256 = "fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659" } },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:52:24Z, size = 222840, hashes = { sha256 = "ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602" } },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:52:25Z, size = 216890, hashes = { sha256 = "197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407" } },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", upload-time = 2026-03-15T18:53:23Z, size = 61455, hashes = { sha256 = "947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69" } },
 ]
 
 [[packages]]
@@ -583,10 +594,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", upload-time = 2026-03-09T19:38:47Z, size = 40319, hashes = { sha256 = "b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", upload-time = 2026-03-09T19:38:45Z, size = 26720, hashes = { sha256 = "18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", upload-time = 2026-03-11T20:45:38Z, size = 40480, hashes = { sha256 = "b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", upload-time = 2026-03-11T20:45:37Z, size = 26759, hashes = { sha256 = "ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70" } }]
 
 [[packages]]
 name = "flatbuffers"
@@ -596,27 +607,27 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be0164
 
 [[packages]]
 name = "fonttools"
-version = "4.62.0"
+version = "4.62.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/5a/96/686339e0fda8142b7ebed39af53f4a5694602a729662f42a6209e3be91d0/fonttools-4.62.0.tar.gz", upload-time = 2026-03-09T16:50:06Z, size = 3579521, hashes = { sha256 = "0dc477c12b8076b4eb9af2e440421b0433ffa9e1dcb39e0640a6c94665ed1098" } }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", upload-time = 2026-03-13T13:54:25Z, size = 3580737, hashes = { sha256 = "e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/8c/c52a4310de58deeac7e9ea800892aec09b00bb3eb0c53265b31ec02be115/fonttools-4.62.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:48:55Z, size = 5032975, hashes = { sha256 = "d732938633681d6e2324e601b79e93f7f72395ec8681f9cdae5a8c08bc167e72" } },
-    { url = "https://files.pythonhosted.org/packages/0b/a1/d16318232964d786907b9b3613b8409f74cf0be2da400854509d3a864e43/fonttools-4.62.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:48:57Z, size = 4988544, hashes = { sha256 = "31a804c16d76038cc4e3826e07678efb0a02dc4f15396ea8e07088adbfb2578e" } },
-    { url = "https://files.pythonhosted.org/packages/b2/8d/7e745ca3e65852adc5e52a83dc213fe1b07d61cb5b394970fcd4b1199d1e/fonttools-4.62.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:48:59Z, size = 4971296, hashes = { sha256 = "090e74ac86e68c20150e665ef8e7e0c20cb9f8b395302c9419fa2e4d332c3b51" } },
-    { url = "https://files.pythonhosted.org/packages/e6/d4/b717a4874175146029ca1517e85474b1af80c9d9a306fc3161e71485eea5/fonttools-4.62.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:02Z, size = 5122503, hashes = { sha256 = "8f086120e8be9e99ca1288aa5ce519833f93fe0ec6ebad2380c1dee18781f0b5" } },
-    { url = "https://files.pythonhosted.org/packages/5f/ac/8e300dbf7b4d135287c261ffd92ede02d9f48f0d2db14665fbc8b059588a/fonttools-4.62.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:49:14Z, size = 5013708, hashes = { sha256 = "83c6524c5b93bad9c2939d88e619fedc62e913c19e673f25d5ab74e7a5d074e5" } },
-    { url = "https://files.pythonhosted.org/packages/fb/bc/60d93477b653eeb1ddf5f9ec34be689b79234d82dbdded269ac0252715b8/fonttools-4.62.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:49:16Z, size = 4964355, hashes = { sha256 = "106aec9226f9498fc5345125ff7200842c01eda273ae038f5049b0916907acee" } },
-    { url = "https://files.pythonhosted.org/packages/cb/eb/6dc62bcc3c3598c28a3ecb77e69018869c3e109bd83031d4973c059d318b/fonttools-4.62.0-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:49:18Z, size = 4953472, hashes = { sha256 = "15d86b96c79013320f13bc1b15f94789edb376c0a2d22fb6088f33637e8dfcbc" } },
-    { url = "https://files.pythonhosted.org/packages/82/b3/3af7592d9b254b7b7fec018135f8776bfa0d1ad335476c2791b1334dc5e4/fonttools-4.62.0-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:21Z, size = 5094701, hashes = { sha256 = "4f16c07e5250d5d71d0f990a59460bc5620c3cc456121f2cfb5b60475699905f" } },
-    { url = "https://files.pythonhosted.org/packages/6f/86/db65b63bb1b824b63e602e9be21b18741ddc99bcf5a7850f9181159ae107/fonttools-4.62.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:49:32Z, size = 4999387, hashes = { sha256 = "6247e58b96b982709cd569a91a2ba935d406dccf17b6aa615afaed37ac3856aa" } },
-    { url = "https://files.pythonhosted.org/packages/86/c8/c6669e42d2f4efd60d38a3252cebbb28851f968890efb2b9b15f9d1092b0/fonttools-4.62.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:49:34Z, size = 4912506, hashes = { sha256 = "840632ea9c1eab7b7f01c369e408c0721c287dfd7500ab937398430689852fd1" } },
-    { url = "https://files.pythonhosted.org/packages/2e/49/0ae552aa098edd0ec548413fbf818f52ceb70535016215094a5ce9bf8f70/fonttools-4.62.0-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:49:37Z, size = 4951202, hashes = { sha256 = "28a9ea2a7467a816d1bec22658b0cce4443ac60abac3e293bdee78beb74588f3" } },
-    { url = "https://files.pythonhosted.org/packages/71/65/ae38fc8a4cea6f162d74cf11f58e9aeef1baa7d0e3d1376dabd336c129e5/fonttools-4.62.0-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:39Z, size = 5060758, hashes = { sha256 = "5ae611294f768d413949fd12693a8cba0e6332fbc1e07aba60121be35eac68d0" } },
-    { url = "https://files.pythonhosted.org/packages/2b/df/bfaa0e845884935355670e6e68f137185ab87295f8bc838db575e4a66064/fonttools-4.62.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:49:50Z, size = 5137378, hashes = { sha256 = "b448075f32708e8fb377fe7687f769a5f51a027172c591ba9a58693631b077a8" } },
-    { url = "https://files.pythonhosted.org/packages/32/32/04f616979a18b48b52e634988b93d847b6346260faf85ecccaf7e2e9057f/fonttools-4.62.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:49:53Z, size = 4920714, hashes = { sha256 = "e5f1fa8cc9f1a56a3e33ee6b954d6d9235e6b9d11eb7a6c9dfe2c2f829dc24db" } },
-    { url = "https://files.pythonhosted.org/packages/3b/2e/274e16689c1dfee5c68302cd7c444213cfddd23cf4620374419625037ec6/fonttools-4.62.0-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:49:55Z, size = 5016012, hashes = { sha256 = "f8c8ea812f82db1e884b9cdb663080453e28f0f9a1f5027a5adb59c4cc8d38d1" } },
-    { url = "https://files.pythonhosted.org/packages/7f/0c/b08117270626e7117ac2f89d732fdd4386ec37d2ab3a944462d29e6f89a1/fonttools-4.62.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:57Z, size = 5042766, hashes = { sha256 = "03c6068adfdc67c565d217e92386b1cdd951abd4240d65180cec62fa74ba31b2" } },
-    { url = "https://files.pythonhosted.org/packages/9c/57/c2487c281dde03abb2dec244fd67059b8d118bd30a653cbf69e94084cb23/fonttools-4.62.0-py3-none-any.whl", upload-time = 2026-03-09T16:50:04Z, size = 1152427, hashes = { sha256 = "75064f19a10c50c74b336aa5ebe7b1f89fd0fb5255807bfd4b0c6317098f4af3" } },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:52:59Z, size = 5033197, hashes = { sha256 = "9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936" } },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:53:02Z, size = 4988768, hashes = { sha256 = "149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392" } },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:53:05Z, size = 4971512, hashes = { sha256 = "0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04" } },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:53:08Z, size = 5122723, hashes = { sha256 = "19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d" } },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:53:21Z, size = 5013926, hashes = { sha256 = "ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68" } },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:53:23Z, size = 4964575, hashes = { sha256 = "6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1" } },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:53:26Z, size = 4953693, hashes = { sha256 = "2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069" } },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:53:29Z, size = 5094920, hashes = { sha256 = "403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9" } },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:53:42Z, size = 4999608, hashes = { sha256 = "bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782" } },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:53:45Z, size = 4912726, hashes = { sha256 = "8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae" } },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:53:48Z, size = 4951422, hashes = { sha256 = "d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7" } },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:53:51Z, size = 5060979, hashes = { sha256 = "c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a" } },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:54:04Z, size = 5137599, hashes = { sha256 = "ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4" } },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:54:07Z, size = 4920933, hashes = { sha256 = "5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b" } },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:54:10Z, size = 5016232, hashes = { sha256 = "92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87" } },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:54:13Z, size = 5042987, hashes = { sha256 = "bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c" } },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", upload-time = 2026-03-13T13:54:22Z, size = 1152647, hashes = { sha256 = "7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd" } },
 ]
 
 [[packages]]
@@ -729,10 +740,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/7d/59/7371175bfd949abfb1170aa076352131d7281bd9449c0f978604fc4431c3/google_auth-2.49.0.tar.gz", upload-time = 2026-03-06T21:53:06Z, size = 333444, hashes = { sha256 = "9cc2d9259d3700d7a257681f81052db6737495a1a46b610597f4b8bafe5286ae" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/37/45/de64b823b639103de4b63dd193480dce99526bd36be6530c2dba85bf7817/google_auth-2.49.0-py3-none-any.whl", upload-time = 2026-03-06T21:52:38Z, size = 240676, hashes = { sha256 = "f893ef7307f19cf53700b7e2f61b5a6affe3aa0edf9943b13788920ab92d8d87" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", upload-time = 2026-03-12T19:30:58Z, size = 333825, hashes = { sha256 = "16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", upload-time = 2026-03-12T19:30:53Z, size = 240737, hashes = { sha256 = "195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -950,10 +961,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/d7/9e/038522f50ceb7e7
 
 [[packages]]
 name = "jsonpointer"
-version = "3.0.0"
+version = "3.1.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", upload-time = 2024-06-10T19:24:42Z, size = 9114, hashes = { sha256 = "2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", upload-time = 2024-06-10T19:24:40Z, size = 7595, hashes = { sha256 = "13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", upload-time = 2026-03-23T22:32:32Z, size = 9068, hashes = { sha256 = "0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", upload-time = 2026-03-23T22:32:31Z, size = 7659, hashes = { sha256 = "8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca" } }]
 
 [[packages]]
 name = "jsonschema"
@@ -1041,10 +1052,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/6e/2d/953a5612a34a3c799a62566a548e711d103f631672fd49650e0f2de80870/jupyterlab-4.5.5.tar.gz", upload-time = 2026-02-23T18:57:34Z, size = 23968441, hashes = { sha256 = "eac620698c59eb810e1729909be418d9373d18137cac66637141abba613b3fda" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b9/52/372d3494766d690dfdd286871bf5f7fb9a6c61f7566ccaa7153a163dd1df/jupyterlab-4.5.5-py3-none-any.whl", upload-time = 2026-02-23T18:57:30Z, size = 12446824, hashes = { sha256 = "a35694a40a8e7f2e82f387472af24e61b22adcce87b5a8ab97a5d9c486202a6d" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/d5/730628e03fff2e8a8e8ccdaedde1489ab1309f9a4fa2536248884e30b7c7/jupyterlab-4.5.6.tar.gz", upload-time = 2026-03-11T14:17:04Z, size = 23970670, hashes = { sha256 = "642fe2cfe7f0f5922a8a558ba7a0d246c7bc133b708dfe43f7b3a826d163cf42" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e1/1b/dad6fdcc658ed7af26fdf3841e7394072c9549a8b896c381ab49dd11e2d9/jupyterlab-4.5.6-py3-none-any.whl", upload-time = 2026-03-11T14:17:00Z, size = 12447124, hashes = { sha256 = "d6b3dac883aa4d9993348e0f8e95b24624f75099aed64eab6a4351a9cdd1e580" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -1472,10 +1483,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409c
 
 [[packages]]
 name = "narwhals"
-version = "2.18.0"
+version = "2.18.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/47/b4/02a8add181b8d2cd5da3b667cd102ae536e8c9572ab1a130816d70a89edb/narwhals-2.18.0.tar.gz", upload-time = 2026-03-10T15:51:27Z, size = 620222, hashes = { sha256 = "1de5cee338bc17c338c6278df2c38c0dd4290499fcf70d75e0a51d5f22a6e960" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl", upload-time = 2026-03-10T15:51:24Z, size = 444865, hashes = { sha256 = "68378155ee706ac9c5b25868ef62ecddd62947b6df7801a0a156bc0a615d2d0d" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/59/96/45218c2fdec4c9f22178f905086e85ef1a6d63862dcc3cd68eb60f1867f5/narwhals-2.18.1.tar.gz", upload-time = 2026-03-24T15:11:25Z, size = 620578, hashes = { sha256 = "652a1fcc9d432bbf114846688884c215f17eb118aa640b7419295d2f910d2a8b" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl", upload-time = 2026-03-24T15:11:23Z, size = 444952, hashes = { sha256 = "a0a8bb80205323851338888ba3a12b4f65d352362c8a94be591244faf36504ad" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1991,10 +2002,10 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", upload-time = 2026-01-16T18:04:18Z, size = 146586, hashes = { sha256 = "9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", upload-time = 2026-01-16T18:04:17Z, size = 83371, hashes = { sha256 = "1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"
@@ -2092,10 +2103,10 @@ wheels = [
 
 [[packages]]
 name = "pygithub"
-version = "2.8.1"
+version = "2.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/c1/74/e560bdeffea72ecb26cff27f0fad548bbff5ecc51d6a155311ea7f9e4c4c/pygithub-2.8.1.tar.gz", upload-time = 2025-09-02T17:41:54Z, size = 2246994, hashes = { sha256 = "341b7c78521cb07324ff670afd1baa2bf5c286f8d9fd302c1798ba594a5400c9" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/07/ba/7049ce39f653f6140aac4beb53a5aaf08b4407b6a3019aae394c1c5244ff/pygithub-2.8.1-py3-none-any.whl", upload-time = 2025-09-02T17:41:52Z, size = 432709, hashes = { sha256 = "23a0a5bca93baef082e03411bf0ce27204c32be8bfa7abc92fe4a3e132936df0" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/9a/44f918e9be12e49cb8b053f09d5d0733b74df52bf4dabc570da1c3ecd9f6/pygithub-2.9.0.tar.gz", upload-time = 2026-03-22T21:14:39Z, size = 2592289, hashes = { sha256 = "a26abda1222febba31238682634cad11d8b966137ed6cc3c5e445b29a11cb0a4" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/2f/de/72e02bc7674e161b155a4b5a03b2347129d0626115bc97ba5bad5070cac9/pygithub-2.9.0-py3-none-any.whl", upload-time = 2026-03-22T21:14:37Z, size = 449653, hashes = { sha256 = "5e2b260ce327bffce9b00f447b65953ef7078ffe93e5a5425624a3075483927c" } }]
 
 [[packages]]
 name = "pygments"
@@ -2106,10 +2117,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", upload-time = 2026-01-30T19:59:55Z, size = 98019, hashes = { sha256 = "35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", upload-time = 2026-01-30T19:59:54Z, size = 28224, hashes = { sha256 = "94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", upload-time = 2026-03-13T19:27:37Z, size = 102564, hashes = { sha256 = "c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", upload-time = 2026-03-13T19:27:35Z, size = 29726, hashes = { sha256 = "28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c" } }]
 
 [[packages]]
 name = "pymongo"
@@ -2203,10 +2214,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a79
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.3"
+version = "1.2.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/d7/7e/9f3b0dd3a074a6c3e1e79f35e465b1f2ee4b262d619de00cfce523cc9b24/python_discovery-1.1.3.tar.gz", upload-time = 2026-03-10T15:08:15Z, size = 56945, hashes = { sha256 = "7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl", upload-time = 2026-03-10T15:08:13Z, size = 31485, hashes = { sha256 = "90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/90/bcce6b46823c9bec1757c964dc37ed332579be512e17a30e9698095dcae4/python_discovery-1.2.0.tar.gz", upload-time = 2026-03-19T01:43:08Z, size = 58055, hashes = { sha256 = "7d33e350704818b09e3da2bd419d37e21e7c30db6e0977bb438916e06b41b5b1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl", upload-time = 2026-03-19T01:43:07Z, size = 31524, hashes = { sha256 = "1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a" } }]
 
 [[packages]]
 name = "python-json-logger"
@@ -2331,10 +2342,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93e
 
 [[packages]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", upload-time = 2025-08-18T20:46:02Z, size = 134517, hashes = { sha256 = "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", upload-time = 2025-08-18T20:46:00Z, size = 64738, hashes = { sha256 = "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", upload-time = 2026-03-25T15:10:41Z, size = 134232, hashes = { sha256 = "c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", upload-time = 2026-03-25T15:10:40Z, size = 65017, hashes = { sha256 = "3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b" } }]
 
 [[packages]]
 name = "requests-oauthlib"
@@ -2442,13 +2453,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", upload-time = 2025-11-30T20:24:08Z, size = 591148, hashes = { sha256 = "3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856" } },
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2025-11-30T20:24:10Z, size = 556030, hashes = { sha256 = "dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", upload-time = 2025-04-16T09:51:18Z, size = 29034, hashes = { sha256 = "e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", upload-time = 2025-04-16T09:51:17Z, size = 34696, hashes = { sha256 = "68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762" } }]
 
 [[packages]]
 name = "ruamel-yaml"
@@ -2692,34 +2696,36 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6
 
 [[packages]]
 name = "ujson"
-version = "5.11.0"
+version = "5.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/43/d9/3f17e3c5773fb4941c68d9a37a47b1a79c9649d6c56aefbed87cc409d18a/ujson-5.11.0.tar.gz", upload-time = 2025-08-20T11:57:02Z, size = 7156583, hashes = { sha256 = "e204ae6f909f099ba6b6b942131cee359ddda2b6e4ea39c12eb8b991fe2010e0" } }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/3e/c35530c5ffc25b71c59ae0cd7b8f99df37313daa162ce1e2f7925f7c2877/ujson-5.12.0.tar.gz", upload-time = 2026-03-11T22:19:30Z, size = 7158451, hashes = { sha256 = "14b2e1eb528d77bc0f4c5bd1a7ebc05e02b5b41beefb7e8567c9675b8b13bcf4" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/3c/fd11a224f73fbffa299fb9644e425f38b38b30231f7923a088dd513aabb4/ujson-5.11.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2025-08-20T11:55:37Z, size = 57600, hashes = { sha256 = "0180a480a7d099082501cad1fe85252e4d4bf926b40960fb3d9e87a3a6fbbc80" } },
-    { url = "https://files.pythonhosted.org/packages/55/b9/405103cae24899df688a3431c776e00528bd4799e7d68820e7ebcf824f92/ujson-5.11.0-cp312-cp312-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2025-08-20T11:55:38Z, size = 59791, hashes = { sha256 = "fa79fdb47701942c2132a9dd2297a1a85941d966d8c87bfd9e29b0cf423f26cc" } },
-    { url = "https://files.pythonhosted.org/packages/17/7b/2dcbc2bbfdbf68f2368fb21ab0f6735e872290bb604c75f6e06b81edcb3f/ujson-5.11.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-08-20T11:55:40Z, size = 57356, hashes = { sha256 = "8254e858437c00f17cb72e7a644fc42dad0ebb21ea981b71df6e84b1072aaa7c" } },
-    { url = "https://files.pythonhosted.org/packages/d1/71/fea2ca18986a366c750767b694430d5ded6b20b6985fddca72f74af38a4c/ujson-5.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2025-08-20T11:55:41Z, size = 1036313, hashes = { sha256 = "1aa8a2ab482f09f6c10fba37112af5f957689a79ea598399c85009f2f29898b5" } },
-    { url = "https://files.pythonhosted.org/packages/a3/bb/d4220bd7532eac6288d8115db51710fa2d7d271250797b0bfba9f1e755af/ujson-5.11.0-cp312-cp312-musllinux_1_2_i686.whl", upload-time = 2025-08-20T11:55:43Z, size = 1195782, hashes = { sha256 = "a638425d3c6eed0318df663df44480f4a40dc87cc7c6da44d221418312f6413b" } },
-    { url = "https://files.pythonhosted.org/packages/80/47/226e540aa38878ce1194454385701d82df538ccb5ff8db2cf1641dde849a/ujson-5.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2025-08-20T11:55:45Z, size = 1088817, hashes = { sha256 = "7e3cff632c1d78023b15f7e3a81c3745cd3f94c044d1e8fa8efbd6b161997bbc" } },
-    { url = "https://files.pythonhosted.org/packages/e9/c5/c161940967184de96f5cbbbcce45b562a4bf851d60f4c677704b1770136d/ujson-5.11.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2025-08-20T11:55:52Z, size = 57603, hashes = { sha256 = "78c684fb21255b9b90320ba7e199780f653e03f6c2528663768965f4126a5b50" } },
-    { url = "https://files.pythonhosted.org/packages/2b/d6/c7b2444238f5b2e2d0e3dab300b9ddc3606e4b1f0e4bed5a48157cebc792/ujson-5.11.0-cp313-cp313-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2025-08-20T11:55:53Z, size = 59794, hashes = { sha256 = "4c9f5d6a27d035dd90a146f7761c2272cf7103de5127c9ab9c4cd39ea61e878a" } },
-    { url = "https://files.pythonhosted.org/packages/fe/a3/292551f936d3d02d9af148f53e1bc04306b00a7cf1fcbb86fa0d1c887242/ujson-5.11.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-08-20T11:55:54Z, size = 57363, hashes = { sha256 = "837da4d27fed5fdc1b630bd18f519744b23a0b5ada1bbde1a36ba463f2900c03" } },
-    { url = "https://files.pythonhosted.org/packages/90/a6/82cfa70448831b1a9e73f882225980b5c689bf539ec6400b31656a60ea46/ujson-5.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2025-08-20T11:55:56Z, size = 1036311, hashes = { sha256 = "787aff4a84da301b7f3bac09bc696e2e5670df829c6f8ecf39916b4e7e24e701" } },
-    { url = "https://files.pythonhosted.org/packages/84/5c/96e2266be50f21e9b27acaee8ca8f23ea0b85cb998c33d4f53147687839b/ujson-5.11.0-cp313-cp313-musllinux_1_2_i686.whl", upload-time = 2025-08-20T11:55:58Z, size = 1195783, hashes = { sha256 = "6dd703c3e86dc6f7044c5ac0b3ae079ed96bf297974598116aa5fb7f655c3a60" } },
-    { url = "https://files.pythonhosted.org/packages/8d/20/78abe3d808cf3bb3e76f71fca46cd208317bf461c905d79f0d26b9df20f1/ujson-5.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2025-08-20T11:55:59Z, size = 1088822, hashes = { sha256 = "3772e4fe6b0c1e025ba3c50841a0ca4786825a4894c8411bf8d3afe3a8061328" } },
-    { url = "https://files.pythonhosted.org/packages/9b/f8/25583c70f83788edbe3ca62ce6c1b79eff465d78dec5eb2b2b56b3e98b33/ujson-5.11.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2025-08-20T11:56:07Z, size = 57631, hashes = { sha256 = "c44c703842024d796b4c78542a6fcd5c3cb948b9fc2a73ee65b9c86a22ee3638" } },
-    { url = "https://files.pythonhosted.org/packages/ed/ca/19b3a632933a09d696f10dc1b0dfa1d692e65ad507d12340116ce4f67967/ujson-5.11.0-cp314-cp314-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2025-08-20T11:56:08Z, size = 59877, hashes = { sha256 = "e750c436fb90edf85585f5c62a35b35082502383840962c6983403d1bd96a02c" } },
-    { url = "https://files.pythonhosted.org/packages/55/7a/4572af5324ad4b2bfdd2321e898a527050290147b4ea337a79a0e4e87ec7/ujson-5.11.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-08-20T11:56:09Z, size = 57363, hashes = { sha256 = "f278b31a7c52eb0947b2db55a5133fbc46b6f0ef49972cd1a80843b72e135aba" } },
-    { url = "https://files.pythonhosted.org/packages/7b/71/a2b8c19cf4e1efe53cf439cdf7198ac60ae15471d2f1040b490c1f0f831f/ujson-5.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2025-08-20T11:56:11Z, size = 1036394, hashes = { sha256 = "ab2cb8351d976e788669c8281465d44d4e94413718af497b4e7342d7b2f78018" } },
-    { url = "https://files.pythonhosted.org/packages/7a/3e/7b98668cba3bb3735929c31b999b374ebc02c19dfa98dfebaeeb5c8597ca/ujson-5.11.0-cp314-cp314-musllinux_1_2_i686.whl", upload-time = 2025-08-20T11:56:12Z, size = 1195837, hashes = { sha256 = "090b4d11b380ae25453100b722d0609d5051ffe98f80ec52853ccf8249dfd840" } },
-    { url = "https://files.pythonhosted.org/packages/a1/ea/8870f208c20b43571a5c409ebb2fe9b9dba5f494e9e60f9314ac01ea8f78/ujson-5.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2025-08-20T11:56:14Z, size = 1088837, hashes = { sha256 = "80017e870d882d5517d28995b62e4e518a894f932f1e242cbc802a2fd64d365c" } },
-    { url = "https://files.pythonhosted.org/packages/ae/e9/fb4a220ee6939db099f4cfeeae796ecb91e7584ad4d445d4ca7f994a9135/ujson-5.11.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2025-08-20T11:56:21Z, size = 58547, hashes = { sha256 = "1a325fd2c3a056cf6c8e023f74a0c478dd282a93141356ae7f16d5309f5ff823" } },
-    { url = "https://files.pythonhosted.org/packages/bd/f8/fc4b952b8f5fea09ea3397a0bd0ad019e474b204cabcb947cead5d4d1ffc/ujson-5.11.0-cp314-cp314t-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2025-08-20T11:56:22Z, size = 60489, hashes = { sha256 = "a0af6574fc1d9d53f4ff371f58c96673e6d988ed2b5bf666a6143c782fa007e9" } },
-    { url = "https://files.pythonhosted.org/packages/2e/e5/af5491dfda4f8b77e24cf3da68ee0d1552f99a13e5c622f4cef1380925c3/ujson-5.11.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2025-08-20T11:56:23Z, size = 58035, hashes = { sha256 = "10f29e71ecf4ecd93a6610bd8efa8e7b6467454a363c3d6416db65de883eb076" } },
-    { url = "https://files.pythonhosted.org/packages/c4/09/0945349dd41f25cc8c38d78ace49f14c5052c5bbb7257d2f466fa7bdb533/ujson-5.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2025-08-20T11:56:25Z, size = 1037212, hashes = { sha256 = "1a0a9b76a89827a592656fe12e000cf4f12da9692f51a841a4a07aa4c7ecc41c" } },
-    { url = "https://files.pythonhosted.org/packages/49/44/8e04496acb3d5a1cbee3a54828d9652f67a37523efa3d3b18a347339680a/ujson-5.11.0-cp314-cp314t-musllinux_1_2_i686.whl", upload-time = 2025-08-20T11:56:27Z, size = 1196500, hashes = { sha256 = "b16930f6a0753cdc7d637b33b4e8f10d5e351e1fb83872ba6375f1e87be39746" } },
-    { url = "https://files.pythonhosted.org/packages/64/ae/4bc825860d679a0f208a19af2f39206dfd804ace2403330fdc3170334a2f/ujson-5.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2025-08-20T11:56:29Z, size = 1089487, hashes = { sha256 = "04c41afc195fd477a59db3a84d5b83a871bd648ef371cf8c6f43072d89144eef" } },
+    { url = "https://files.pythonhosted.org/packages/9a/10/853c723bcabc3e9825a079019055fc99e71b85c6bae600607a2b9d31d18d/ujson-5.12.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-11T22:18:20Z, size = 57754, hashes = { sha256 = "a2d79c6635ccffcbfc1d5c045874ba36b594589be81d50d43472570bb8de9c57" } },
+    { url = "https://files.pythonhosted.org/packages/f9/c6/6e024830d988f521f144ead641981c1f7a82c17ad1927c22de3242565f5c/ujson-5.12.0-cp312-cp312-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2026-03-11T22:18:21Z, size = 59936, hashes = { sha256 = "7e07f6f644d2c44d53b7a320a084eef98063651912c1b9449b5f45fcbdc6ccd2" } },
+    { url = "https://files.pythonhosted.org/packages/34/c9/c5f236af5abe06b720b40b88819d00d10182d2247b1664e487b3ed9229cf/ujson-5.12.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-11T22:18:22Z, size = 57463, hashes = { sha256 = "085b6ce182cdd6657481c7c4003a417e0655c4f6e58b76f26ee18f0ae21db827" } },
+    { url = "https://files.pythonhosted.org/packages/ae/04/41342d9ef68e793a87d84e4531a150c2b682f3bcedfe59a7a5e3f73e9213/ujson-5.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-11T22:18:24Z, size = 1037239, hashes = { sha256 = "16b4fe9c97dc605f5e1887a9e1224287291e35c56cbc379f8aa44b6b7bcfe2bb" } },
+    { url = "https://files.pythonhosted.org/packages/d4/81/dc2b7617d5812670d4ff4a42f6dd77926430ee52df0dedb2aec7990b2034/ujson-5.12.0-cp312-cp312-musllinux_1_2_i686.whl", upload-time = 2026-03-11T22:18:25Z, size = 1196713, hashes = { sha256 = "0d2e8db5ade3736a163906154ca686203acc7d1d30736cbf577c730d13653d84" } },
+    { url = "https://files.pythonhosted.org/packages/b6/9c/80acff0504f92459ed69e80a176286e32ca0147ac6a8252cd0659aad3227/ujson-5.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-11T22:18:26Z, size = 1089742, hashes = { sha256 = "93bc91fdadcf046da37a214eaa714574e7e9b1913568e93bb09527b2ceb7f759" } },
+    { url = "https://files.pythonhosted.org/packages/e5/a9/f96376818d71495d1a4be19a0ab6acf0cc01dd8826553734c3d4dac685b2/ujson-5.12.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-11T22:18:33Z, size = 57757, hashes = { sha256 = "7bbf05c38debc90d1a195b11340cc85cb43ab3e753dc47558a3a84a38cbc72da" } },
+    { url = "https://files.pythonhosted.org/packages/98/8d/dd4a151caac6fdcb77f024fbe7f09d465ebf347a628ed6dd581a0a7f6364/ujson-5.12.0-cp313-cp313-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2026-03-11T22:18:35Z, size = 59940, hashes = { sha256 = "3c2f947e55d3c7cfe124dd4521ee481516f3007d13c6ad4bf6aeb722e190eb1b" } },
+    { url = "https://files.pythonhosted.org/packages/c7/17/0d36c2fee0a8d8dc37b011ccd5bbdcfaff8b8ec2bcfc5be998661cdc935b/ujson-5.12.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-11T22:18:36Z, size = 57465, hashes = { sha256 = "2ea6206043385343aff0b7da65cf73677f6f5e50de8f1c879e557f4298cac36a" } },
+    { url = "https://files.pythonhosted.org/packages/8c/04/b0ee4a4b643a01ba398441da1e357480595edb37c6c94c508dbe0eb9eb60/ujson-5.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-11T22:18:37Z, size = 1037236, hashes = { sha256 = "bb349dbba57c76eec25e5917e07f35aabaf0a33b9e67fc13d188002500106487" } },
+    { url = "https://files.pythonhosted.org/packages/2d/08/0e7780d0bbb48fe57ded91f550144bcc99c03b5360bf2886dd0dae0ea8f5/ujson-5.12.0-cp313-cp313-musllinux_1_2_i686.whl", upload-time = 2026-03-11T22:18:39Z, size = 1196717, hashes = { sha256 = "937794042342006f707837f38d721426b11b0774d327a2a45c0bd389eb750a87" } },
+    { url = "https://files.pythonhosted.org/packages/ba/4c/e0e34107715bb4dd2d4dcc1ce244d2f074638837adf38aff85a37506efe4/ujson-5.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-11T22:18:40Z, size = 1089748, hashes = { sha256 = "6ad57654570464eb1b040b5c353dee442608e06cff9102b8fcb105565a44c9ed" } },
+    { url = "https://files.pythonhosted.org/packages/bf/8b/e2f09e16dabfa91f6a84555df34a4329fa7621e92ed054d170b9054b9bb2/ujson-5.12.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-11T22:18:48Z, size = 57783, hashes = { sha256 = "99cc80facad240b0c2fb5a633044420878aac87a8e7c348b9486450cba93f27c" } },
+    { url = "https://files.pythonhosted.org/packages/68/fb/ba1d06f3658a0c36d0ab3869ec3914f202bad0a9bde92654e41516c7bb13/ujson-5.12.0-cp314-cp314-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2026-03-11T22:18:49Z, size = 60011, hashes = { sha256 = "d1831c07bd4dce53c4b666fa846c7eba4b7c414f2e641a4585b7f50b72f502dc" } },
+    { url = "https://files.pythonhosted.org/packages/64/2b/3e322bf82d926d9857206cd5820438d78392d1f523dacecb8bd899952f73/ujson-5.12.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-11T22:18:50Z, size = 57465, hashes = { sha256 = "0e00cec383eab2406c9e006bd4edb55d284e94bb943fda558326048178d26961" } },
+    { url = "https://files.pythonhosted.org/packages/e9/fd/af72d69603f9885e5136509a529a4f6d88bf652b457263ff96aefcd3ab7d/ujson-5.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-11T22:18:51Z, size = 1037275, hashes = { sha256 = "f19b3af31d02a2e79c5f9a6deaab0fb3c116456aeb9277d11720ad433de6dfc6" } },
+    { url = "https://files.pythonhosted.org/packages/9c/a7/a2411ec81aef7872578e56304c3e41b3a544a9809e95c8e1df46923fc40b/ujson-5.12.0-cp314-cp314-musllinux_1_2_i686.whl", upload-time = 2026-03-11T22:18:53Z, size = 1196758, hashes = { sha256 = "bacbd3c69862478cbe1c7ed4325caedec580d8acf31b8ee1b9a1e02a56295cad" } },
+    { url = "https://files.pythonhosted.org/packages/ed/85/aa18ae175dd03a118555aa14304d4f466f9db61b924c97c6f84388ecacb1/ujson-5.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-11T22:18:55Z, size = 1089760, hashes = { sha256 = "94c5f1621cbcab83c03be46441f090b68b9f307b6c7ec44d4e3f6d5997383df4" } },
+    { url = "https://files.pythonhosted.org/packages/db/2e/60114a35d1d6796eb428f7affcba00a921831ff604a37d9142c3d8bbe5c5/ujson-5.12.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-11T22:19:01Z, size = 58689, hashes = { sha256 = "d30ad4359413c8821cc7b3707f7ca38aa8bc852ba3b9c5a759ee2d7740157315" } },
+    { url = "https://files.pythonhosted.org/packages/c8/ad/010925c2116c21ce119f9c2ff18d01f48a19ade3ff4c5795da03ce5829fc/ujson-5.12.0-cp314-cp314t-manylinux_2_24_i686.manylinux_2_28_i686.whl", upload-time = 2026-03-11T22:19:03Z, size = 60618, hashes = { sha256 = "02f93da7a4115e24f886b04fd56df1ee8741c2ce4ea491b7ab3152f744ad8f8e" } },
+    { url = "https://files.pythonhosted.org/packages/9b/74/db7f638bf20282b1dccf454386cbd483faaaed3cdbb9cb27e06f74bb109e/ujson-5.12.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-11T22:19:04Z, size = 58151, hashes = { sha256 = "3ff4ede90ed771140caa7e1890de17431763a483c54b3c1f88bd30f0cc1affc0" } },
+    { url = "https://files.pythonhosted.org/packages/9c/7e/3ebaecfa70a2e8ce623db8e21bd5cb05d42a5ef943bcbb3309d71b5de68d/ujson-5.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-11T22:19:05Z, size = 1038117, hashes = { sha256 = "a7bf9cc97f05048ac8f3e02cd58f0fe62b901453c24345bfde287f4305dcc31c" } },
+    { url = "https://files.pythonhosted.org/packages/2e/aa/e073eda7f0036c2973b28db7bb99faba17a932e7b52d801f9bb3e726271f/ujson-5.12.0-cp314-cp314t-musllinux_1_2_i686.whl", upload-time = 2026-03-11T22:19:06Z, size = 1197434, hashes = { sha256 = "2324d9a0502317ffc35d38e153c1b2fa9610ae03775c9d0f8d0cca7b8572b04e" } },
+    { url = "https://files.pythonhosted.org/packages/1c/01/b9a13f058fdd50c746b192c4447ca8d6352e696dcda912ccee10f032ff85/ujson-5.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-11T22:19:08Z, size = 1090401, hashes = { sha256 = "50524f4f6a1c839714dbaff5386a1afb245d2d5ec8213a01fbc99cea7307811e" } },
+    { url = "https://files.pythonhosted.org/packages/0e/da/e9ae98133336e7c0d50b43626c3f2327937cecfa354d844e02ac17379ed1/ujson-5.12.0-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-11T22:19:15Z, size = 54518, hashes = { sha256 = "6c0aed6a4439994c9666fb8a5b6c4eac94d4ef6ddc95f9b806a599ef83547e3b" } },
+    { url = "https://files.pythonhosted.org/packages/58/10/978d89dded6bb1558cd46ba78f4351198bd2346db8a8ee1a94119022ce40/ujson-5.12.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-11T22:19:16Z, size = 55736, hashes = { sha256 = "efae5df7a8cc8bdb1037b0f786b044ce281081441df5418c3a0f0e1f86fe7bb3" } },
 ]
 
 [[packages]]
@@ -2788,10 +2794,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff740
 
 [[packages]]
 name = "werkzeug"
-version = "3.1.6"
+version = "3.1.7"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", upload-time = 2026-02-19T15:17:18Z, size = 864736, hashes = { sha256 = "210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", upload-time = 2026-02-19T15:17:17Z, size = 225166, hashes = { sha256 = "7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", upload-time = 2026-03-24T01:08:07Z, size = 875700, hashes = { sha256 = "fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", upload-time = 2026-03-24T01:08:06Z, size = 226295, hashes = { sha256 = "4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f" } }]
 
 [[packages]]
 name = "wheel"

--- a/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -102,9 +102,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "126f48fefecb46db4371aee825bd049e82107c22bb69c814341b8a564de9eb0c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "bb70d3307b7c4cc94457649823eae8d5a0fb76d0f67e01ac85362a3261250047" } }]
 
 [[packages]]
 name = "autopep8"
@@ -159,15 +159,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -1212,11 +1212,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "97122b4219fc74d6b9fa6e41b485080ff321a31dd31fd33b2fd8eb36f550045f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "55f92461c32dedd5574daac55f079693dc1ba94c77fe1d4691b3d623a902ef5a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -1264,6 +1264,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5f2aefda93dff508a809f26899c744d276f2d707fdefa473301d0daa3aa156e9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8c9d009aa86f24541e2e481edbaf99cdf31550938f88b05fee0fecb208e25043" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c5b42543b7dafcd57a6eba4f6fe09e0ba672c6cf480fa97d2b8391209f2b4bf2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4da4f6b3301ecc683e732a33d351b6d2b8f3ad8204598248c758f2d1520dd595" } },
 ]
 
 [[packages]]
@@ -1328,9 +1330,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1861,6 +1863,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7f2378720203f3e878d4c731aef08f5f291f0d01e0db66a0d32c533e43041522" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9d9b2c1ebf19f7f57cb6a17544bc8a920e395eabf15c152480415eec8b1a6ec" } },
 ]
 
 [[packages]]

--- a/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -141,9 +141,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "black"
-version = "26.3.0"
+version = "26.3.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/black-26.3.0-8-py3-none-any.whl", hashes = { sha256 = "d7ba52e1cdf10e6498db079fa30dcd0517b9b43bce915b9bdc107bca77828bf3" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/black-26.3.1-8-py3-none-any.whl", hashes = { sha256 = "76b9d439e1b4a3e50d8fe52cdbc5a3e9cd2a5b1e8594a45677199d1497a78bf9" } }]
 
 [[packages]]
 name = "bleach"
@@ -153,21 +153,21 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "bokeh"
-version = "3.8.2"
+version = "3.9.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/bokeh-3.8.2-8-py3-none-any.whl", hashes = { sha256 = "aec3f27813eb307c5749ccb8a35c70cce685e29226e226bcc1509d82a0b0e833" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/bokeh-3.9.0-8-py3-none-any.whl", hashes = { sha256 = "d53b5f5d870431aee76d7d478628adffecb16d82d80ff98ff904be8b3db62807" } }]
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6253f79dab41e62971026b56b31f04286237cf7439186124166e834dc4a63e1c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6d20b74964f04e1e348018e334856f414f2d5dde1b618e9978344c93519adaa2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
 
 [[packages]]
 name = "certifi"
@@ -357,9 +357,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.1-8-py3-none-any.whl", hashes = { sha256 = "37d177516fc5f3f9f2c115b37b7cae46b5f409d2c2581bef0f66aac23c928ca0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.2-8-py3-none-any.whl", hashes = { sha256 = "1a06237406de68d077f625dd66d1c6ed8948192a5b5e9d509e224613f0cecd1c" } }]
 
 [[packages]]
 name = "flatbuffers"
@@ -429,9 +429,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.0-8-py3-none-any.whl", hashes = { sha256 = "0b5ee3cd6ef9cffca33f6ae8f49ff83c801a4b05d159bfb816a62243296d8132" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.1-8-py3-none-any.whl", hashes = { sha256 = "66042030906be9d7785567f0eed81d4d335b3e56f54a0c60193eb1d2c7aa7dcc" } }]
 
 [[packages]]
 name = "google-cloud-core"
@@ -687,9 +687,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "jupyterlab"
-version = "4.5.5"
+version = "4.5.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/jupyterlab-4.5.5-8-py3-none-any.whl", hashes = { sha256 = "0c80f94eb20f59398befcb6aa775f0d99a688bf9f08198351a9e3473da29a6fc" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/jupyterlab-4.5.6-8-py3-none-any.whl", hashes = { sha256 = "65220d916950536d1d725b9ed77d3feddf8ae4042bd419bf6736af4bfe4f2a21" } }]
 
 [[packages]]
 name = "jupyterlab-git"
@@ -942,9 +942,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.17.0-8-py3-none-any.whl", hashes = { sha256 = "913a86059a3560391bd42127c6c92225b5cf34540b8678785ab0913c1937a818" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "b9d649dee7ce11d75a7c24f6d90b6530a4420869c299648e3718fb246ce3ffc2" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1328,9 +1328,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "0591de88e9cf017c9359ba66e0656e29cdae7a57aeaf78947f952aef1b8b9447" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1373,9 +1373,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.2-8-py3-none-any.whl", hashes = { sha256 = "ec835f207587c9cdd6ce59b1d08491e66d4de527385ba0d2595fa0b44c1a4053" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.3-8-py3-none-any.whl", hashes = { sha256 = "0a4f389c3546405adde681661b8bb985b160c126602b868e422fda5f171febf1" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1505,12 +1505,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bdce3b540862098992196b3380a66999bbed37408aecb3bf7ca9dcb1c0feaf93" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d4553438b49e9a3489c3de0415a578064c11fa97b0d222bfe7aa4d2f1af59731" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rsa-4.9.1-8-py3-none-any.whl", hashes = { sha256 = "0f8ea382eb6353c825b5ea44c42b9619551a7e8a67cfaba349f0d35752e1a556" } }]
 
 [[packages]]
 name = "ruamel-yaml"
@@ -1688,11 +1682,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "51e6d0644e5fa64d3cab035f92c14b4f3a2af6df5a009d71e3f35abba538bcc9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "42bada2a90c446b1e8dbbc68611d377d35605e769b58c262ef2c5685fe4f49a5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "c0775112cc2ab1a7e944a6a661c06458a4679bcaebfb0a1bd84e2c1dd869a165" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5342d0f38ea598a577533975f33267f962485bcea67828b7e277c22853005e13" } },
 ]
 
 [[packages]]
@@ -1733,11 +1727,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "ujson"
-version = "5.11.0"
+version = "5.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.11.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "32dbca5368848f7d879d3a0aff88a2c74d61415c962f11ee88f5915531bd3e6f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.11.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "80fc24ce26059262394cdb129fcf23954cc563331b30bcd5b853e00da4a608f1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.12.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "94649206b8d0c54bc3f8b58fadbd10871661dd4c51ac35cda0adce83e5b9278e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/ujson-5.12.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "69ddb21f0e48a3ced3bdbd9a3f5470c0ca2cac4d609467fe56e81fb0ceaeb8cc" } },
 ]
 
 [[packages]]

--- a/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -100,9 +100,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-26.1.0-2-py3-none-any.whl", hashes = { sha256 = "c05d9d58b0411fa7bcabceef61ac716468836735dbbf39ef17e34e952cea5e31" } }]
 
 [[packages]]
 name = "autopep8"
@@ -151,15 +151,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -1132,13 +1132,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ca63597a67b36a20819a198590452bb386312d530de4703472a16e88e159975e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "acb45f1a2e516c8d7a44cfbc9046d832d3aa8730e20dd389be3bc0f6f63079cb" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "5a31841ea2079fdfef6821f75b8955847201488945db2049e652aee8fcce77f5" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8bcf60a75dc286cf4d9410de1a2c90c55648a157e12e760bbec2820dfbb8e0d3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -1190,6 +1188,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "586f08c129ddf7b39041396a6e532d3a8230bb8b7f51e627ae6b10ef557f3cc5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "74159bd221074ba9137e85a4346e19efae57aab9f0f5b7e8612bef79117f9a38" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b27820345f00dcfe4def2b5b8ab07e2011e040c9f9524665a1b977eb997e4b51" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3bdcbc33a9eee499809dcfe1627f8f12af2235445aa41e4d72d970f858f01fc8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c46cbc4c39d68b069d41f0076ca8d342beaeea3f9d6e052ff72bd729ffee84cd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "c42bbe26b956cc1d910daf6935c4ba5370495970d4a9f328c12256f2a08f412d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b90a547f13de65881927ac1b14598f2ddf6e294099caff5eebec0df7d80b2678" } },
 ]
 
 [[packages]]
@@ -1256,9 +1258,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1794,6 +1796,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "71f6065dbf8b8aa60e95fc1c674df2c9b7fb7a3351396dac795f588e9ba89032" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "37b0c4e2e934574aa0338c6a8141aba248dc0ffe7112c1fc3c7d1e12cc8de8a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9b42c797d1a45bb859278d4efd76c476b54244b46f3504678d22d2fdb3429b60" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a220a1801c3d62b6dd716fb3c3d71f94ef41a1853fdbfad819d60f32d1f03d59" } },
 ]
 
 [[packages]]

--- a/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -82,9 +82,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-26.1.0-2-py3-none-any.whl", hashes = { sha256 = "c05d9d58b0411fa7bcabceef61ac716468836735dbbf39ef17e34e952cea5e31" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -115,15 +115,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -878,13 +878,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "ca63597a67b36a20819a198590452bb386312d530de4703472a16e88e159975e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "acb45f1a2e516c8d7a44cfbc9046d832d3aa8730e20dd389be3bc0f6f63079cb" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "5a31841ea2079fdfef6821f75b8955847201488945db2049e652aee8fcce77f5" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.5-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8bcf60a75dc286cf4d9410de1a2c90c55648a157e12e760bbec2820dfbb8e0d3" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -936,6 +934,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "586f08c129ddf7b39041396a6e532d3a8230bb8b7f51e627ae6b10ef557f3cc5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "74159bd221074ba9137e85a4346e19efae57aab9f0f5b7e8612bef79117f9a38" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b27820345f00dcfe4def2b5b8ab07e2011e040c9f9524665a1b977eb997e4b51" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3bdcbc33a9eee499809dcfe1627f8f12af2235445aa41e4d72d970f858f01fc8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "c46cbc4c39d68b069d41f0076ca8d342beaeea3f9d6e052ff72bd729ffee84cd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "c42bbe26b956cc1d910daf6935c4ba5370495970d4a9f328c12256f2a08f412d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyarrow-23.0.1-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "b90a547f13de65881927ac1b14598f2ddf6e294099caff5eebec0df7d80b2678" } },
 ]
 
 [[packages]]
@@ -992,9 +994,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1392,6 +1394,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "71f6065dbf8b8aa60e95fc1c674df2c9b7fb7a3351396dac795f588e9ba89032" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "37b0c4e2e934574aa0338c6a8141aba248dc0ffe7112c1fc3c7d1e12cc8de8a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9b42c797d1a45bb859278d4efd76c476b54244b46f3504678d22d2fdb3429b60" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a220a1801c3d62b6dd716fb3c3d71f94ef41a1853fdbfad819d60f32d1f03d59" } },
 ]
 
 [[packages]]

--- a/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -115,15 +115,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.64-2-py3-none-any.whl", hashes = { sha256 = "2136abdf2b233e1a89b9563874cf7203d2b88439bcc99486cf8881be3c9b599a" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "db1319b52f88c816dd65db4a7c5ebded12d44043baa81432696c16017008e583" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.64-2-py3-none-any.whl", hashes = { sha256 = "f01171e5c1f437649384c7c4fa761562bf4d154a1af9545c09d4553186f40ae6" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.67-2-py3-none-any.whl", hashes = { sha256 = "2f460462a180c3b10527e9d7ff1fa03f37041b19df653b047408b87aa302c290" } }]
 
 [[packages]]
 name = "certifi"
@@ -295,9 +295,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/filelock-3.25.1-2-py3-none-any.whl", hashes = { sha256 = "d3e0cda4591270f41b9643a2f23776bf464f89be02a8cac4c6da5f57c93e710b" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/filelock-3.25.2-2-py3-none-any.whl", hashes = { sha256 = "ff122a5a2afb7ece0ba72e8f89dd24aba7da0d56683795babad4c5894b37493b" } }]
 
 [[packages]]
 name = "fonttools"
@@ -330,9 +330,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/google_auth-2.49.0-2-py3-none-any.whl", hashes = { sha256 = "d219a78bdadf92759107909dd63dec7d9c17da7f76f7829d055eec45889e794a" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/google_auth-2.49.1-2-py3-none-any.whl", hashes = { sha256 = "486c8e5c1c1f96e4bc8b747a1ee2332330ec750296a984e37716825afa1382fd" } }]
 
 [[packages]]
 name = "googleapis-common-protos"
@@ -655,9 +655,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/narwhals-2.17.0-2-py3-none-any.whl", hashes = { sha256 = "7ae0196ed17cda5672a6cb38d18a76ec8de1177c782efcda9a092b80da4b3afd" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/narwhals-2.18.0-2-py3-none-any.whl", hashes = { sha256 = "1bfa66615b62a208b82702830cb2f942c384b607df4a1dce884fd938b8cf186d" } }]
 
 [[packages]]
 name = "nbclient"
@@ -992,9 +992,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.11.0-2-py3-none-any.whl", hashes = { sha256 = "2debd85aa7bb015325bdc5c1d4ca87365125708e1d78e20008cde2df8c93d843" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.0-2-py3-none-any.whl", hashes = { sha256 = "cb630577f4b8f485d3da1d80c8759c97972d7b166f84a7005eb8060a523bdcc8" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1041,9 +1041,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/python_discovery-1.1.2-2-py3-none-any.whl", hashes = { sha256 = "36e0131ecbc1f5a41eb39b3892f52eac743ee7d0732382f22d4e4d99809eb5a4" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/python_discovery-1.1.3-2-py3-none-any.whl", hashes = { sha256 = "8767b44c30b725674c19f139eb1fdbc8b46e9b0ca4e58b612b8fdc106fbbae19" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1122,12 +1122,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "0f7f8b8dcd9f0fb3cf7289f33ea1744ac4a47fb60581f46932f55b633aaa1ad5" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rpds_py-0.30.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "3cd14f655cf15503309f9e3c021571429331f26686278daeee9793f01187fd43" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/rsa-4.9.1-2-py3-none-any.whl", hashes = { sha256 = "6fcfed81598bd236377f1079e25a13efc0da53e7c81030a0b9b91c11eb3bb007" } }]
 
 [[packages]]
 name = "s3transfer"
@@ -1248,13 +1242,13 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "cfbd7badd456905c6923b7a43e85d75ae45587dfeed8262b9e36dd6f27f6cd2e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "9c5ad3cfca1100cf697c7559e64e807710beb0fe11d86e82bc30021ee6cd835d" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "3da1820c3e5ad37c5e5eb40af25bb3d7568320ae382210cf7ee7191ab0e2eb9f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "c6b9e80318e38ad54d6c3c4bbb6b38f9f0190c896e82e7c216b74c2bbddcb1ca" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "1a902b88db666a23eb3df3c8249ab13f459524f6bd7073df6a9b39c1f1b65ee5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "357b777e0d9cc1cb1de849708e59cf79dfc95aeabce42b584ea818005b022d05" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "8c428693b160a32c34a96f954425005f966ce885ecad988134a032f0d3f32cc2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "7c18fd68b9fad8ec2c8dc8ba52641155541478228413244031bfd743b8d965cb" } },
 ]
 
 [[packages]]

--- a/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -58,9 +58,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-25.4.0-2-py3-none-any.whl", hashes = { sha256 = "e1dc38a2bc0bd08b70d628566c13bd92a68a9ebb82553a20ea4c7f9d6a8c5597" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/attrs-26.1.0-2-py3-none-any.whl", hashes = { sha256 = "c05d9d58b0411fa7bcabceef61ac716468836735dbbf39ef17e34e952cea5e31" } }]
 
 [[packages]]
 name = "beautifulsoup4"
@@ -545,6 +545,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "cc9821009f2a8a44c518a93ac2108b13bccc5907bc34204ed7d80cc23b56c6cf" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "cc4efffe1520f4decfd4cb32ea12c985ca91a1150d0a60812dc9e59834126f8c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "01096c612974da308601fd776d0456bbe34237c3caea6f38856491da554bb17d" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "71f6065dbf8b8aa60e95fc1c674df2c9b7fb7a3351396dac795f588e9ba89032" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_ppc64le.whl", hashes = { sha256 = "37b0c4e2e934574aa0338c6a8141aba248dc0ffe7112c1fc3c7d1e12cc8de8a1" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_s390x.whl", hashes = { sha256 = "9b42c797d1a45bb859278d4efd76c476b54244b46f3504678d22d2fdb3429b60" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/yarl-1.23.0-3-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "a220a1801c3d62b6dd716fb3c3d71f94ef41a1853fdbfad819d60f32d1f03d59" } },
 ]
 
 # The following packages were excluded from the output:

--- a/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/minimal/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -485,13 +485,13 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "cfbd7badd456905c6923b7a43e85d75ae45587dfeed8262b9e36dd6f27f6cd2e" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "9c5ad3cfca1100cf697c7559e64e807710beb0fe11d86e82bc30021ee6cd835d" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "3da1820c3e5ad37c5e5eb40af25bb3d7568320ae382210cf7ee7191ab0e2eb9f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.4-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "c6b9e80318e38ad54d6c3c4bbb6b38f9f0190c896e82e7c216b74c2bbddcb1ca" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "1a902b88db666a23eb3df3c8249ab13f459524f6bd7073df6a9b39c1f1b65ee5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_ppc64le.whl", hashes = { sha256 = "357b777e0d9cc1cb1de849708e59cf79dfc95aeabce42b584ea818005b022d05" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_s390x.whl", hashes = { sha256 = "8c428693b160a32c34a96f954425005f966ce885ecad988134a032f0d3f32cc2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/tornado-6.5.5-2-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "7c18fd68b9fad8ec2c8dc8ba52641155541478228413244031bfd743b8d965cb" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -108,15 +108,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6253f79dab41e62971026b56b31f04286237cf7439186124166e834dc4a63e1c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6d20b74964f04e1e348018e334856f414f2d5dde1b618e9978344c93519adaa2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
 
 [[packages]]
 name = "certifi"
@@ -279,9 +279,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.1-8-py3-none-any.whl", hashes = { sha256 = "37d177516fc5f3f9f2c115b37b7cae46b5f409d2c2581bef0f66aac23c928ca0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.2-8-py3-none-any.whl", hashes = { sha256 = "1a06237406de68d077f625dd66d1c6ed8948192a5b5e9d509e224613f0cecd1c" } }]
 
 [[packages]]
 name = "fonttools"
@@ -336,11 +336,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "hf-xet"
-version = "1.3.2"
+version = "1.4.2"
 marker = "(python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'amd64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'arm64' and sys_platform == 'linux') or (python_full_version >= '3.12' and implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux')"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.3.2-8-cp37-abi3-linux_aarch64.whl", hashes = { sha256 = "5479e1cb25fa7647fa4bd729f48a460117635d2ee3c0f218f302ffc0652ec761" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.3.2-8-cp37-abi3-linux_x86_64.whl", hashes = { sha256 = "6d6185eda4ef6bf61ecb780bd39fd64c5cbe0bc0e8a48309afe1a97b817d5b49" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.4.2-8-cp37-abi3-linux_aarch64.whl", hashes = { sha256 = "fcb089de9e460badbfacdc54316c4d1845fee0c8a98e4e8a9924781c4d7b762c" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/hf_xet-1.4.2-8-cp37-abi3-linux_x86_64.whl", hashes = { sha256 = "5cd68f6e6bfe271762a59962baa8131221e7d89e31a263a5542749642621592e" } },
 ]
 
 [[packages]]
@@ -633,9 +633,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.17.0-8-py3-none-any.whl", hashes = { sha256 = "913a86059a3560391bd42127c6c92225b5cf34540b8678785ab0913c1937a818" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "b9d649dee7ce11d75a7c24f6d90b6530a4420869c299648e3718fb246ce3ffc2" } }]
 
 [[packages]]
 name = "nbclient"
@@ -891,9 +891,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "0591de88e9cf017c9359ba66e0656e29cdae7a57aeaf78947f952aef1b8b9447" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1182,11 +1182,11 @@ wheels = [
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "51e6d0644e5fa64d3cab035f92c14b4f3a2af6df5a009d71e3f35abba538bcc9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "42bada2a90c446b1e8dbbc68611d377d35605e769b58c262ef2c5685fe4f49a5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "c0775112cc2ab1a7e944a6a661c06458a4679bcaebfb0a1bd84e2c1dd869a165" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5342d0f38ea598a577533975f33267f962485bcea67828b7e277c22853005e13" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -84,9 +84,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "126f48fefecb46db4371aee825bd049e82107c22bb69c814341b8a564de9eb0c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "bb70d3307b7c4cc94457649823eae8d5a0fb76d0f67e01ac85362a3261250047" } }]
 
 [[packages]]
 name = "beautifulsoup4"
@@ -108,15 +108,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -810,11 +810,11 @@ wheels = [
 
 [[packages]]
 name = "protobuf"
-version = "7.34.0"
+version = "7.34.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-7.34.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "82fed737fd9031955720f252d17b495e62ffb65c9e0648e9370f0b49f6f847f7" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-7.34.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "eb5b39a5be6e9fe8b8c52e14457119a57263f52706e91d20daca8bc3781dd425" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-7.34.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "6ccd12e20a14044aea9bcf29c86426834b4cc94d3c971e927453de88eb8ae0f8" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-7.34.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "86298a3f164fc3a745f0c672a93dfb7d5f8729959abea7bb25d54b4bb1d96560" } },
 ]
 
 [[packages]]
@@ -851,6 +851,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5f2aefda93dff508a809f26899c744d276f2d707fdefa473301d0daa3aa156e9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8c9d009aa86f24541e2e481edbaf99cdf31550938f88b05fee0fecb208e25043" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c5b42543b7dafcd57a6eba4f6fe09e0ba672c6cf480fa97d2b8391209f2b4bf2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4da4f6b3301ecc683e732a33d351b6d2b8f3ad8204598248c758f2d1520dd595" } },
 ]
 
 [[packages]]
@@ -891,9 +893,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1169,6 +1171,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "21df4468684a214edaf4e90183f44a6f2e15a06b07ac9cae2856bfd04e61082f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "936d3cfdf1394ce2dc66c2521274e6961517418a4ef281bcca669297bde573b9" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a92491706f9b4530549f2df479a4c9ac942b9ae87f79d2afde13d7c2f3096a36" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7ab83dd5a819610d2f3a9a816ad6009d267243ea1c9c006b04554898492c6e70" } },
 ]
 
 [[packages]]
@@ -1337,6 +1341,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7f2378720203f3e878d4c731aef08f5f291f0d01e0db66a0d32c533e43041522" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9d9b2c1ebf19f7f57cb6a17544bc8a920e395eabf15c152480415eec8b1a6ec" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -117,15 +117,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6253f79dab41e62971026b56b31f04286237cf7439186124166e834dc4a63e1c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6d20b74964f04e1e348018e334856f414f2d5dde1b618e9978344c93519adaa2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
 
 [[packages]]
 name = "certifi"
@@ -291,9 +291,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.1-8-py3-none-any.whl", hashes = { sha256 = "37d177516fc5f3f9f2c115b37b7cae46b5f409d2c2581bef0f66aac23c928ca0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.2-8-py3-none-any.whl", hashes = { sha256 = "1a06237406de68d077f625dd66d1c6ed8948192a5b5e9d509e224613f0cecd1c" } }]
 
 [[packages]]
 name = "fonttools"
@@ -324,9 +324,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.0-8-py3-none-any.whl", hashes = { sha256 = "0b5ee3cd6ef9cffca33f6ae8f49ff83c801a4b05d159bfb816a62243296d8132" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.1-8-py3-none-any.whl", hashes = { sha256 = "66042030906be9d7785567f0eed81d4d335b3e56f54a0c60193eb1d2c7aa7dcc" } }]
 
 [[packages]]
 name = "googleapis-common-protos"
@@ -642,9 +642,9 @@ wheels = [
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.17.0-8-py3-none-any.whl", hashes = { sha256 = "913a86059a3560391bd42127c6c92225b5cf34540b8678785ab0913c1937a818" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "b9d649dee7ce11d75a7c24f6d90b6530a4420869c299648e3718fb246ce3ffc2" } }]
 
 [[packages]]
 name = "nbclient"
@@ -965,9 +965,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "0591de88e9cf017c9359ba66e0656e29cdae7a57aeaf78947f952aef1b8b9447" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1010,9 +1010,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.2-8-py3-none-any.whl", hashes = { sha256 = "ec835f207587c9cdd6ce59b1d08491e66d4de527385ba0d2595fa0b44c1a4053" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.3-8-py3-none-any.whl", hashes = { sha256 = "0a4f389c3546405adde681661b8bb985b160c126602b868e422fda5f171febf1" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1085,12 +1085,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bdce3b540862098992196b3380a66999bbed37408aecb3bf7ca9dcb1c0feaf93" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d4553438b49e9a3489c3de0415a578064c11fa97b0d222bfe7aa4d2f1af59731" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rsa-4.9.1-8-py3-none-any.whl", hashes = { sha256 = "0f8ea382eb6353c825b5ea44c42b9619551a7e8a67cfaba349f0d35752e1a556" } }]
 
 [[packages]]
 name = "s3transfer"
@@ -1241,11 +1235,11 @@ wheels = [
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "51e6d0644e5fa64d3cab035f92c14b4f3a2af6df5a009d71e3f35abba538bcc9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "42bada2a90c446b1e8dbbc68611d377d35605e769b58c262ef2c5685fe4f49a5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "c0775112cc2ab1a7e944a6a661c06458a4679bcaebfb0a1bd84e2c1dd869a165" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5342d0f38ea598a577533975f33267f962485bcea67828b7e277c22853005e13" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -84,9 +84,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "126f48fefecb46db4371aee825bd049e82107c22bb69c814341b8a564de9eb0c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "bb70d3307b7c4cc94457649823eae8d5a0fb76d0f67e01ac85362a3261250047" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -117,15 +117,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -861,11 +861,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "97122b4219fc74d6b9fa6e41b485080ff321a31dd31fd33b2fd8eb36f550045f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "55f92461c32dedd5574daac55f079693dc1ba94c77fe1d4691b3d623a902ef5a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -913,6 +913,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5f2aefda93dff508a809f26899c744d276f2d707fdefa473301d0daa3aa156e9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8c9d009aa86f24541e2e481edbaf99cdf31550938f88b05fee0fecb208e25043" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c5b42543b7dafcd57a6eba4f6fe09e0ba672c6cf480fa97d2b8391209f2b4bf2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4da4f6b3301ecc683e732a33d351b6d2b8f3ad8204598248c758f2d1520dd595" } },
 ]
 
 [[packages]]
@@ -965,9 +967,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1222,6 +1224,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "21df4468684a214edaf4e90183f44a6f2e15a06b07ac9cae2856bfd04e61082f" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-10-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "936d3cfdf1394ce2dc66c2521274e6961517418a4ef281bcca669297bde573b9" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "a92491706f9b4530549f2df479a4c9ac942b9ae87f79d2afde13d7c2f3096a36" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/torch-2.9.1-11-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "7ab83dd5a819610d2f3a9a816ad6009d267243ea1c9c006b04554898492c6e70" } },
 ]
 
 [[packages]]
@@ -1390,6 +1394,8 @@ marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7f2378720203f3e878d4c731aef08f5f291f0d01e0db66a0d32c533e43041522" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9d9b2c1ebf19f7f57cb6a17544bc8a920e395eabf15c152480415eec8b1a6ec" } },
 ]
 
 [[packages]]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -108,15 +108,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/boto3-1.42.64-12-py3-none-any.whl", hashes = { sha256 = "5f2eae2ab95753412fbf53e51937e855302911f20cf301f64371b55ea588a354" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/boto3-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "7b180411b5ed0c06a58ac0d66dffbca9e455a6f8b6854dea61d9af0f5d055351" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/botocore-1.42.64-12-py3-none-any.whl", hashes = { sha256 = "98fa021c39af4d50b5528f39a49b1b93fe6b60cee3a00a2592a30960b3a97b36" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/botocore-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "47b5c6db8619413865aaa66e8bbe796849fbe86150a49a76c3bf54b6229fa84d" } }]
 
 [[packages]]
 name = "certifi"
@@ -270,9 +270,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/filelock-3.25.1-12-py3-none-any.whl", hashes = { sha256 = "e46d8fc0eee73c30215731f024e978b95f5679d90c109cef912700d3326d69fa" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/filelock-3.25.2-12-py3-none-any.whl", hashes = { sha256 = "4d2d1b7e90eed7dd7ef75a3f549869d15da1a0bb41e6e0e69d9e5003f1d97fba" } }]
 
 [[packages]]
 name = "fonttools"
@@ -300,9 +300,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/google_auth-2.49.0-12-py3-none-any.whl", hashes = { sha256 = "9d22eb6e21b0625e4488022ee107cb24cc0b373dc28e45ff9affb6f4b6cc28e5" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/google_auth-2.49.1-12-py3-none-any.whl", hashes = { sha256 = "9e8b54bfea5d6202400a0a7382a6b9ca02512dd9475e47f35fa197ef3584ad63" } }]
 
 [[packages]]
 name = "googleapis-common-protos"
@@ -582,9 +582,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/narwhals-2.17.0-12-py3-none-any.whl", hashes = { sha256 = "fd1ecf6a2ebc05766cb729595b818f3ecc9ba7de81f2afb959f8d716034a632d" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/narwhals-2.18.0-12-py3-none-any.whl", hashes = { sha256 = "a6c0e0fbc4d2e1211b9400534955bb6d5ab9027313a1463d7a19fd14bf944006" } }]
 
 [[packages]]
 name = "nbclient"
@@ -873,9 +873,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyjwt-2.11.0-12-py3-none-any.whl", hashes = { sha256 = "ce6ad695a786d30cc5091f0223b3574151614caa2c0484a0f7ff1f7532e45d47" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyjwt-2.12.0-12-py3-none-any.whl", hashes = { sha256 = "c59af40549bc064212f9c92b54c9c5f604882e1cd43f8ab2442ccbc12187f950" } }]
 
 [[packages]]
 name = "pymongo"
@@ -909,9 +909,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/python_discovery-1.1.2-12-py3-none-any.whl", hashes = { sha256 = "0a0fa79e44290c7ba4b23645c582eda88e9d34960b9e5be0c7bbe0b2182a0bb2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/python_discovery-1.1.3-12-py3-none-any.whl", hashes = { sha256 = "5e5d9cf9cb56f7fc5e9c85c1658546822d6f7113d479cfa8565355691e64f78a" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -972,12 +972,6 @@ name = "rpds-py"
 version = "0.30.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/rpds_py-0.30.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "079f16ffe8de26af88c26dff158b9f96a3c1964f10205a0595e59e52000e253f" } }]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "python_full_version >= '3.6' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/rsa-4.9.1-12-py3-none-any.whl", hashes = { sha256 = "2cdecd651d0b348b91664f8a2bd2e69408ba716174bf47eec465d40add22d85e" } }]
 
 [[packages]]
 name = "s3transfer"
@@ -1113,9 +1107,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/tornado-6.5.4-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "8a6e25fe75f402b6932c5a2f296ef45c4c138025f664cd9fb086b8f8fe06afa4" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/tornado-6.5.5-12-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "4a4fa3342ebf8f69a1f439f684fdc8984cadddc6f571fccd71768989d8ab27cb" } }]
 
 [[packages]]
 name = "tqdm"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -78,9 +78,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/attrs-25.4.0-12-py3-none-any.whl", hashes = { sha256 = "392db93a8a91fe1136a04b6e76a66467d78490efa31a9c5bd114287e9ae6a554" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/attrs-26.1.0-12-py3-none-any.whl", hashes = { sha256 = "496a2d1671c1ba87f218a620f4f1861ca94dd41e3f9f1359ae27deb925501437" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -108,15 +108,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/boto3-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "7b180411b5ed0c06a58ac0d66dffbca9e455a6f8b6854dea61d9af0f5d055351" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/botocore-1.42.67-12-py3-none-any.whl", hashes = { sha256 = "47b5c6db8619413865aaa66e8bbe796849fbe86150a49a76c3bf54b6229fa84d" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -786,9 +786,12 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/protobuf-6.33.5-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "738ef1273295ef0cfbdd13908c8694339469ce4dc9e62334455c61eaa3b46697" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
+]
 
 [[packages]]
 name = "psutil"
@@ -827,7 +830,10 @@ wheels = [
 name = "pyarrow"
 version = "23.0.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyarrow-23.0.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ed608bad6ebd64361ac979923756ba815d0cdf7c9fda3009987b20062c59613a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyarrow-23.0.1-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "ed608bad6ebd64361ac979923756ba815d0cdf7c9fda3009987b20062c59613a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyarrow-23.0.1-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "e711139c483e2802c06e6ca2a815f47147d1d6765e579eb754e6175e0645ba5c" } },
+]
 
 [[packages]]
 name = "pyasn1"
@@ -873,9 +879,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/pyjwt-2.12.0-12-py3-none-any.whl", hashes = { sha256 = "c59af40549bc064212f9c92b54c9c5f604882e1cd43f8ab2442ccbc12187f950" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1097,7 +1103,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "torch"
 version = "2.9.1"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/torch-2.9.1-14-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c6b187493adf0046b2079c563f3ba651e681a7ebbd2c93c394ad4daec5c258bd" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/torch-2.9.1-14-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "c6b187493adf0046b2079c563f3ba651e681a7ebbd2c93c394ad4daec5c258bd" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/torch-2.9.1-15-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "0fe5962823b7588d826ca51d018b9069c6841d9d167ff9bec8d92378fe0e4258" } },
+]
 
 [[packages]]
 name = "torchvision"
@@ -1241,7 +1250,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "yarl"
 version = "1.23.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-12-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "1240fc36ab655611db2fa570fcd28d9f1a730c25caff06205f0a008733b9698a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/rocm6.4-ubi9/yarl-1.23.0-13-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "5ba0e1455750dafb8e86f8ac487adc3ba035a6fcdde3d683a4a78ac111c34d19" } },
+]
 
 [[packages]]
 name = "zipp"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -141,10 +141,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b45
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", upload-time = 2025-10-06T13:54:44Z, size = 934251, hashes = { sha256 = "16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", upload-time = 2025-10-06T13:54:43Z, size = 67615, hashes = { sha256 = "adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", upload-time = 2026-03-19T14:22:25Z, size = 952055, hashes = { sha256 = "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", upload-time = 2026-03-19T14:22:23Z, size = 67548, hashes = { sha256 = "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -212,17 +212,16 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d
 
 [[packages]]
 name = "boto3"
-version = "1.42.65"
+version = "1.42.76"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1e/c9/8ff8a901cf62374f1289cf36391f855e1702c70f545c28d1b57608a84ff2/boto3-1.42.65.tar.gz", upload-time = 2026-03-10T19:44:58Z, size = 112805, hashes = { sha256 = "c740af6bdaebcc1a00f3827a5729050bf6fc820ee148bf7d06f28db11c80e2a1" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/46/bb/ace5921655df51e3c9b787b3f0bd6aa25548e5cf1dabae02e53fa88f2d98/boto3-1.42.65-py3-none-any.whl", upload-time = 2026-03-10T19:44:55Z, size = 140556, hashes = { sha256 = "cc7f2e0aec6c68ee5b10232cf3e01326acf6100bc785a770385b61a0474b31f4" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/f0/dc/21b3dfb135125eb7e3a46b9aab0aede847726f239fc8f39474742a87ebb0/boto3-1.42.76-py3-none-any.whl", upload-time = 2026-03-25T19:33:23Z, size = 140557, hashes = { sha256 = "63c6779c814847016b89ae1b72ed968f8a63d80e589ba337511aa6fc1b59585e" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.65"
+version = "1.42.76"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/2e/81/2c832e2117d24da4fe800861e8ddd19bbaa308623b1198eb2c2cc6fcd3d4/botocore-1.42.65.tar.gz", upload-time = 2026-03-10T19:44:43Z, size = 14970239, hashes = { sha256 = "7d52c148df07f70c375eeda58f99b439c7c7836c25df74cccfba3bb6e12444d2" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8e/9e/2ca03a55408c0820d7f0a04ae52bc6dfc7e4fff1f007a90135a68e056c93/botocore-1.42.65-py3-none-any.whl", upload-time = 2026-03-10T19:44:37Z, size = 14644794, hashes = { sha256 = "0283c332ce00cbd1b894e86b7bed89dd624a5ca3a4ee62ec4db3898d16652e98" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/70/62/a982acb81c5e0312f90f841b790abad65622c08aad356eed7008ea3d475b/botocore-1.42.76.tar.gz", upload-time = 2026-03-25T19:33:12Z, size = 15021811, hashes = { sha256 = "c553fa0ae29e36a5c407f74da78b78404b81b74b15fb62bf640a3cd9385f0874" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f5/63/7429d68876b7718ab5c4b8a44414de7907f5ba6bb27ccfad384df14fb277/botocore-1.42.76-py3-none-any.whl", upload-time = 2026-03-25T19:33:07Z, size = 14697736, hashes = { sha256 = "151e714ae3c32f68ea0b4dc60751401e03f84a87c6cf864ea0ee64aa10eb4607" } }]
 
 [[packages]]
 name = "certifi"
@@ -267,47 +266,59 @@ wheels = [
 
 [[packages]]
 name = "charset-normalizer"
-version = "3.4.5"
+version = "3.4.6"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", upload-time = 2026-03-06T06:03:19Z, size = 134804, hashes = { sha256 = "95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644" } }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", upload-time = 2026-03-15T18:53:25Z, size = 143363, hashes = { sha256 = "1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-06T06:01:16Z, size = 189356, hashes = { sha256 = "0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54" } },
-    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-06T06:01:17Z, size = 206369, hashes = { sha256 = "dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467" } },
-    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-06T06:01:19Z, size = 203285, hashes = { sha256 = "ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60" } },
-    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T06:01:20Z, size = 196274, hashes = { sha256 = "7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d" } },
-    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", upload-time = 2026-03-06T06:01:22Z, size = 184715, hashes = { sha256 = "a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e" } },
-    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-06T06:01:23Z, size = 193426, hashes = { sha256 = "754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f" } },
-    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-06T06:01:25Z, size = 191780, hashes = { sha256 = "0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc" } },
-    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", upload-time = 2026-03-06T06:01:26Z, size = 185805, hashes = { sha256 = "c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95" } },
-    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-06T06:01:27Z, size = 208342, hashes = { sha256 = "d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a" } },
-    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", upload-time = 2026-03-06T06:01:29Z, size = 193661, hashes = { sha256 = "19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac" } },
-    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", upload-time = 2026-03-06T06:01:30Z, size = 204819, hashes = { sha256 = "4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1" } },
-    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-06T06:01:31Z, size = 198080, hashes = { sha256 = "a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98" } },
-    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-06T06:01:38Z, size = 188890, hashes = { sha256 = "165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8" } },
-    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-06T06:01:40Z, size = 206136, hashes = { sha256 = "28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d" } },
-    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-06T06:01:41Z, size = 202551, hashes = { sha256 = "d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce" } },
-    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T06:01:43Z, size = 195572, hashes = { sha256 = "0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819" } },
-    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", upload-time = 2026-03-06T06:01:44Z, size = 184438, hashes = { sha256 = "c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d" } },
-    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-06T06:01:46Z, size = 193035, hashes = { sha256 = "e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763" } },
-    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-06T06:01:47Z, size = 191340, hashes = { sha256 = "e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9" } },
-    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", upload-time = 2026-03-06T06:01:48Z, size = 185464, hashes = { sha256 = "597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c" } },
-    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-06T06:01:50Z, size = 208014, hashes = { sha256 = "5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67" } },
-    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", upload-time = 2026-03-06T06:01:51Z, size = 193297, hashes = { sha256 = "2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3" } },
-    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", upload-time = 2026-03-06T06:01:53Z, size = 204321, hashes = { sha256 = "65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf" } },
-    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-06T06:01:56Z, size = 197509, hashes = { sha256 = "c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6" } },
-    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-06T06:02:02Z, size = 189688, hashes = { sha256 = "a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f" } },
-    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-06T06:02:05Z, size = 206833, hashes = { sha256 = "a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4" } },
-    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-06T06:02:06Z, size = 202879, hashes = { sha256 = "d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee" } },
-    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-06T06:02:08Z, size = 195764, hashes = { sha256 = "01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66" } },
-    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", upload-time = 2026-03-06T06:02:10Z, size = 183728, hashes = { sha256 = "b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362" } },
-    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-06T06:02:11Z, size = 192937, hashes = { sha256 = "e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7" } },
-    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-06T06:02:13Z, size = 192040, hashes = { sha256 = "4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d" } },
-    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", upload-time = 2026-03-06T06:02:14Z, size = 184107, hashes = { sha256 = "d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6" } },
-    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-06T06:02:16Z, size = 208310, hashes = { sha256 = "30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39" } },
-    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", upload-time = 2026-03-06T06:02:18Z, size = 192918, hashes = { sha256 = "d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6" } },
-    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", upload-time = 2026-03-06T06:02:19Z, size = 204615, hashes = { sha256 = "c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94" } },
-    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-06T06:02:21Z, size = 197784, hashes = { sha256 = "1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e" } },
-    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", upload-time = 2026-03-06T06:03:17Z, size = 55455, hashes = { sha256 = "9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0" } },
+    { url = "https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:50:52Z, size = 199191, hashes = { sha256 = "a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21" } },
+    { url = "https://files.pythonhosted.org/packages/6c/92/9934d1bbd69f7f398b38c5dae1cbf9cc672e7c34a4adf7b17c0a9c17d15d/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:50:54Z, size = 218674, hashes = { sha256 = "836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2" } },
+    { url = "https://files.pythonhosted.org/packages/af/90/25f6ab406659286be929fd89ab0e78e38aa183fc374e03aa3c12d730af8a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:50:55Z, size = 215259, hashes = { sha256 = "f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff" } },
+    { url = "https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:50:57Z, size = 207276, hashes = { sha256 = "0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5" } },
+    { url = "https://files.pythonhosted.org/packages/f7/72/d0426afec4b71dc159fa6b4e68f868cd5a3ecd918fec5813a15d292a7d10/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:50:58Z, size = 195161, hashes = { sha256 = "530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0" } },
+    { url = "https://files.pythonhosted.org/packages/bf/18/c82b06a68bfcb6ce55e508225d210c7e6a4ea122bfc0748892f3dc4e8e11/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:51:00Z, size = 203452, hashes = { sha256 = "30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a" } },
+    { url = "https://files.pythonhosted.org/packages/44/d6/0c25979b92f8adafdbb946160348d8d44aa60ce99afdc27df524379875cb/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:51:01Z, size = 202272, hashes = { sha256 = "ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2" } },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/7fea3e8fe84136bebbac715dd1221cc25c173c57a699c030ab9b8900cbb7/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:51:03Z, size = 195622, hashes = { sha256 = "90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5" } },
+    { url = "https://files.pythonhosted.org/packages/57/8a/d6f7fd5cb96c58ef2f681424fbca01264461336d2a7fc875e4446b1f1346/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:51:05Z, size = 220056, hashes = { sha256 = "8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6" } },
+    { url = "https://files.pythonhosted.org/packages/16/50/478cdda782c8c9c3fb5da3cc72dd7f331f031e7f1363a893cdd6ca0f8de0/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:51:06Z, size = 203751, hashes = { sha256 = "695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d" } },
+    { url = "https://files.pythonhosted.org/packages/75/fc/cc2fcac943939c8e4d8791abfa139f685e5150cae9f94b60f12520feaa9b/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:51:08Z, size = 216563, hashes = { sha256 = "231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2" } },
+    { url = "https://files.pythonhosted.org/packages/a8/b7/a4add1d9a5f68f3d037261aecca83abdb0ab15960a3591d340e829b37298/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:51:10Z, size = 209265, hashes = { sha256 = "a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923" } },
+    { url = "https://files.pythonhosted.org/packages/47/7b/20e809b89c69d37be748d98e84dce6820bf663cf19cf6b942c951a3e8f41/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:51:17Z, size = 198527, hashes = { sha256 = "423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843" } },
+    { url = "https://files.pythonhosted.org/packages/37/a6/4f8d27527d59c039dce6f7622593cdcd3d70a8504d87d09eb11e9fdc6062/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:51:18Z, size = 218388, hashes = { sha256 = "d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf" } },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/4770ccb3e491a9bacf1c46cc8b812214fe367c86a96353ccc6daf87b01ec/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:51:20Z, size = 214563, hashes = { sha256 = "d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8" } },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:51:21Z, size = 206587, hashes = { sha256 = "530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9" } },
+    { url = "https://files.pythonhosted.org/packages/7e/70/3def227f1ec56f5c69dfc8392b8bd63b11a18ca8178d9211d7cc5e5e4f27/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:51:23Z, size = 194724, hashes = { sha256 = "a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88" } },
+    { url = "https://files.pythonhosted.org/packages/58/ab/9318352e220c05efd31c2779a23b50969dc94b985a2efa643ed9077bfca5/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:51:25Z, size = 202956, hashes = { sha256 = "34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84" } },
+    { url = "https://files.pythonhosted.org/packages/75/13/f3550a3ac25b70f87ac98c40d3199a8503676c2f1620efbf8d42095cfc40/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:51:26Z, size = 201923, hashes = { sha256 = "5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd" } },
+    { url = "https://files.pythonhosted.org/packages/1b/db/c5c643b912740b45e8eec21de1bbab8e7fc085944d37e1e709d3dcd9d72f/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:51:28Z, size = 195366, hashes = { sha256 = "80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c" } },
+    { url = "https://files.pythonhosted.org/packages/5a/67/3b1c62744f9b2448443e0eb160d8b001c849ec3fef591e012eda6484787c/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:51:29Z, size = 219752, hashes = { sha256 = "92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194" } },
+    { url = "https://files.pythonhosted.org/packages/f6/98/32ffbaf7f0366ffb0445930b87d103f6b406bc2c271563644bde8a2b1093/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:51:30Z, size = 203296, hashes = { sha256 = "613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc" } },
+    { url = "https://files.pythonhosted.org/packages/41/12/5d308c1bbe60cabb0c5ef511574a647067e2a1f631bc8634fcafaccd8293/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:51:32Z, size = 215956, hashes = { sha256 = "2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f" } },
+    { url = "https://files.pythonhosted.org/packages/53/e9/5f85f6c5e20669dbe56b165c67b0260547dea97dba7e187938833d791687/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:51:34Z, size = 208652, hashes = { sha256 = "6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2" } },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:51:42Z, size = 199277, hashes = { sha256 = "ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421" } },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:51:44Z, size = 218758, hashes = { sha256 = "b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2" } },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:51:45Z, size = 215299, hashes = { sha256 = "5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30" } },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:51:47Z, size = 206811, hashes = { sha256 = "7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db" } },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:51:48Z, size = 193706, hashes = { sha256 = "bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8" } },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:51:50Z, size = 202706, hashes = { sha256 = "22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815" } },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:51:52Z, size = 202497, hashes = { sha256 = "7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a" } },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:51:53Z, size = 193511, hashes = { sha256 = "7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43" } },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:51:55Z, size = 220133, hashes = { sha256 = "58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0" } },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:51:56Z, size = 203035, hashes = { sha256 = "419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1" } },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:51:58Z, size = 216321, hashes = { sha256 = "5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f" } },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:51:59Z, size = 208973, hashes = { sha256 = "0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815" } },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-15T18:52:08Z, size = 208138, hashes = { sha256 = "f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc" } },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", upload-time = 2026-03-15T18:52:10Z, size = 224679, hashes = { sha256 = "06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e" } },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", upload-time = 2026-03-15T18:52:11Z, size = 223475, hashes = { sha256 = "e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077" } },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", upload-time = 2026-03-15T18:52:13Z, size = 215230, hashes = { sha256 = "95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f" } },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", upload-time = 2026-03-15T18:52:14Z, size = 199045, hashes = { sha256 = "7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e" } },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", upload-time = 2026-03-15T18:52:16Z, size = 211658, hashes = { sha256 = "172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484" } },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-15T18:52:17Z, size = 210769, hashes = { sha256 = "4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7" } },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", upload-time = 2026-03-15T18:52:19Z, size = 201328, hashes = { sha256 = "79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff" } },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", upload-time = 2026-03-15T18:52:21Z, size = 225302, hashes = { sha256 = "87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e" } },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", upload-time = 2026-03-15T18:52:22Z, size = 211127, hashes = { sha256 = "fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659" } },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", upload-time = 2026-03-15T18:52:24Z, size = 222840, hashes = { sha256 = "ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602" } },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-15T18:52:25Z, size = 216890, hashes = { sha256 = "197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407" } },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", upload-time = 2026-03-15T18:53:23Z, size = 61455, hashes = { sha256 = "947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69" } },
 ]
 
 [[packages]]
@@ -494,10 +505,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e4
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", upload-time = 2026-03-09T19:38:47Z, size = 40319, hashes = { sha256 = "b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", upload-time = 2026-03-09T19:38:45Z, size = 26720, hashes = { sha256 = "18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", upload-time = 2026-03-11T20:45:38Z, size = 40480, hashes = { sha256 = "b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", upload-time = 2026-03-11T20:45:37Z, size = 26759, hashes = { sha256 = "ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70" } }]
 
 [[packages]]
 name = "flatbuffers"
@@ -507,27 +518,27 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be0164
 
 [[packages]]
 name = "fonttools"
-version = "4.62.0"
+version = "4.62.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/5a/96/686339e0fda8142b7ebed39af53f4a5694602a729662f42a6209e3be91d0/fonttools-4.62.0.tar.gz", upload-time = 2026-03-09T16:50:06Z, size = 3579521, hashes = { sha256 = "0dc477c12b8076b4eb9af2e440421b0433ffa9e1dcb39e0640a6c94665ed1098" } }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", upload-time = 2026-03-13T13:54:25Z, size = 3580737, hashes = { sha256 = "e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/8c/c52a4310de58deeac7e9ea800892aec09b00bb3eb0c53265b31ec02be115/fonttools-4.62.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:48:55Z, size = 5032975, hashes = { sha256 = "d732938633681d6e2324e601b79e93f7f72395ec8681f9cdae5a8c08bc167e72" } },
-    { url = "https://files.pythonhosted.org/packages/0b/a1/d16318232964d786907b9b3613b8409f74cf0be2da400854509d3a864e43/fonttools-4.62.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:48:57Z, size = 4988544, hashes = { sha256 = "31a804c16d76038cc4e3826e07678efb0a02dc4f15396ea8e07088adbfb2578e" } },
-    { url = "https://files.pythonhosted.org/packages/b2/8d/7e745ca3e65852adc5e52a83dc213fe1b07d61cb5b394970fcd4b1199d1e/fonttools-4.62.0-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:48:59Z, size = 4971296, hashes = { sha256 = "090e74ac86e68c20150e665ef8e7e0c20cb9f8b395302c9419fa2e4d332c3b51" } },
-    { url = "https://files.pythonhosted.org/packages/e6/d4/b717a4874175146029ca1517e85474b1af80c9d9a306fc3161e71485eea5/fonttools-4.62.0-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:02Z, size = 5122503, hashes = { sha256 = "8f086120e8be9e99ca1288aa5ce519833f93fe0ec6ebad2380c1dee18781f0b5" } },
-    { url = "https://files.pythonhosted.org/packages/5f/ac/8e300dbf7b4d135287c261ffd92ede02d9f48f0d2db14665fbc8b059588a/fonttools-4.62.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:49:14Z, size = 5013708, hashes = { sha256 = "83c6524c5b93bad9c2939d88e619fedc62e913c19e673f25d5ab74e7a5d074e5" } },
-    { url = "https://files.pythonhosted.org/packages/fb/bc/60d93477b653eeb1ddf5f9ec34be689b79234d82dbdded269ac0252715b8/fonttools-4.62.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:49:16Z, size = 4964355, hashes = { sha256 = "106aec9226f9498fc5345125ff7200842c01eda273ae038f5049b0916907acee" } },
-    { url = "https://files.pythonhosted.org/packages/cb/eb/6dc62bcc3c3598c28a3ecb77e69018869c3e109bd83031d4973c059d318b/fonttools-4.62.0-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:49:18Z, size = 4953472, hashes = { sha256 = "15d86b96c79013320f13bc1b15f94789edb376c0a2d22fb6088f33637e8dfcbc" } },
-    { url = "https://files.pythonhosted.org/packages/82/b3/3af7592d9b254b7b7fec018135f8776bfa0d1ad335476c2791b1334dc5e4/fonttools-4.62.0-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:21Z, size = 5094701, hashes = { sha256 = "4f16c07e5250d5d71d0f990a59460bc5620c3cc456121f2cfb5b60475699905f" } },
-    { url = "https://files.pythonhosted.org/packages/6f/86/db65b63bb1b824b63e602e9be21b18741ddc99bcf5a7850f9181159ae107/fonttools-4.62.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:49:32Z, size = 4999387, hashes = { sha256 = "6247e58b96b982709cd569a91a2ba935d406dccf17b6aa615afaed37ac3856aa" } },
-    { url = "https://files.pythonhosted.org/packages/86/c8/c6669e42d2f4efd60d38a3252cebbb28851f968890efb2b9b15f9d1092b0/fonttools-4.62.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:49:34Z, size = 4912506, hashes = { sha256 = "840632ea9c1eab7b7f01c369e408c0721c287dfd7500ab937398430689852fd1" } },
-    { url = "https://files.pythonhosted.org/packages/2e/49/0ae552aa098edd0ec548413fbf818f52ceb70535016215094a5ce9bf8f70/fonttools-4.62.0-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:49:37Z, size = 4951202, hashes = { sha256 = "28a9ea2a7467a816d1bec22658b0cce4443ac60abac3e293bdee78beb74588f3" } },
-    { url = "https://files.pythonhosted.org/packages/71/65/ae38fc8a4cea6f162d74cf11f58e9aeef1baa7d0e3d1376dabd336c129e5/fonttools-4.62.0-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:39Z, size = 5060758, hashes = { sha256 = "5ae611294f768d413949fd12693a8cba0e6332fbc1e07aba60121be35eac68d0" } },
-    { url = "https://files.pythonhosted.org/packages/2b/df/bfaa0e845884935355670e6e68f137185ab87295f8bc838db575e4a66064/fonttools-4.62.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-09T16:49:50Z, size = 5137378, hashes = { sha256 = "b448075f32708e8fb377fe7687f769a5f51a027172c591ba9a58693631b077a8" } },
-    { url = "https://files.pythonhosted.org/packages/32/32/04f616979a18b48b52e634988b93d847b6346260faf85ecccaf7e2e9057f/fonttools-4.62.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-09T16:49:53Z, size = 4920714, hashes = { sha256 = "e5f1fa8cc9f1a56a3e33ee6b954d6d9235e6b9d11eb7a6c9dfe2c2f829dc24db" } },
-    { url = "https://files.pythonhosted.org/packages/3b/2e/274e16689c1dfee5c68302cd7c444213cfddd23cf4620374419625037ec6/fonttools-4.62.0-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-09T16:49:55Z, size = 5016012, hashes = { sha256 = "f8c8ea812f82db1e884b9cdb663080453e28f0f9a1f5027a5adb59c4cc8d38d1" } },
-    { url = "https://files.pythonhosted.org/packages/7f/0c/b08117270626e7117ac2f89d732fdd4386ec37d2ab3a944462d29e6f89a1/fonttools-4.62.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-09T16:49:57Z, size = 5042766, hashes = { sha256 = "03c6068adfdc67c565d217e92386b1cdd951abd4240d65180cec62fa74ba31b2" } },
-    { url = "https://files.pythonhosted.org/packages/9c/57/c2487c281dde03abb2dec244fd67059b8d118bd30a653cbf69e94084cb23/fonttools-4.62.0-py3-none-any.whl", upload-time = 2026-03-09T16:50:04Z, size = 1152427, hashes = { sha256 = "75064f19a10c50c74b336aa5ebe7b1f89fd0fb5255807bfd4b0c6317098f4af3" } },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:52:59Z, size = 5033197, hashes = { sha256 = "9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936" } },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:53:02Z, size = 4988768, hashes = { sha256 = "149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392" } },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:53:05Z, size = 4971512, hashes = { sha256 = "0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04" } },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:53:08Z, size = 5122723, hashes = { sha256 = "19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d" } },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:53:21Z, size = 5013926, hashes = { sha256 = "ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68" } },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:53:23Z, size = 4964575, hashes = { sha256 = "6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1" } },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:53:26Z, size = 4953693, hashes = { sha256 = "2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069" } },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:53:29Z, size = 5094920, hashes = { sha256 = "403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9" } },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:53:42Z, size = 4999608, hashes = { sha256 = "bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782" } },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:53:45Z, size = 4912726, hashes = { sha256 = "8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae" } },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:53:48Z, size = 4951422, hashes = { sha256 = "d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7" } },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:53:51Z, size = 5060979, hashes = { sha256 = "c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a" } },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", upload-time = 2026-03-13T13:54:04Z, size = 5137599, hashes = { sha256 = "ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4" } },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", upload-time = 2026-03-13T13:54:07Z, size = 4920933, hashes = { sha256 = "5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b" } },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", upload-time = 2026-03-13T13:54:10Z, size = 5016232, hashes = { sha256 = "92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87" } },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2026-03-13T13:54:13Z, size = 5042987, hashes = { sha256 = "bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c" } },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", upload-time = 2026-03-13T13:54:22Z, size = 1152647, hashes = { sha256 = "7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd" } },
 ]
 
 [[packages]]
@@ -612,10 +623,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/7d/59/7371175bfd949abfb1170aa076352131d7281bd9449c0f978604fc4431c3/google_auth-2.49.0.tar.gz", upload-time = 2026-03-06T21:53:06Z, size = 333444, hashes = { sha256 = "9cc2d9259d3700d7a257681f81052db6737495a1a46b610597f4b8bafe5286ae" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/37/45/de64b823b639103de4b63dd193480dce99526bd36be6530c2dba85bf7817/google_auth-2.49.0-py3-none-any.whl", upload-time = 2026-03-06T21:52:38Z, size = 240676, hashes = { sha256 = "f893ef7307f19cf53700b7e2f61b5a6affe3aa0edf9943b13788920ab92d8d87" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", upload-time = 2026-03-12T19:30:58Z, size = 333825, hashes = { sha256 = "16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", upload-time = 2026-03-12T19:30:53Z, size = 240737, hashes = { sha256 = "195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7" } }]
 
 [[packages]]
 name = "google-pasta"
@@ -1157,10 +1168,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409c
 
 [[packages]]
 name = "narwhals"
-version = "2.18.0"
+version = "2.18.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/47/b4/02a8add181b8d2cd5da3b667cd102ae536e8c9572ab1a130816d70a89edb/narwhals-2.18.0.tar.gz", upload-time = 2026-03-10T15:51:27Z, size = 620222, hashes = { sha256 = "1de5cee338bc17c338c6278df2c38c0dd4290499fcf70d75e0a51d5f22a6e960" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl", upload-time = 2026-03-10T15:51:24Z, size = 444865, hashes = { sha256 = "68378155ee706ac9c5b25868ef62ecddd62947b6df7801a0a156bc0a615d2d0d" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/59/96/45218c2fdec4c9f22178f905086e85ef1a6d63862dcc3cd68eb60f1867f5/narwhals-2.18.1.tar.gz", upload-time = 2026-03-24T15:11:25Z, size = 620578, hashes = { sha256 = "652a1fcc9d432bbf114846688884c215f17eb118aa640b7419295d2f910d2a8b" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl", upload-time = 2026-03-24T15:11:23Z, size = 444952, hashes = { sha256 = "a0a8bb80205323851338888ba3a12b4f65d352362c8a94be591244faf36504ad" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1625,10 +1636,10 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.3"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", upload-time = 2026-01-16T18:04:18Z, size = 146586, hashes = { sha256 = "9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", upload-time = 2026-01-16T18:04:17Z, size = 83371, hashes = { sha256 = "1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"
@@ -1726,10 +1737,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", upload-time = 2026-01-30T19:59:55Z, size = 98019, hashes = { sha256 = "35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", upload-time = 2026-01-30T19:59:54Z, size = 28224, hashes = { sha256 = "94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", upload-time = 2026-03-13T19:27:37Z, size = 102564, hashes = { sha256 = "c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", upload-time = 2026-03-13T19:27:35Z, size = 29726, hashes = { sha256 = "28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1823,10 +1834,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a79
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.3"
+version = "1.2.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/d7/7e/9f3b0dd3a074a6c3e1e79f35e465b1f2ee4b262d619de00cfce523cc9b24/python_discovery-1.1.3.tar.gz", upload-time = 2026-03-10T15:08:15Z, size = 56945, hashes = { sha256 = "7acca36e818cd88e9b2ba03e045ad7e93e1713e29c6bbfba5d90202310b7baa5" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/e7/80/73211fc5bfbfc562369b4aa61dc1e4bf07dc7b34df7b317e4539316b809c/python_discovery-1.1.3-py3-none-any.whl", upload-time = 2026-03-10T15:08:13Z, size = 31485, hashes = { sha256 = "90e795f0121bc84572e737c9aa9966311b9fde44ffb88a5953b3ec9b31c6945e" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/90/bcce6b46823c9bec1757c964dc37ed332579be512e17a30e9698095dcae4/python_discovery-1.2.0.tar.gz", upload-time = 2026-03-19T01:43:08Z, size = 58055, hashes = { sha256 = "7d33e350704818b09e3da2bd419d37e21e7c30db6e0977bb438916e06b41b5b1" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/c2/3c/2005227cb951df502412de2fa781f800663cccbef8d90ec6f1b371ac2c0d/python_discovery-1.2.0-py3-none-any.whl", upload-time = 2026-03-19T01:43:07Z, size = 31524, hashes = { sha256 = "1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a" } }]
 
 [[packages]]
 name = "pytz"
@@ -1985,13 +1996,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", upload-time = 2025-11-30T20:24:08Z, size = 591148, hashes = { sha256 = "3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856" } },
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", upload-time = 2025-11-30T20:24:10Z, size = 556030, hashes = { sha256 = "dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", upload-time = 2025-04-16T09:51:18Z, size = 29034, hashes = { sha256 = "e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", upload-time = 2025-04-16T09:51:17Z, size = 34696, hashes = { sha256 = "68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762" } }]
 
 [[packages]]
 name = "s3transfer"
@@ -2221,10 +2225,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff740
 
 [[packages]]
 name = "werkzeug"
-version = "3.1.6"
+version = "3.1.7"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", upload-time = 2026-02-19T15:17:18Z, size = 864736, hashes = { sha256 = "210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", upload-time = 2026-02-19T15:17:17Z, size = 225166, hashes = { sha256 = "7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", upload-time = 2026-03-24T01:08:07Z, size = 875700, hashes = { sha256 = "fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", upload-time = 2026-03-24T01:08:06Z, size = 226295, hashes = { sha256 = "4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f" } }]
 
 [[packages]]
 name = "wheel"

--- a/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -123,15 +123,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.64"
+version = "1.42.67"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6253f79dab41e62971026b56b31f04286237cf7439186124166e834dc4a63e1c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.64"
+version = "1.42.67"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.64-8-py3-none-any.whl", hashes = { sha256 = "6d20b74964f04e1e348018e334856f414f2d5dde1b618e9978344c93519adaa2" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
 
 [[packages]]
 name = "certifi"
@@ -297,9 +297,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "filelock"
-version = "3.25.1"
+version = "3.25.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.1-8-py3-none-any.whl", hashes = { sha256 = "37d177516fc5f3f9f2c115b37b7cae46b5f409d2c2581bef0f66aac23c928ca0" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/filelock-3.25.2-8-py3-none-any.whl", hashes = { sha256 = "1a06237406de68d077f625dd66d1c6ed8948192a5b5e9d509e224613f0cecd1c" } }]
 
 [[packages]]
 name = "flatbuffers"
@@ -342,9 +342,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "google-auth"
-version = "2.49.0"
+version = "2.49.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.0-8-py3-none-any.whl", hashes = { sha256 = "0b5ee3cd6ef9cffca33f6ae8f49ff83c801a4b05d159bfb816a62243296d8132" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/google_auth-2.49.1-8-py3-none-any.whl", hashes = { sha256 = "66042030906be9d7785567f0eed81d4d335b3e56f54a0c60193eb1d2c7aa7dcc" } }]
 
 [[packages]]
 name = "google-pasta"
@@ -687,9 +687,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "narwhals"
-version = "2.17.0"
+version = "2.18.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.17.0-8-py3-none-any.whl", hashes = { sha256 = "913a86059a3560391bd42127c6c92225b5cf34540b8678785ab0913c1937a818" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/narwhals-2.18.0-8-py3-none-any.whl", hashes = { sha256 = "b9d649dee7ce11d75a7c24f6d90b6530a4420869c299648e3718fb246ce3ffc2" } }]
 
 [[packages]]
 name = "nbclient"
@@ -1019,9 +1019,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.11.0-8-py3-none-any.whl", hashes = { sha256 = "0591de88e9cf017c9359ba66e0656e29cdae7a57aeaf78947f952aef1b8b9447" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1064,9 +1064,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "python-discovery"
-version = "1.1.2"
+version = "1.1.3"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.2-8-py3-none-any.whl", hashes = { sha256 = "ec835f207587c9cdd6ce59b1d08491e66d4de527385ba0d2595fa0b44c1a4053" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/python_discovery-1.1.3-8-py3-none-any.whl", hashes = { sha256 = "0a4f389c3546405adde681661b8bb985b160c126602b868e422fda5f171febf1" } }]
 
 [[packages]]
 name = "python-dotenv"
@@ -1139,12 +1139,6 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "bdce3b540862098992196b3380a66999bbed37408aecb3bf7ca9dcb1c0feaf93" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rpds_py-0.30.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d4553438b49e9a3489c3de0415a578064c11fa97b0d222bfe7aa4d2f1af59731" } },
 ]
-
-[[packages]]
-name = "rsa"
-version = "4.9.1"
-marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/rsa-4.9.1-8-py3-none-any.whl", hashes = { sha256 = "0f8ea382eb6353c825b5ea44c42b9619551a7e8a67cfaba349f0d35752e1a556" } }]
 
 [[packages]]
 name = "s3transfer"
@@ -1286,11 +1280,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "tornado"
-version = "6.5.4"
+version = "6.5.5"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "51e6d0644e5fa64d3cab035f92c14b4f3a2af6df5a009d71e3f35abba538bcc9" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.4-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "42bada2a90c446b1e8dbbc68611d377d35605e769b58c262ef2c5685fe4f49a5" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_aarch64.whl", hashes = { sha256 = "c0775112cc2ab1a7e944a6a661c06458a4679bcaebfb0a1bd84e2c1dd869a165" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/tornado-6.5.5-8-cp39-abi3-linux_x86_64.whl", hashes = { sha256 = "5342d0f38ea598a577533975f33267f962485bcea67828b7e277c22853005e13" } },
 ]
 
 [[packages]]

--- a/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -90,9 +90,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-25.4.0-8-py3-none-any.whl", hashes = { sha256 = "126f48fefecb46db4371aee825bd049e82107c22bb69c814341b8a564de9eb0c" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/attrs-26.1.0-8-py3-none-any.whl", hashes = { sha256 = "bb70d3307b7c4cc94457649823eae8d5a0fb76d0f67e01ac85362a3261250047" } }]
 
 [[packages]]
 name = "bcrypt"
@@ -123,15 +123,15 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "boto3"
-version = "1.42.67"
+version = "1.42.71"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/boto3-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "b66131ad5b2e1370d9cd5f7fa21e72cada024ebeb4145e14c7c190318b97d237" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/boto3-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "875431afa6c54392d5f36025da1efdf545b1520d5570989a63a5bd877b1c146c" } }]
 
 [[packages]]
 name = "botocore"
-version = "1.42.67"
+version = "1.42.71"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/botocore-1.42.67-8-py3-none-any.whl", hashes = { sha256 = "e2212aad080c1ce8d4a5e740dd6a1fea632320499481d18570d80e281f009593" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/botocore-1.42.71-2-py3-none-any.whl", hashes = { sha256 = "433e11987c54ebd212cba53b2096bc43bbcec9ba2aa39d9e4059167384b74ab3" } }]
 
 [[packages]]
 name = "certifi"
@@ -915,11 +915,11 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
 wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "97122b4219fc74d6b9fa6e41b485080ff321a31dd31fd33b2fd8eb36f550045f" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/protobuf-6.33.5-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "55f92461c32dedd5574daac55f079693dc1ba94c77fe1d4691b3d623a902ef5a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "3b825be3b33c315cd7d535d78cf3943687cae423c3db822dd327f15016155a99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/protobuf-6.33.6-2-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "9032e57769d206b9a013583bb68ebfac9516b2311bc93665419b4968b762e410" } },
 ]
 
 [[packages]]
@@ -967,6 +967,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "5f2aefda93dff508a809f26899c744d276f2d707fdefa473301d0daa3aa156e9" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "8c9d009aa86f24541e2e481edbaf99cdf31550938f88b05fee0fecb208e25043" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "c5b42543b7dafcd57a6eba4f6fe09e0ba672c6cf480fa97d2b8391209f2b4bf2" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyarrow-23.0.1-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "4da4f6b3301ecc683e732a33d351b6d2b8f3ad8204598248c758f2d1520dd595" } },
 ]
 
 [[packages]]
@@ -1019,9 +1021,9 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 
 [[packages]]
 name = "pyjwt"
-version = "2.12.0"
+version = "2.12.1"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/pyjwt-2.12.0-8-py3-none-any.whl", hashes = { sha256 = "99a1b7042200196b4bc158ef6a8676afe27b8510dd0884565a44fc64c5c420ed" } }]
+wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cpu-ubi9/pyjwt-2.12.1-2-py3-none-any.whl", hashes = { sha256 = "1404b596ee0cc4ca9c56590bc0115e7602933803ab3d9b756235ac752da6ea2f" } }]
 
 [[packages]]
 name = "pymongo"
@@ -1426,6 +1428,8 @@ marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "e0d589b9bd196c3a0f1fae4e24ddb797cc6955247e55a19e5981957679ab2e86" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-8-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "157216b1a209178b5d7be8f4854168fffd05c9d074883705a6a7fac1b723cb98" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_aarch64.whl", hashes = { sha256 = "7f2378720203f3e878d4c731aef08f5f291f0d01e0db66a0d32c533e43041522" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.4-EA2/cuda12.9-ubi9/yarl-1.23.0-9-cp312-cp312-linux_x86_64.whl", hashes = { sha256 = "d9d9b2c1ebf19f7f57cb6a17544bc8a920e395eabf15c152480415eec8b1a6ec" } },
 ]
 
 [[packages]]


### PR DESCRIPTION
## Summary
- Run `FORCE_LOCKFILES_UPGRADE=1 gmake refresh-lock-files` to update all pylock files
- Version bumps: attrs 25.4.0→26.1.0, boto3/botocore 1.42.67→1.42.71, protobuf 6.33.5→6.33.6 / 7.34.0→7.34.1, pyjwt 2.12.0→2.12.1, new pyarrow/yarl arch wheels
- **Note:** protobuf 6.33.6 dropped ppc64le/s390x wheels — this may break builds for jupyter-minimal, jupyter-datascience, runtime-minimal, runtime-datascience on those architectures

## Test plan
- [ ] Verify Konflux builds pass for all image variants, especially ppc64le/s390x targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned dependency versions across all container environments, including attrs, boto3, botocore, protobuf, tornado, jupyterlab, narwhals, and others to their latest patch releases.
  * Removed rsa package dependency.
  * Enhanced architecture support by adding wheel variants for multiple platforms and build tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->