### PR TITLE
fix(cve): CVE-2026-4926 - path-to-regexp ReDoS in code-server [rhoai-…

### DIFF
--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -63,6 +63,9 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 	git clone --depth 1 --branch "${CODESERVER_VERSION}" --recurse-submodules --shallow-submodules https://github.com/coder/code-server.git
 	cd code-server
 	source ${NVM_DIR}/nvm.sh
+	# CVE-2026-4926: path-to-regexp ReDoS via sequential optional groups (GHSA-j3q9-mxjg-w52f)
+	# Affects path-to-regexp 8.0.0–8.3.x (transitive via express → router). Fixed upstream in v4.116.0.
+	jq '.overrides["path-to-regexp"] = "~8.4.0"' package.json > /tmp/pkg.json && mv /tmp/pkg.json package.json
 	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
 	nvm use ${NODE_VERSION}
 	npm install


### PR DESCRIPTION
 ## Summary

      - Inject npm override for `path-to-regexp ~8.4.0` into code-server's `package.json` at build time via `jq`, before `npm install`
      - Forces npm to resolve `path-to-regexp` to 8.4.2 instead of the vulnerable 8.2.0 (transitive via `express 5.0.1` → `router 2.1.0`)
      - Backports the fix for code-server v4.104.0 (fixed upstream in v4.116.0)

      ## CVE Details

      | Field | Value |
      |---|---|
      | CVE | [CVE-2026-4926](https://access.redhat.com/security/cve/CVE-2026-4926) |
      | Advisory | [GHSA-j3q9-mxjg-w52f](https://github.com/advisories/GHSA-j3q9-mxjg-w52f) |
      | CVSS | 7.5 (High) |
      | CWE | CWE-1333 (Inefficient Regular Expression Complexity) |
      | Affected | path-to-regexp 8.0.0–8.3.x |
      | Fix | path-to-regexp >= 8.4.0 |

      ## What Changed

      **1 file changed, 3 lines added** in `codeserver/ubi9-python-3.12/get_code_server_rpm.sh`:

      ```bash
      # CVE-2026-4926: path-to-regexp ReDoS via sequential optional groups (GHSA-j3q9-mxjg-w52f)
      # Affects path-to-regexp 8.0.0–8.3.x (transitive via express → router). Fixed upstream in v4.116.0.
      jq '.overrides["path-to-regexp"] = "~8.4.0"' package.json > /tmp/pkg.json && mv /tmp/pkg.json package.json
      ```

      ## How It Works

      1. `get_code_server_rpm.sh` clones code-server v4.104.0 from GitHub
      2. The `jq` command injects `"overrides": {"path-to-regexp": "~8.4.0"}` into `package.json`
      3. `npm install` (runs with network access) sees the override, resolves `path-to-regexp` to 8.4.2
      4. The rest of the build proceeds unchanged — RPM ships with the fixed version

      ## Risk Assessment

      - **Semver compatible**: `router@2.1.0` requires `^8.0.0` — version 8.4.2 satisfies this
      - **Route pattern compatible**: codebase uses `/proxy/:port{/*path}` (single optional group) and `/.*/` (native regex) — unaffected by 8.4.x behavioral changes
      - **No-op on upgrade**: when `CODESERVER_VERSION` is bumped to v4.116.0+, the override is harmless (upstream already ships >= 8.4.0)

      ## Test Plan

      - [x] Verified `jq` override applies correctly in Docker build log
      - [x] Confirmed `npm install` resolves past the override (build proceeds to compilation stage)
      - [ ] Full Konflux/CI pipeline build
      - [ ] Verify `path-to-regexp` version in built image: `rpm2cpio <rpm> | cpio -t | grep path-to-regexp`

