### PR TITLE
fix(cve): upgrade pyjwt to 2.12.0 for CVE-2026-32597 [RHAIENG-3795]

### DIFF
--- a/codeserver/ubi9-python-3.12/pyproject.toml
+++ b/codeserver/ubi9-python-3.12/pyproject.toml
@@ -41,4 +41,6 @@ override-dependencies = [
     # RHAIENG-3209: CVE-2026-25990  Pillow: Out-of-bounds Write
     # Upstream: https://github.com/vllm-project/llm-compressor/releases/tag/0.7.1.1
     "pillow>=12.1.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -62,4 +62,6 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -101,6 +101,8 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 # from https://redhat-internal.slack.com/archives/C079FE5H94J/p1756934476976759?thread_ts=1756933154.294109&cid=C079FE5H94J

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -78,4 +78,6 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -79,4 +79,6 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -70,6 +70,8 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 environments = [

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -68,6 +68,8 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 environments = [

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -85,6 +85,8 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 [tool.uv.sources]

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -59,4 +59,6 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHAIENG-3211: CVE-2026-26007 cryptography Subgroup Attack
     "cryptography>=46.0.5",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -77,6 +77,8 @@ override-dependencies = [
     # RHAIENG-3209: CVE-2026-25990  Pillow: Out-of-bounds Write
     # Upstream: https://github.com/vllm-project/llm-compressor/releases/tag/0.7.1.1
     "pillow>=12.1.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 # from https://redhat-internal.slack.com/archives/C079FE5H94J/p1756934476976759?thread_ts=1756933154.294109&cid=C079FE5H94J

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -74,4 +74,6 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHAIENG-3211: CVE-2026-26007 cryptography Subgroup Attack
     "cryptography>=46.0.5",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -76,4 +76,6 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHAIENG-3211: CVE-2026-26007 cryptography Subgroup Attack
     "cryptography>=46.0.5",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -68,6 +68,8 @@ override-dependencies = [
     # RHAIENG-3209: CVE-2026-25990  Pillow: Out-of-bounds Write
     # Upstream: https://github.com/vllm-project/llm-compressor/releases/tag/0.7.1.1
     "pillow>=12.1.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 environments = [

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -67,6 +67,8 @@ override-dependencies = [
     # RHAIENG-3209: CVE-2026-25990  Pillow: Out-of-bounds Write
     # Upstream: https://github.com/vllm-project/llm-compressor/releases/tag/0.7.1.1
     "pillow>=12.1.1",
+    # RHAIENG-3795: CVE-2026-32597 PyJWT crit header RFC 7515 violation
+    "pyjwt>=2.12.0",
 ]
 
 environments = [

--- a/uv.lock
+++ b/uv.lock
@@ -1258,11 +1258,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/00161ed607273db4c
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Addresses [RHAIENG-3795](https://redhat.atlassian.net/browse/RHAIENG-3795) by adding `pyjwt>=2.12.0` override-dependency to all image pyproject.toml files
- Fixes CVE-2026-32597 vulnerability related to crit header RFC 7515 violation
- Updated uv.lock: pyjwt 2.11.0 -> 2.12.1

## Files Changed
- 14 pyproject.toml files (added pyjwt override-dependency)
- uv.lock (pyjwt version bumped)

## Test Plan
- [ ] CI passes
- [ ] Verify pyjwt version in built images is >= 2.12.0

Jira: https://issues.redhat.com/browse/RHAIENG-3795

Made with [Cursor](https://cursor.com)

[RHAIENG-3795]: https://redhat.atlassian.net/browse/RHAIENG-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ