### PR TITLE
[rhoai-3.3] RHAIENG-4574: fix nginx.conf corruption race in envsubst|tee

### DIFF
--- a/codeserver/ubi9-python-3.12/run-nginx.sh
+++ b/codeserver/ubi9-python-3.12/run-nginx.sh
@@ -24,7 +24,14 @@ else
         export BASE_URL="_"
     fi
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
-    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+
+    # A temp file is used because piping envsubst directly into the same file via `tee`
+    # is a race condition: `tee` can truncate the file before `envsubst` finishes reading it,
+    # resulting in an empty/corrupt config and "no events section" errors from nginx.
+    tmp=$(mktemp)
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
 fi
 
 nginx

--- a/rstudio/c9s-python-3.12/run-nginx.sh
+++ b/rstudio/c9s-python-3.12/run-nginx.sh
@@ -24,7 +24,14 @@ else
         export BASE_URL="_"
     fi
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
-    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+
+    # A temp file is used because piping envsubst directly into the same file via `tee`
+    # is a race condition: `tee` can truncate the file before `envsubst` finishes reading it,
+    # resulting in an empty/corrupt config and "no events section" errors from nginx.
+    tmp=$(mktemp)
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
 fi
 
 nginx

--- a/rstudio/rhel9-python-3.12/run-nginx.sh
+++ b/rstudio/rhel9-python-3.12/run-nginx.sh
@@ -24,7 +24,14 @@ else
         export BASE_URL="_"
     fi
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
-    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+
+    # A temp file is used because piping envsubst directly into the same file via `tee`
+    # is a race condition: `tee` can truncate the file before `envsubst` finishes reading it,
+    # resulting in an empty/corrupt config and "no events section" errors from nginx.
+    tmp=$(mktemp)
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
 fi
 
 nginx


### PR DESCRIPTION
## Summary

Backports the `envsubst | tee` → temp-file fix from main (`bbffd5b06`) to `rhoai-3.3`.

The `envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf` pattern reads from and writes to the same file in a single shell pipeline. `tee` truncates the output file on open (`O_WRONLY|O_TRUNC`), which races with `envsubst` still reading from the same inode. When `tee` wins the race, nginx sees an empty or partial config and fails with:

```
nginx: [emerg] no "events" section in configuration
```

This failure is **reproducible on s390x** (likely due to I/O scheduling differences on remote SSH builders) but the race is theoretically possible on any architecture.

**Fix:** Write envsubst output to a temp file, then overwrite the original. Applied to all three affected files:
- `codeserver/ubi9-python-3.12/run-nginx.sh`
- `rstudio/rhel9-python-3.12/run-nginx.sh`
- `rstudio/c9s-python-3.12/run-nginx.sh`

## Evidence

- **On-push codeserver builds on rhoai-3.3 fail almost every commit** since at least March 2026
- The only recent success was commit `c625e3653` (April 1-2)
- The fix already exists on `main` and `rhoai-3.4` (commit `bbffd5b06`)
- Jira: [RHAIENG-4574](https://redhat.atlassian.net/browse/RHAIENG-4574)

## Test plan

- [ ] Verify codeserver s390x on-push build passes after merge
- [ ] Verify rstudio builds are not broken by the change

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stability of nginx configuration updates across multiple environments through improved file handling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->