### PR TITLE
fix(cve): upgrade pyjwt to 2.12.0 for CVE-2026-32597 [RHAIENG-3755]

### DIFF
--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -38,4 +38,6 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/kubernetes-client/python/issues/2458
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -55,4 +55,6 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -94,4 +94,6 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -70,4 +70,6 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -72,4 +72,6 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -64,6 +64,8 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 constraint-dependencies = [

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -61,6 +61,8 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 environments = [

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -78,6 +78,8 @@ override-dependencies = [
     # RHAIENG-2458: CVE-2025-66418 urllib3 decompression vulnerability
     # Upstream: https://github.com/elyra-ai/elyra/issues/3325
     "urllib3>=2.6.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 [tool.uv.sources]

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -45,7 +45,9 @@ dependencies = [
 override-dependencies = [
     # tf2onnx has pinned protobuf version, that causes conflict with other packages
     "protobuf==6.31.1",
-    "keras~=3.12.0"
+    "keras~=3.12.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 constraint-dependencies = [

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = [
 override-dependencies = [
     # tf2onnx has pinned protobuf version, that causes conflict with other packages
     "protobuf==6.31.1",
-    "keras~=3.12.0"
+    "keras~=3.12.0",
+    # RHAIENG-3755: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 environments = [

--- a/uv.lock
+++ b/uv.lock
@@ -1433,11 +1433,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/00161ed607273db4c
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Addresses [RHAIENG-3755](https://redhat.atlassian.net/browse/RHAIENG-3755) by adding `pyjwt>=2.12.0` override-dependency to all image pyproject.toml files
- Fixes CVE-2026-32597 vulnerability related to crit header RFC 7515 violation
- Updated uv.lock: pyjwt 2.10.1 -> 2.12.1

## Files Changed
- 10 pyproject.toml files (added pyjwt override-dependency)
- uv.lock (pyjwt version bumped)

## Test Plan
- [ ] CI passes
- [ ] Verify pyjwt version in built images is >= 2.12.0

Jira: https://issues.redhat.com/browse/RHAIENG-3755

Made with [Cursor](https://cursor.com)

[RHAIENG-3755]: https://redhat.atlassian.net/browse/RHAIENG-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded PyJWT dependency to version 2.12.0 or higher across all container and runtime environments to enhance security posture and ensure standards compliance.
  * Updated Keras to version 3.12.0 in TensorFlow and PyTorch-based runtime configurations for improved compatibility and system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2234)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->