### PR TITLE
[rhoai-2.25] fix(cve): CVE-2026-27904 & CVE-2026-26996 - minimatch

### DIFF
--- a/jupyter/utils/addons/package.json5
+++ b/jupyter/utils/addons/package.json5
@@ -38,4 +38,10 @@
     '@types/webpack': '^5.28.5'
   },
   // "packageManager": "pnpm@10.8.1" // forces install of a precise version, so annoying
+  pnpm: {
+    overrides: {
+      // RHOAIENG-51140 / RHOAIENG-50431: CVE-2026-27904 & CVE-2026-26996 minimatch DoS
+      "minimatch": ">=10.2.3",
+    },
+  },
 }

--- a/jupyter/utils/addons/pnpm-lock.yaml
+++ b/jupyter/utils/addons/pnpm-lock.yaml
@@ -1056,9 +1056,9 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -2506,7 +2506,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.0
-      minimatch: 10.0.1
+      minimatch: 10.2.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -2758,7 +2758,7 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.0.1:
+  minimatch@10.2.3:
     dependencies:
       brace-expansion: 2.0.1
 


### PR DESCRIPTION
- Update minimatch from 10.0.1 to 10.2.3 in jupyter/utils/addons
- Add pnpm.overrides to package.json5 to prevent regression
- Fixes DoS via catastrophic backtracking in glob expressions
- Fixes DoS via specially crafted glob patterns

Resolves: RHOAIENG-51140, RHOAIENG-51136, RHOAIENG-51134, RHOAIENG-51133, RHOAIENG-51128, [RHOAIENG-51127](https://redhat.atlassian.net/browse/RHOAIENG-51127)
Resolves: RHOAIENG-50431, RHOAIENG-50427, RHOAIENG-50425, RHOAIENG-50424, RHOAIENG-50419, [RHOAIENG-50418](https://redhat.atlassian.net/browse/RHOAIENG-50418)
