### PR TITLE
[rhoai-2.25] RHOAIENG-58277: fix: pin meson<1.11 to fix pandas builds on ppc64le/s390x

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -56,7 +56,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+    echo "meson<1.11" > build_constraints.txt && \
+    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 
 # dummy file to make image build wait for this stage
 RUN touch /tmp/control

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -56,7 +56,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+    echo "meson<1.11" > build_constraints.txt && \
+    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 
 # dummy file to make image build wait for this stage
 RUN touch /tmp/control

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -336,12 +336,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing software and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
         # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress \
             --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
+            --build-constraint build_constraints.txt \
             --requirements=./pylock.toml; \
     else \
         # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -336,12 +336,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing software and packages" && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
         # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress \
             --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
+            --build-constraint build_constraints.txt \
             --requirements=./pylock.toml; \
     else \
         # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -333,15 +333,17 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing softwares and packages" && \
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ]; then \
         export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; \
         export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH && \
-        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml; \
+        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     elif [ "$TARGETARCH" = "s390x" ]; then \
         # For s390x, we need special flags and environment variables for building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \
-        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml; \
+        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     else \
         # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
         #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -336,15 +336,17 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing softwares and packages" && \
+    # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ]; then \
         export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; \
         export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH && \
-        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml; \
+        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     elif [ "$TARGETARCH" = "s390x" ]; then \
         # For s390x, we need special flags and environment variables for building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \
-        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml; \
+        uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     else \
         # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
         #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.


### PR DESCRIPTION
## Summary
- Pin `meson<1.11` as a build constraint in Dockerfiles for jupyter-datascience, codeserver, and runtimes-datascience images
- Meson 1.11.0 (released 2026-04-13) introduced stricter type checking that breaks pandas 2.3.3 source builds on ppc64le and s390x, where no pre-built wheel exists on PyPI
- Follows the existing `--build-constraint` pattern used in jupyter/trustyai
- Backport of the same fix applied to rhoai-3.3 in #2126

## Test plan
- [x] Rebuild `odh-workbench-jupyter-datascience-cpu-py312` on ppc64le and s390x — pandas installs successfully
- [x] Rebuild `codeserver-ubi9-python-3.12` on ppc64le and s390x — pandas installs successfully
- [x] Rebuild `runtimes-datascience` on ppc64le and s390x — pandas installs successfully
- [x] Verify x86_64/aarch64 builds are unaffected (pre-built wheels, constraint is a no-op)

Resolves: [RHOAIENG-58277](https://redhat.atlassian.net/browse/RHOAIENG-58277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added Meson version constraints to Python dependency installation in container images to resolve build compatibility issues across all supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->