### PR TITLE
[rhoai-3.3] patched CVE-2026-33236 - NLTK 3.9.2 to 3.9.4 (pytorch+llmcompressor)

### DIFF
--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -1,0 +1,92 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+# retrigger Konflux builds to fix https://issues.redhat.com/browse/RHOAIENG-31914
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-llmcompressor-cuda)"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-pytorch, kfbuild-cuda, kfbuild-llmcompressor, kfbuild-runtime-pytorch-llmcompressor-cuda]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-notebooks
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-on-pull-request-77104
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:notebooks-{{revision}}
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312
+  - name: dockerfile
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+  - name: build-args-file
+    value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+  - name: path-context
+    value: .
+  - name: enable-cache-proxy
+    value: true
+  - name: hermetic
+    value: false
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  timeouts:
+    pipeline: 8h
+    tasks: 4h
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -1,0 +1,92 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+# retrigger Konflux builds to fix https://issues.redhat.com/browse/RHOAIENG-31914
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|kfbuild-llmcompressor-cuda)"
+    pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-pytorch, kfbuild-cuda, kfbuild-jupyter, kfbuild-llmcompressor, kfbuild-workbench-jupyter-pytorch-llmcompressor-cuda]"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-notebooks
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-on-pull-request-66001
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:notebooks-{{revision}}
+  - name: additional-tags
+    value:
+    - '{{target_branch}}-{{revision}}'
+  - name: additional-labels
+    value:
+    - version=on-pr-{{revision}}
+    - io.openshift.tags=odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312
+  - name: dockerfile
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+  - name: build-args-file
+    value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+  - name: path-context
+    value: .
+  - name: enable-cache-proxy
+    value: true
+  - name: hermetic
+    value: false
+  - name: build-image-index
+    value: true
+  - name: build-platforms
+    value:
+    - linux-d160-m8xlarge/amd64
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+  timeouts:
+    pipeline: 8h
+    tasks: 4h
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 16Gi
+        limits:
+          cpu: '16'
+          memory: 32Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -2959,10 +2959,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb
 
 [[packages]]
 name = "nltk"
-version = "3.9.2"
+version = "3.9.4"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", upload-time = 2025-10-01T07:19:23Z, size = 2887629, hashes = { sha256 = "0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", upload-time = 2025-10-01T07:19:21Z, size = 1513404, hashes = { sha256 = "1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", upload-time = 2026-03-24T06:13:40Z, size = 2946864, hashes = { sha256 = "ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", upload-time = 2026-03-24T06:13:38Z, size = 1552087, hashes = { sha256 = "f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f" } }]
 
 [[packages]]
 name = "notebook-shim"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -2363,10 +2363,10 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb
 
 [[packages]]
 name = "nltk"
-version = "3.9.2"
+version = "3.9.4"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", upload-time = 2025-10-01T07:19:23Z, size = 2887629, hashes = { sha256 = "0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", upload-time = 2025-10-01T07:19:21Z, size = 1513404, hashes = { sha256 = "1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", upload-time = 2026-03-24T06:13:40Z, size = 2946864, hashes = { sha256 = "ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", upload-time = 2026-03-24T06:13:38Z, size = 1552087, hashes = { sha256 = "f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f" } }]
 
 [[packages]]
 name = "numexpr"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

1.   Upgraded NLTK from 3.9.2 to 3.9.4 to fix two CVEs CVE-2026-33236 and CVE-2026-33231.
2.   Applied surgical edit to two pylock.toml files - swapped version, sdist URL+hash, and wheel URL+hash for the NLTK package entry.

Fixes:                                                                                                                                                     
  - [RHOAIENG-54743](https://redhat.atlassian.net/browse/RHOAIENG-54743) (CVE-2026-33236 - jupyter image)
  - [RHOAIENG-54742](https://redhat.atlassian.net/browse/RHOAIENG-54742) (CVE-2026-33236 - runtime image)
  - [RHOAIENG-54649](https://redhat.atlassian.net/browse/RHOAIENG-54649) (CVE-2026-33231 - runtime image)                                                                                                          
  - [RHOAIENG-54651](https://redhat.atlassian.net/browse/RHOAIENG-54651) (CVE-2026-33231 - jupyter image)
                                                         

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  1. Hash verification - Downloaded NLTK 3.9.4 from PyPI and verified SHA256 hashes match pylock.toml entries exactly                                        
  2. Package installation test - Installed NLTK 3.9.4 in clean venv, confirmed version, dependencies, and basic functionality   
  3. Static tests - Ran make test to validate pylock.toml syntax and consistency with pyproject.toml (all relevant tests passed)                             
  4. Local image build attempt - Attempted jupyter pytorch-llmcompressor build 
  
Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-54743]: https://redhat.atlassian.net/browse/RHOAIENG-54743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-54742]: https://redhat.atlassian.net/browse/RHOAIENG-54742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-54649]: https://redhat.atlassian.net/browse/RHOAIENG-54649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-54651]: https://redhat.atlassian.net/browse/RHOAIENG-54651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull-request build manifests to retrigger Konflux/PR builds for PyTorch runtime images with LLMCompressor (two runtime targets), including PR filtering, run limits, and build parameterization.

* **Chores**
  * Updated NLTK dependency to 3.9.4 in Python 3.12 runtime environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2227)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->