### PR TITLE
[rhoai-2.25] fix(cve): CVE-2026-30922 - update pyasn1 to 0.6.3

### DIFF
--- a/codeserver/ubi9-python-3.12/pylock.toml
+++ b/codeserver/ubi9-python-3.12/pylock.toml
@@ -1716,9 +1716,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -10,3 +10,7 @@
 # RHAIENG-4014: CVE-2026-33236 NLTK path traversal in XML index files
 # Reference: https://access.redhat.com/security/cve/CVE-2026-33236
 nltk>=3.9.4
+
+# RHAIENG-3841: CVE-2026-30922 pyasn1 Denial of Service via Unbounded Recursion
+# Reference: https://access.redhat.com/security/cve/CVE-2026-30922
+pyasn1>=0.6.3

--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -11,6 +11,6 @@
 # Reference: https://access.redhat.com/security/cve/CVE-2026-33236
 nltk>=3.9.4
 
-# RHAIENG-3841: CVE-2026-30922 pyasn1 Denial of Service via Unbounded Recursion
+# CVE-2026-30922 pyasn1 Denial of Service via Unbounded Recursion
 # Reference: https://access.redhat.com/security/cve/CVE-2026-30922
 pyasn1>=0.6.3

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -3374,9 +3374,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -3798,10 +3798,10 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -3510,9 +3510,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -3372,9 +3372,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -3548,9 +3548,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -3659,9 +3659,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -3155,9 +3155,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -2924,10 +2924,10 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -3052,9 +3052,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -2914,9 +2914,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -3084,9 +3084,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -3201,9 +3201,9 @@ wheels = [
 
 [[packages]]
 name = "pyasn1"
-version = "0.6.1"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", upload-time = 2024-09-10T22:41:42Z, size = 145322, hashes = { sha256 = "6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", upload-time = 2024-09-11T16:00:36Z, size = 83135, hashes = { sha256 = "0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629" } }]
+version = "0.6.3"
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", upload-time = 2026-03-17T01:06:53Z, size = 148685, hashes = { sha256 = "697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", upload-time = 2026-03-17T01:06:52Z, size = 83997, hashes = { sha256 = "a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde" } }]
 
 [[packages]]
 name = "pyasn1-modules"


### PR DESCRIPTION
## CVE Details

| Field | Value |
|-------|-------|
| CVE ID | CVE-2026-30922 |
| GHSA | GHSA-jr27-m4p2-rc6r |
| Severity | Medium |
| Title | pyasn1 Vulnerable to Denial of Service via Unbounded Recursion |
| Affected | pyasn1 ≤ 0.6.2 |
| Fixed in | 0.6.3 |

## Fix Summary

Updated pyasn1 from 0.6.1 to 0.6.3 across all 13 workbench and pipeline runtime images in the rhoai-2.25 branch. pyasn1 is a pure-Python ASN.1 library used for cryptographic operations and X.509 certificate parsing.

### Changes

**`dependencies/cve-constraints.txt`**
- Added: `pyasn1>=0.6.3` (with [RHOAIENG-54242](https://redhat.atlassian.net/browse/RHOAIENG-54242) and CVE reference)

**13 `pylock.toml` files** (all workbench + pipeline runtime images):
- Updated pyasn1: `0.6.1` → `0.6.3`
- New wheel sha256: `a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde`
- New sdist sha256: `697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf`

Files updated:
- `jupyter/trustyai/ubi9-python-3.12/pylock.toml`
- `jupyter/datascience/ubi9-python-3.12/pylock.toml`
- `jupyter/pytorch/ubi9-python-3.12/pylock.toml`
- `jupyter/tensorflow/ubi9-python-3.12/pylock.toml`
- `jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml`
- `jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml`
- `jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml`
- `runtimes/datascience/ubi9-python-3.12/pylock.toml`
- `runtimes/pytorch/ubi9-python-3.12/pylock.toml`
- `runtimes/tensorflow/ubi9-python-3.12/pylock.toml`
- `runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml`
- `runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml`
- `codeserver/ubi9-python-3.12/pylock.toml`

## Test Results

⚠️ Tests could not be run — hermetic Konflux/cachi2 builds require a full CI environment. Checksums verified against PyPI (files.pythonhosted.org). Post-fix grep confirmed no pyasn1 ≤ 0.6.2 remains in any lock file.

## Breaking Changes

None. pyasn1 0.6.3 is backward-compatible with 0.6.1.

## Verification Steps

- [ ] Confirm Konflux build pipeline succeeds for affected images
- [ ] Run `pip show pyasn1` inside built container to confirm 0.6.3
- [ ] Run `pip-audit` to verify CVE-2026-30922 no longer flagged

## Risk Assessment

**Low** — pure-Python package, single universal wheel, minor patch release, all 13 images updated consistently.

## Jira References

[RHOAIENG-54242](https://redhat.atlassian.net/browse/RHOAIENG-54242)
[RHOAIENG-54241](https://redhat.atlassian.net/browse/RHOAIENG-54241)
[RHOAIENG-54240](https://redhat.atlassian.net/browse/RHOAIENG-54240)
[RHOAIENG-54239](https://redhat.atlassian.net/browse/RHOAIENG-54239)
[RHOAIENG-54238](https://redhat.atlassian.net/browse/RHOAIENG-54238)
[RHOAIENG-54237](https://redhat.atlassian.net/browse/RHOAIENG-54237)
[RHOAIENG-54233](https://redhat.atlassian.net/browse/RHOAIENG-54233)
[RHOAIENG-54232](https://redhat.atlassian.net/browse/RHOAIENG-54232)
[RHOAIENG-54231](https://redhat.atlassian.net/browse/RHOAIENG-54231)
[RHOAIENG-54230](https://redhat.atlassian.net/browse/RHOAIENG-54230)
[RHOAIENG-54229](https://redhat.atlassian.net/browse/RHOAIENG-54229)
[RHOAIENG-54227](https://redhat.atlassian.net/browse/RHOAIENG-54227)
[RHOAIENG-54225](https://redhat.atlassian.net/browse/RHOAIENG-54225)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pyasn1 dependency to 0.6.3 across multiple environments and lockfiles.
  * Added a CVE-based minimum-version constraint for pyasn1 (addresses CVE-2026-30922).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-54242]: https://redhat.atlassian.net/browse/RHOAIENG-54242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-54242]: https://redhat.atlassian.net/browse/RHOAIENG-54242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ