### PR TITLE
chore: add .cve-fix/examples.md guidance for CVE fixer workflow

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,0 +1,22 @@
+<!-- last-analyzed: 2026-04-22 | cve-merged: 0 -->
+
+<!-- Insufficient PR history for full pattern extraction.
+     Update with /guidance.update after more CVE fixes are merged. -->
+
+## Titles
+- No CVE PR history available yet — follow conventional commit format: `fix(cve): CVE-YYYY-XXXXX - <package>`
+
+## Branches
+- `fix/cve-YYYY-XXXXX-<package>-attempt-N`
+
+## Files
+- Unknown — update after analyzing merged CVE PRs
+
+## Co-upgrades
+- Unknown — update after analyzing merged CVE PRs
+
+## PR Description
+- Include: CVE ID, severity, affected package, fix summary, test results, Jira references
+
+## Don'ts
+- ❌ Don't combine multiple CVE fixes in a single PR


### PR DESCRIPTION
Adds `.cve-fix/examples.md` so the CVE fixer workflow knows how to
create fix PRs matching this repo's conventions (branch naming, files that
change together, co-upgrades, etc.).

Generated by `/onboard` — no CVE PR history was available yet.
Run `/guidance.update` after more CVE fixes are merged to improve guidance quality.

🤖 Generated by /onboard