### PR TITLE
[rhoai-3.4] RHAIENG-4576: fix(ci): docs.yaml workflow produces empty release notes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,9 +13,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  poetry_version: '1.8.3'
-
 jobs:
   generate-releasenotes:
     name: Generate list of images for release notes

--- a/ci/package_versions.py
+++ b/ci/package_versions.py
@@ -72,9 +72,7 @@ class Tag:
         return json.loads(self._data["annotations"]["opendatahub.io/notebook-python-dependencies"])
 
 
-def main():
-    pathname = "manifests/base/*.yaml"
-    # pathname = 'manifests/overlays/additional/*.yaml'
+def _load_imagestreams(pathname: str) -> list[Manifest]:
     imagestreams: list[Manifest] = []
     for fn in glob.glob(pathname, root_dir=ROOT_DIR):
         # there may be more than one yaml document in a file (e.g. rstudio buildconfigs)
@@ -89,9 +87,11 @@ def main():
                     or data["metadata"]["labels"]["opendatahub.io/notebook-image"] != "true"
                 ):
                     continue
-                imagestream = Manifest(data)
-                imagestreams.append(imagestream)
+                imagestreams.append(Manifest(data))
+    return imagestreams
 
+
+def _generate_table(imagestreams: list[Manifest]) -> list[tuple[str, str, str]]:
     tabular_data: list[tuple[str, str, str]] = []
 
     # todo(jdanek): maybe we want to change to sorting by `imagestream.order`
@@ -128,8 +128,7 @@ def main():
                 sw_version = sw_version.lstrip("v")
                 software.append(f"{sw_name}: {sw_version}")
 
-            # in 2.16.1 we only have RStudio as tech preview, and that is not a prebuilt image we ship
-            tech_preview_names = ()  # or define the actual names you want to check
+            tech_preview_names = ()
             maybe_techpreview = "" if name not in tech_preview_names else " (Technology Preview)"
             maybe_recommended = "" if not recommended or len(imagestream.tags) == 1 else " (Recommended)"
 
@@ -143,6 +142,12 @@ def main():
 
             prev_tag = tag
 
+    return tabular_data
+
+
+def _print_section(heading: str, tabular_data: list[tuple[str, str, str]]) -> None:
+    print(f"## {heading}")
+    print()
     print("| Image name | Image version | Preinstalled packages |")
     print("|------------|---------------|-----------------------|")
     for row in tabular_data:
@@ -150,7 +155,7 @@ def main():
 
     print()
 
-    print("## Source")
+    print(f"### {heading} Source")
     print()
     print("_mouse hover reveals copy button in top right corner of the box_")
     print()
@@ -160,6 +165,20 @@ def main():
     for row in tabular_data:
         print(f"{' | '.join(escape(r) for r in row)}")
     print("```")
+
+
+MANIFEST_DIRS = {
+    "ODH": "manifests/odh/base/*.yaml",
+    "RHOAI": "manifests/rhoai/base/*.yaml",
+}
+
+
+def main():
+    for heading, pathname in MANIFEST_DIRS.items():
+        imagestreams = _load_imagestreams(pathname)
+        tabular_data = _generate_table(imagestreams)
+        _print_section(heading, tabular_data)
+        print()
 
 
 def escape(s: str) -> str:


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/notebooks#3461 to `rhoai-3.4`.

- Fix `ci/package_versions.py` to read from `manifests/odh/base/` and `manifests/rhoai/base/` instead of the removed `manifests/base/` path.
- Remove stale `poetry_version` env var from `.github/workflows/docs.yaml`.

Fixes: [RHAIENG-4576](https://issues.redhat.com/browse/RHAIENG-4576)

## Test plan

- [x] `uv run ci/package_versions.py` produces two non-empty tables (ODH + RHOAI)
- [x] All existing unit tests pass

Made with [Cursor](https://cursor.com)

[RHAIENG-4576]: https://redhat.atlassian.net/browse/RHAIENG-4576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ