### PR TITLE
[rhoai-2.25] RHAIENG-4574: fix nginx.conf corruption race in envsubst|tee

### DIFF
--- a/codeserver/ubi9-python-3.12/run-nginx.sh
+++ b/codeserver/ubi9-python-3.12/run-nginx.sh
@@ -20,7 +20,14 @@ if [ -z "$NB_PREFIX" ]; then
 else
     export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
-    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+
+    # A temp file is used because piping envsubst directly into the same file via `tee`
+    # is a race condition: `tee` can truncate the file before `envsubst` finishes reading it,
+    # resulting in an empty/corrupt config and "no events section" errors from nginx.
+    tmp=$(mktemp)
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
 fi
 
 nginx

--- a/rstudio/c9s-python-3.11/run-nginx.sh
+++ b/rstudio/c9s-python-3.11/run-nginx.sh
@@ -20,7 +20,14 @@ if [ -z "$NB_PREFIX" ]; then
 else
     export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
-    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+
+    # A temp file is used because piping envsubst directly into the same file via `tee`
+    # is a race condition: `tee` can truncate the file before `envsubst` finishes reading it,
+    # resulting in an empty/corrupt config and "no events section" errors from nginx.
+    tmp=$(mktemp)
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
 fi
 
 nginx

--- a/rstudio/rhel9-python-3.11/run-nginx.sh
+++ b/rstudio/rhel9-python-3.11/run-nginx.sh
@@ -20,7 +20,14 @@ if [ -z "$NB_PREFIX" ]; then
 else
     export BASE_URL=$(echo $NB_PREFIX | awk -F/ '{ print $4"-"$3 }')$(echo $NOTEBOOK_ARGS | grep -Po 'hub_host":"\K.*?(?=")' | awk -F/ '{ print $3 }' | awk -F. '{for (i=2; i<=NF; i++) printf ".%s", $i}')
     envsubst '${NB_PREFIX},${BASE_URL}' < /opt/app-root/etc/nginx.default.d/proxy.conf.template_nbprefix > /opt/app-root/etc/nginx.default.d/proxy.conf
-    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf
+
+    # A temp file is used because piping envsubst directly into the same file via `tee`
+    # is a race condition: `tee` can truncate the file before `envsubst` finishes reading it,
+    # resulting in an empty/corrupt config and "no events section" errors from nginx.
+    tmp=$(mktemp)
+    envsubst '${BASE_URL}' < /etc/nginx/nginx.conf > "$tmp"
+    cat "$tmp" > /etc/nginx/nginx.conf
+    rm -f "$tmp"
 fi
 
 nginx


### PR DESCRIPTION
* https://github.com/opendatahub-io/notebooks/issues/1285

## Summary

Backports the `envsubst | tee` → temp-file fix to `rhoai-2.25`.

Same fix as PR #2133 (rhoai-3.3) and commit `bbffd5b06` (main).

The `envsubst '${BASE_URL}' < /etc/nginx/nginx.conf | tee /etc/nginx/nginx.conf` pattern reads from and writes to the same file in a single shell pipeline. `tee` truncates the file before `envsubst` reads it, producing a corrupt config.

Reproduced on real s390x hardware (Testing Farm RHEL 9.7):
- Buggy pattern: **500/500 corruptions (100%)**
- Fixed pattern: **0/500 corruptions**

Cross-platform failure rates:
| Platform | Failure rate |
|---|---|
| s390x native | 100% |
| x86_64 native | 0.6% |
| s390x QEMU on x86_64 | 0% (host scheduler dominates) |

Strace confirms: on s390x, `tee`'s `openat(O_TRUNC)` always completes before `envsubst`'s `openat(O_RDONLY)`.

**Files fixed:**
- `codeserver/ubi9-python-3.12/run-nginx.sh`
- `rstudio/rhel9-python-3.11/run-nginx.sh`
- `rstudio/c9s-python-3.11/run-nginx.sh`

## Test plan
- [ ] Verify codeserver s390x build passes after merge
- [ ] Verify rstudio builds are not broken

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced nginx configuration update reliability to prevent potential corruption during substitution across multiple container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->