### PR TITLE
[rhoai-3.4-ea.2] RHAIENG-4576: fix(ci): docs.yaml workflow produces empty release notes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,9 +8,6 @@
 permissions:
   contents: read
 
-env:
-  poetry_version: '1.8.3'
-
 jobs:
   generate-releasenotes:
     name: Generate list of images for release notes

--- a/ci/package_versions.py
+++ b/ci/package_versions.py
@@ -72,9 +72,7 @@ class Tag:
         return json.loads(self._data["annotations"]["opendatahub.io/notebook-python-dependencies"])
 
 
-def main():
-    pathname = "manifests/base/*.yaml"
-    # pathname = 'manifests/overlays/additional/*.yaml'
+def _load_imagestreams(pathname: str) -> list[Manifest]:
     imagestreams: list[Manifest] = []
     for fn in glob.glob(pathname, root_dir=ROOT_DIR):
         # there may be more than one yaml document in a file (e.g. rstudio buildconfigs)
@@ -89,9 +87,11 @@ def main():
                     or data["metadata"]["labels"]["opendatahub.io/notebook-image"] != "true"
                 ):
                     continue
-                imagestream = Manifest(data)
-                imagestreams.append(imagestream)
+                imagestreams.append(Manifest(data))
+    return imagestreams
 
+
+def _generate_table(imagestreams: list[Manifest]) -> list[tuple[str, str, str]]:
     tabular_data: list[tuple[str, str, str]] = []
 
     # todo(jdanek): maybe we want to change to sorting by `imagestream.order`
@@ -128,8 +128,7 @@ def main():
                 sw_version = sw_version.lstrip("v")
                 software.append(f"{sw_name}: {sw_version}")
 
-            # in 2.16.1 we only have RStudio as tech preview, and that is not a prebuilt image we ship
-            tech_preview_names = ()  # or define the actual names you want to check
+            tech_preview_names = ()
             maybe_techpreview = "" if name not in tech_preview_names else " (Technology Preview)"
             maybe_recommended = "" if not recommended or len(imagestream.tags) == 1 else " (Recommended)"
 
@@ -143,6 +142,12 @@ def main():
 
             prev_tag = tag
 
+    return tabular_data
+
+
+def _print_section(heading: str, tabular_data: list[tuple[str, str, str]]) -> None:
+    print(f"## {heading}")
+    print()
     print("| Image name | Image version | Preinstalled packages |")
     print("|------------|---------------|-----------------------|")
     for row in tabular_data:
@@ -150,7 +155,7 @@ def main():
 
     print()
 
-    print("## Source")
+    print(f"### {heading} Source")
     print()
     print("_mouse hover reveals copy button in top right corner of the box_")
     print()
@@ -160,6 +165,20 @@ def main():
     for row in tabular_data:
         print(f"{' | '.join(escape(r) for r in row)}")
     print("```")
+
+
+MANIFEST_DIRS = {
+    "ODH": "manifests/odh/base/*.yaml",
+    "RHOAI": "manifests/rhoai/base/*.yaml",
+}
+
+
+def main():
+    for heading, pathname in MANIFEST_DIRS.items():
+        imagestreams = _load_imagestreams(pathname)
+        tabular_data = _generate_table(imagestreams)
+        _print_section(heading, tabular_data)
+        print()
 
 
 def escape(s: str) -> str:


### PR DESCRIPTION
Cherry-pick of eacc722a2 from opendatahub-io/notebooks main to rhoai-3.4-ea.2.

The `ci/package_versions.py` script was looking for manifests in the old
`manifests/base/` path instead of `manifests/odh/base/` and `manifests/rhoai/base/`,
so the Docs (release notes) workflow has been producing empty tables.

This fix updates the manifest paths and also removes a stale `poetry_version`
env var from `docs.yaml`.

/cherry-pick eacc722a2f553b195dcb7436a2640c519c1ef654

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration, refining permissions settings for documentation processes.

* **Refactor**
  * Improved package version documentation script to support multiple manifest sources with enhanced table formatting and better section organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->