### PR TITLE
RHOAIENG-59965: Remove outdate s390x checking. PyArrow is provided from RH index

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -56,9 +56,6 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 BASE_PKGS=(perl mesa-libGL skopeo compat-openssl11 openshift-clients)
-if [ "$(uname -m)" = "s390x" ]; then
-    BASE_PKGS+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel)
-fi
 dnf install -y "${BASE_PKGS[@]}"
 dnf clean all
 rm -rf /var/cache/yum

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -56,9 +56,6 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 BASE_PKGS=(perl mesa-libGL skopeo compat-openssl11 openshift-clients)
-if [ "$(uname -m)" = "s390x" ]; then
-    BASE_PKGS+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel)
-fi
 dnf install -y "${BASE_PKGS[@]}"
 dnf clean all
 rm -rf /var/cache/yum


### PR DESCRIPTION
[RHOAIENG-59965](https://redhat.atlassian.net/browse/RHOAIENG-59965): Remove outdate s390x checking. PyArrow is provided from RH index

## Description
[RHOAIENG-59965](https://redhat.atlassian.net/browse/RHOAIENG-59965): Remove outdate s390x checking. PyArrow is provided from RH index

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
