### PR TITLE
fix(ci): repair Gitleaks SARIF upload on RHDS

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -47,6 +47,10 @@ jobs:
         # handles baseline comparison and only alerts on net-new leaks.
         run: gitleaks git --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif --no-banner --exit-code 0
 
+      - name: Sanitize Gitleaks SARIF for upload
+        # Gitleaks can emit endColumn=0; upload-sarif rejects that (needs endColumn >= 1).
+        run: python3 scripts/ci/sanitize_gitleaks_sarif.py gitleaks.sarif
+
       - name: Upload SARIF
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4

--- a/scripts/ci/sanitize_gitleaks_sarif.py
+++ b/scripts/ci/sanitize_gitleaks_sarif.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fix Gitleaks SARIF so GitHub code scanning upload accepts it.
+
+Gitleaks 8.30.x sometimes emits endColumn=0. upload-sarif requires endColumn >= 1
+(SARIF 2.1.0).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def sanitize_sarif(data: dict) -> tuple[dict, int]:
+    fixed = 0
+    for run in data.get("runs", []):
+        for result in run.get("results", []):
+            for location in result.get("locations", []):
+                region = location.get("physicalLocation", {}).get("region")
+                if not region:
+                    continue
+                end_col = region.get("endColumn")
+                if end_col is None or end_col < 1:
+                    start_col = region.get("startColumn", 1) or 1
+                    region["endColumn"] = max(start_col, 1)
+                    fixed += 1
+    return data, fixed
+
+
+def main() -> int:
+    path = Path(sys.argv[1] if len(sys.argv) > 1 else "gitleaks.sarif")
+    data = json.loads(path.read_text())
+    data, fixed = sanitize_sarif(data)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+    if fixed:
+        print(f"Sanitized {fixed} SARIF region(s) with invalid endColumn in {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/ci/test_sanitize_gitleaks_sarif.py
+++ b/tests/unit/scripts/ci/test_sanitize_gitleaks_sarif.py
@@ -1,0 +1,63 @@
+"""Tests for scripts/ci/sanitize_gitleaks_sarif.py."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.ci.sanitize_gitleaks_sarif import sanitize_sarif
+
+
+def test_sanitize_sarif_fixes_invalid_end_column() -> None:
+    data = {
+        "runs": [
+            {
+                "results": [
+                    {
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "region": {
+                                        "startLine": 1,
+                                        "startColumn": 1,
+                                        "endLine": 1,
+                                        "endColumn": 0,
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    _, fixed = sanitize_sarif(data)
+    region = data["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+    assert fixed == 1
+    assert region["endColumn"] == 1
+
+
+def test_sanitize_sarif_leaves_valid_regions() -> None:
+    data = {
+        "runs": [
+            {
+                "results": [
+                    {
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "region": {
+                                        "startLine": 10,
+                                        "startColumn": 5,
+                                        "endLine": 10,
+                                        "endColumn": 20,
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    _, fixed = sanitize_sarif(data)
+    assert fixed == 0


### PR DESCRIPTION
## Summary

Gitleaks CI was failing at **Upload SARIF**, not at the scan itself:

```
endColumn must be greater than or equal to 1
(results[56] and results[125])
```

**Root cause:** `gitleaks git` scans git history and still hits blobs under `.pnpm-store/` from accidental commits (e.g. RHOAIENG-60105/60120 jira-autofix-bot commits). Two of those findings emit `endColumn: 0`, which GitHub's `upload-sarif` rejects.

**Fix:**
1. Allowlist `\.pnpm-store/` in `.gitleaks.toml` (drops ~138 false-positive cache hits from history)
2. Run `scripts/ci/sanitize_gitleaks_sarif.py` before upload to clamp any remaining invalid `endColumn` values

Also mirror `.gitleaks.toml` change in [opendatahub-io/security-config](https://github.com/opendatahub-io/security-config) when convenient (file is normally synced from there).

## Test plan

- [x] Local `gitleaks git` + allowlist: 0 invalid `endColumn`
- [x] `sanitize_gitleaks_sarif.py` fixes pre-allowlist SARIF (2 regions)
- [x] `pytest tests/unit/scripts/ci/test_sanitize_gitleaks_sarif.py`
- [ ] CI Gitleaks job green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gitleaks configuration to exclude `.pnpm-store` directory from leak detection
  * Enhanced SARIF report generation in the security scanning CI pipeline for improved compatibility with GitHub code scanning
  * Added validation and automated tests for security report formatting to ensure data integrity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->