### PR TITLE
[rhoai-3.4] RHAIENG-5135: Konflux codeserver — replace quarantined es5-ext (@unes fork)

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/README.md
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/README.md
@@ -41,6 +41,12 @@ This directory is **copied over** the read-only `prefetch-input/code-server` sub
 8. **ci/build/build-vscode.sh**  
    - Builds for current arch (no x64 fallback on ppc64le/s390x). Uses system Node from `setup-offline-binaries.sh` cache.
 
+9. **es5-ext → @unes/es5-ext (quarantined package replacement)**  
+   - **es5-ext** (both 0.10.63 and 0.10.64) is quarantined by Nexus Firewall (sonatype-2022-2248) because its `_postinstall.js` makes network calls to geolocate the host and executes undisclosed code (protestware). Both versions are flagged; there is no clean upstream version. See [es5-ext issue #186](https://github.com/medikoo/es5-ext/issues/186).  
+   - The `overrides` field in `lib/vscode/package.json` aliases `es5-ext` to **`npm:@unes/es5-ext@0.10.64-1`**, a [community fork](https://www.npmjs.com/package/@unes/es5-ext) that strips the postinstall script and rebases daily against upstream.  
+   - `es5-ext` is a transitive devDependency pulled in through `gulp-sourcemaps` → `debug-fabulous` → `memoizee` → `es5-ext`, and through the `d` / `es6-*` / `esniff` / `timers-ext` family. The override covers all transitive consumers.  
+   - When regenerating `lib/vscode/package-lock.json`, the override takes effect automatically during `npm install`.
+
 All of the above are **overlays**: at build time the Dockerfile copies this patches tree on top of the read-only `prefetch-input/code-server` submodule, so every `package.json` / `package-lock.json` that referenced the old git/codeload refs is replaced by these files and thus uses the registry versions we define here.
 
 **Argon2 (no prefetch):**  

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/package-lock.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/package-lock.json
@@ -4576,6 +4576,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -5813,9 +5814,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5827,26 +5828,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/debug-fabulous": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
-      "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "3.X",
-        "memoizee": "0.4.X",
-        "object-assign": "4.X"
-      }
-    },
-    "node_modules/debug-fabulous/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/decamelize": {
@@ -6551,11 +6532,12 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.63",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.63.tgz",
-      "integrity": "sha512-hUCZd2Byj/mNKjfP9jXrdVZ62B8KuA/VoK7X8nUh5qT+AxDmcbvZz041oDVZdbIN1qW6XY9VDNwzkvKnZvK2TQ==",
+      "name": "@unes/es5-ext",
+      "version": "0.10.64-1",
+      "resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+      "integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -7350,6 +7332,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -9655,6 +9638,28 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/gulp-sourcemaps/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/gulp-sourcemaps/node_modules/debug-fabulous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+      "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "3.X",
+        "memoizee": "0.4.X",
+        "object-assign": "4.X"
+      }
+    },
     "node_modules/gulp-sourcemaps/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -10803,6 +10808,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -10829,7 +10835,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.1",
@@ -11869,8 +11876,9 @@
     "node_modules/lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM= sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es5-ext": "~0.10.2"
       }
@@ -12200,20 +12208,45 @@
       }
     },
     "node_modules/memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
         "es6-weak-map": "^2.0.3",
         "event-emitter": "^0.3.5",
         "is-promise": "^2.2.2",
         "lru-queue": "^0.1.0",
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
+    },
+    "node_modules/memoizee/node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/memoizee/node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/memory-fs": {
       "version": "0.5.0",
@@ -12284,6 +12317,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -13995,6 +14029,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -16876,13 +16911,17 @@
       }
     },
     "node_modules/timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/tiny-inflate": {
@@ -16947,6 +16986,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/package.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/package.json
@@ -231,7 +231,8 @@
     },
     "@vscode/l10n-dev@0.0.35": {
       "web-tree-sitter": "0.23.0"
-    }
+    },
+    "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Cherry-pick `-x` of **`c4eb85dcf`** ([#3556](https://github.com/opendatahub-io/notebooks/pull/3556), ODH `main`) onto `rhoai-3.4`.

Fixes **Konflux Production Internal** `prefetch-dependencies` failure on **codeserver-datascience-cpu** (Sonatype quarantine on npm `es5-ext@0.10.63`). Not a pylock regression; [RHAIENG-5135](https://redhat.atlassian.net/browse/RHAIENG-5135) content remains valid.

| Source commit | Cherry-pick on branch | Fix |
|---------------|----------------------|-----|
| `c4eb85dcf` | `3134324b3` | npm override → `@unes/es5-ext@0.10.64-1` in code-server VS Code `package.json` / lockfile |

Split from #2281 (llmcompressor Tekton fix is a separate PR).

## Files changed

- `codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.106.3/lib/vscode/package.json`
- `codeserver/.../package-lock.json`, `README.md`

Under `codeserver/.../prefetch-input/` — **not** touched by konflux-central Tekton autosync.

## Test plan

- [ ] Merge to `rhoai-3.4`
- [ ] Retrigger Konflux Production Internal on-push for **codeserver-datascience-cpu** (or a PR touching codeserver paths)
- [ ] Confirm `step-prefetch-dependencies` passes (no 403 on `es5-ext`)

## Related

- PR #2280 (pylock baseline)
- Supersedes half of #2281

Made with [Cursor](https://cursor.com)

[RHAIENG-5135]: https://redhat.atlassian.net/browse/RHAIENG-5135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with information about the dependency override mechanism, including affected versions, the replacement strategy, transitive application through dependency chains, and automatic application during package lock regeneration.

* **Chores**
  * Added dependency override configuration in the package settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->