### PR TITLE
[rhoai-3.3] fix(ci): update trivy-action to v0.35.0, add .pinact.yaml

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -18,7 +18,7 @@ jobs:
 
       # https://github.com/astral-sh/setup-uv
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           version: "latest"
           activate-environment: false
@@ -26,13 +26,13 @@ jobs:
           enable-cache: false
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # Trivy does not support pylock.toml https://github.com/aquasecurity/trivy/discussions/9408
       - run: find . -name pyproject.toml -execdir uv lock \;
 
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # 0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           scan-type: 'fs'
           format: 'sarif'
@@ -42,6 +42,6 @@ jobs:
           ignore-unfixed: false
 
       - name: Update Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,8 @@
+---
+# pinact configuration
+# https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Two spaces before # to satisfy yamllint's "comments" rule
+# (too few spaces before comment: expected 2)
+separator: "  # "


### PR DESCRIPTION
## Summary

- Update `trivy-action` from broken v0.33.1 to v0.35.0 (digest-pinned)
- Add `.pinact.yaml` config (already present on main and rhoai-3.4)

The v0.33.1 install script fails to download current Trivy releases, causing the `Security / Trivy scan (fs)` check to fail on every PR.

Upstream PR: https://github.com/opendatahub-io/notebooks/pull/3384

Made with [Cursor](https://cursor.com)