### PR TITLE
[rhoai-3.3] RHOAIENG-58277: fix installation of pandas in jupter-datascience by pinning meson version 

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -415,6 +415,8 @@ echo "Installing software and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    echo "Creating build constraint for meson<1.11 (pandas fix for ppc64le/s390x)"
+    echo "meson<1.11" > /tmp/build-constraint.txt
     # We need special flags and environment variables when building packages
     # aipcc does not have some dependencies to build cryptography==43.0.3 on ppc64le, so we need to use pypi.org/simple
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
@@ -422,6 +424,7 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     uv pip install --strict --no-deps --no-cache --no-config --no-progress \
         --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
         --extra-index-url https://pypi.org/simple \
+        --build-constraint /tmp/build-constraint.txt \
         --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,


### PR DESCRIPTION
Builds for `odh-workbench-jupyter-datascience-cpu-py312-rhel9` were failing on ppc64le and s390x architectures with:

```
× Failed to build `pandas==2.3.3`
  ╰─▶ Call to `mesonpy.build_wheel` failed (exit status: 1)
      
      ../pandas/_libs/tslibs/meson.build:32:7: ERROR: python.extension_module
      keyword argument 'dependencies' was of type array[str] but should have
      been array[Dependency | InternalDependency]
```

Pinning the Meson version to < 1.11 using `--build-constraint` for ppc64le and s390x builds resolves the issue mentioned above.
Have tested the changes locally and  able to build the image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration for specific system architectures to improve compatibility and reliability during installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->