### PR TITLE
[rhoai-3.3] CVE-2026-2492: mitigate TensorFlow HDF5 plugin privilege escalation

### DIFF
--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -158,6 +158,10 @@ ARG TENSORFLOW_SOURCE_CODE=jupyter/rocm/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
+# CVE-2026-2492: Disable HDF5 plugin loading to prevent local privilege escalation
+# via unsecured plugin search path in TensorFlow's h5py integration
+ENV HDF5_PLUGIN_PATH=disable
+
 COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 
 USER 0

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -158,6 +158,10 @@ ARG TENSORFLOW_SOURCE_CODE=jupyter/rocm/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
+# CVE-2026-2492: Disable HDF5 plugin loading to prevent local privilege escalation
+# via unsecured plugin search path in TensorFlow's h5py integration
+ENV HDF5_PLUGIN_PATH=disable
+
 LABEL name="odh-notebook-jupyter-rocm-tensorflow-ubi9-python-3.12" \
     summary="Jupyter AMD tensorflow notebook image for ODH notebooks" \
     description="Jupyter AMD tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -160,6 +160,10 @@ ARG TENSORFLOW_SOURCE_CODE=jupyter/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
+# CVE-2026-2492: Disable HDF5 plugin loading to prevent local privilege escalation
+# via unsecured plugin search path in TensorFlow's h5py integration
+ENV HDF5_PLUGIN_PATH=disable
+
 LABEL name="odh-notebook-cuda-jupyter-tensorflow-ubi9-python-3.12" \
     summary="Jupyter CUDA tensorflow notebook image for ODH notebooks" \
     description="Jupyter CUDA tensorflow notebook image with base Python 3.12 builder image based on UBI9 for ODH notebooks" \

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -160,6 +160,10 @@ ARG TENSORFLOW_SOURCE_CODE=jupyter/tensorflow/ubi9-python-3.12
 
 WORKDIR /opt/app-root/bin
 
+# CVE-2026-2492: Disable HDF5 plugin loading to prevent local privilege escalation
+# via unsecured plugin search path in TensorFlow's h5py integration
+ENV HDF5_PLUGIN_PATH=disable
+
 # Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -91,6 +91,10 @@ LABEL name="odh-notebook-cuda-runtime-tensorflow-ubi9-python-3.12" \
 
 WORKDIR /opt/app-root/bin
 
+# CVE-2026-2492: Disable HDF5 plugin loading to prevent local privilege escalation
+# via unsecured plugin search path in TensorFlow's h5py integration
+ENV HDF5_PLUGIN_PATH=disable
+
 # Install Python packages from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -81,6 +81,10 @@ ENV UV_DEFAULT_INDEX=https://pypi.org/simple
 
 WORKDIR /opt/app-root/bin
 
+# CVE-2026-2492: Disable HDF5 plugin loading to prevent local privilege escalation
+# via unsecured plugin search path in TensorFlow's h5py integration
+ENV HDF5_PLUGIN_PATH=disable
+
 # Install Python packages from requirements.txt
 COPY ${TENSORFLOW_SOURCE_CODE}/pylock.toml ./
 # Copy Elyra dependencies for air-gapped enviroment


### PR DESCRIPTION
This PR aims to provide the same fix applied to RHOAI 2.25, on PR #2122 

## Summary                                                                                                                                                               
   - Mitigates **CVE-2026-2492** (CVSS 7.0 High) — TensorFlow HDF5 Library Uncontrolled Search Path Element Local Privilege Escalation                                      
   - Sets `ENV HDF5_PLUGIN_PATH=disable` in all 6 TensorFlow Dockerfiles (jupyter CUDA, jupyter ROCm, runtime CUDA — both upstream and Konflux variants)                    
   - This is functionally identical to the [upstream TensorFlow fix](https://github.com/tensorflow/tensorflow/commit/46e7f7fb144fd11cf6d17c23dd47620328d77082) which sets
    the same env var before h5py imports
   - TensorFlow upgrade to 2.21.0 (which includes the upstream fix natively) is **not feasible** due to tf2onnx incompatibility with Keras 3
   (`tf2onnx.convert.from_keras` breaks with TF ≥2.16)

   ## Files Changed
   - `jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda`
   - `jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda`
   - `jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm`
   - `jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm`
   - `runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda`
   - `runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda`

### Jira
   - https://redhat.atlassian.net/browse/RHOAIENG-50454
   - https://redhat.atlassian.net/browse/RHOAIENG-50453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled HDF5 plugin loading in TensorFlow and Jupyter environments to improve security and stability across CPU and GPU configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->