### PR TITLE
[rhoai-3.3] RHOAIENG-58277: fix: pin meson<1.11 to fix pandas builds on ppc64le/s390x

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -72,7 +72,9 @@ pip install --no-cache-dir uv
 source ./devel_env_setup.sh
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-UV_NO_CACHE=false UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+# RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+echo "meson<1.11" > build_constraints.txt
+UV_NO_CACHE=false UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 EOF
 
 # dummy file to make image build wait for this stage

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -417,6 +417,8 @@ echo "Installing software and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
+    echo "meson<1.11" > build_constraints.txt
     # We need special flags and environment variables when building packages
     # aipcc does not have some dependencies to build cryptography==43.0.3 on ppc64le, so we need to use pypi.org/simple
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
@@ -424,6 +426,7 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     uv pip install --strict --no-deps --no-cache --no-config --no-progress \
         --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
         --extra-index-url https://pypi.org/simple \
+        --build-constraint build_constraints.txt \
         --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -415,6 +415,8 @@ echo "Installing software and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
+    echo "meson<1.11" > build_constraints.txt
     # We need special flags and environment variables when building packages
     # aipcc does not have some dependencies to build cryptography==43.0.3 on ppc64le, so we need to use pypi.org/simple
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
@@ -422,6 +424,7 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     uv pip install --strict --no-deps --no-cache --no-config --no-progress \
         --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
         --extra-index-url https://pypi.org/simple \
+        --build-constraint build_constraints.txt \
         --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -179,7 +179,7 @@ if [[ $(uname -m) == "ppc64le" ]] || [[ $(uname -m) == "s390x" ]]; then
     make -j${MAX_JOBS} VERBOSE=1 && \
     make install -j${MAX_JOBS} && \
     cd ../../python/ && \
-    uv pip install --extra-index-url https://pypi.org/simple -v -r requirements-build.txt && \
+    uv pip install --extra-index-url https://pypi.org/simple -v -r requirements-build.txt 'setuptools<82' && \
     if [[ $(uname -m) == "s390x" ]]; then
         PYARROW_WITH_PARQUET=1 \
         PYARROW_WITH_DATASET=1 \

--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -179,7 +179,7 @@ if [[ $(uname -m) == "ppc64le" ]] || [[ $(uname -m) == "s390x" ]]; then
     make -j${MAX_JOBS} VERBOSE=1 && \
     make install -j${MAX_JOBS} && \
     cd ../../python/ && \
-    uv pip install --extra-index-url https://pypi.org/simple -v -r requirements-build.txt 'setuptools<82' && \
+    uv pip install --extra-index-url https://pypi.org/simple -v -r requirements-build.txt && \
     if [[ $(uname -m) == "s390x" ]]; then
         PYARROW_WITH_PARQUET=1 \
         PYARROW_WITH_DATASET=1 \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -438,15 +438,17 @@ ENV ELYRA_INSTALL_PACKAGES="false"
 RUN --mount=type=cache,target=/root/.cache/pip /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Installing softwares and packages"
+# RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+echo "meson<1.11" > build_constraints.txt
 if [ "$TARGETARCH" = "ppc64le" ]; then
     export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
     export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 elif [ "$TARGETARCH" = "s390x" ]; then
     # For s390x, we need special flags and environment variables for building packages
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
     CFLAGS="-O3" CXXFLAGS="-O3" \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -428,15 +428,17 @@ ENV ELYRA_INSTALL_PACKAGES="false"
 RUN --mount=type=cache,target=/root/.cache/pip /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Installing softwares and packages"
+# RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+echo "meson<1.11" > build_constraints.txt
 if [ "$TARGETARCH" = "ppc64le" ]; then
     export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
     export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 elif [ "$TARGETARCH" = "s390x" ]; then
     # For s390x, we need special flags and environment variables for building packages
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
     CFLAGS="-O3" CXXFLAGS="-O3" \
-    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.


### PR DESCRIPTION
## Summary
- Pin `meson<1.11` as a build constraint in Dockerfiles for jupyter-datascience, codeserver, and runtimes-datascience images
- Meson 1.11.0 (released 2026-04-13) introduced stricter type checking that breaks pandas 2.3.3 source builds on ppc64le and s390x, where no pre-built wheel exists on PyPI
- Follows the existing `--build-constraint` pattern used in jupyter/trustyai

## Test plan
- [x] Rebuild `odh-workbench-jupyter-datascience-cpu-py312` on ppc64le and s390x — pandas installs successfully
- [x] Rebuild `codeserver-ubi9-python-3.12` on ppc64le and s390x — pandas installs successfully
- [x] Rebuild `runtimes-datascience` on ppc64le and s390x — pandas installs successfully
- [ ] Verify x86_64/aarch64 builds are unaffected (pre-built wheels, constraint is a no-op)

Resolves: [RHOAIENG-58277](https://redhat.atlassian.net/browse/RHOAIENG-58277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Resolved build failures impacting Python package installation on ppc64le and s390x processor architectures for datascience and codeserver container images. These fixes enhance build reliability and platform support across multiple container image variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->