### PR TITLE
[rhoai-3.4] fix(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -158,7 +158,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: 'Run Gemini PR Review'
-        uses: 'google-github-actions/run-gemini-cli@v0'
+        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489'  # v0.1.22
         id: 'gemini_pr_review'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Checkout the branch
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ env.BRANCH_NAME }}
 
@@ -61,7 +61,7 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
@@ -156,7 +156,7 @@ jobs:
 
       # Checkout the release branch to apply the updates
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
 
@@ -233,10 +233,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: pull-request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5  # v2.12.1
         with:
           source_branch: ${{ env.DIGEST_UPDATER_BRANCH }}
           destination_branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
## Description

Cherry-pick of #2188 to `rhoai-3.4`.

Pin unpinned action tag references to full commit SHAs in two downstream-only workflow files, fixing the `GitHub Actions SHA pinning` CI check.

These files (`gemini-pr-review.yml`, `notebook-digest-updater.yaml`) do not exist in `opendatahub-io/notebooks`, so this fix must go directly into `rhds/notebooks`.

### Changes

| File | Action | Old | New |
|---|---|---|---|
| `gemini-pr-review.yml:161` | `google-github-actions/run-gemini-cli` | `@v0` | `@f77273f4...` (v0.1.22) |
| `notebook-digest-updater.yaml:32,64,159,236` | `actions/checkout` | `@v4` | `@34e11487...` (v4.3.1) |
| `notebook-digest-updater.yaml:239` | `repo-sync/pull-request` | `@v2` | `@7e79a9f5...` (v2.12.1) |

Generated with `pinact run`.

## How Has This Been Tested?

- `pinact run --check` passes locally
- The CI output from previous runs already identifies these exact SHAs

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)