### PR TITLE
[rhoai-3.4] fix(ci): set pylock downgrade baseline on push (cherry-pick opendatahub-io#3704)

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -59,8 +59,9 @@ jobs:
         run: make test
         if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
         env:
-          # Prefer the PR base commit so fork PRs compare pylocks to upstream main, not the fork's main.
-          NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
+          # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).
+          NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
 
       - name: Upload Python coverage to Codecov
         if: ${{ !cancelled() && steps.install-deps.conclusion == 'success' }}


### PR DESCRIPTION
## Summary

Cherry-pick of [opendatahub-io/notebooks#3704](https://github.com/opendatahub-io/notebooks/pull/3704) (`d71f2ec7b`) onto `rhoai-3.4`.

On **push**, `NOTEBOOKS_DOWNGRADE_BASE_REF` was unset, so `tests/test_pylock_downgrade.py` compared pylocks to `origin/main` instead of the previous commit on `rhoai-3.4`. That caused false downgrade failures after merges (e.g. post–#2280 Code static analysis run).

Sets baseline to `github.event.before` on push; keeps `pull_request.base.sha` for PRs.

## Test plan

- [ ] Code static analysis `pytest-tests` passes on this PR
- [ ] After merge, push to `rhoai-3.4` no longer fails `test_pylock_downgrade` vs `origin/main`

## Related

- Upstream: https://github.com/opendatahub-io/notebooks/pull/3704 (merged)
- [RHAIENG-5135](https://redhat.atlassian.net/browse/RHAIENG-5135) / post-merge CI investigation on `rhoai-3.4`


Made with [Cursor](https://cursor.com)

[RHAIENG-5135]: https://redhat.atlassian.net/browse/RHAIENG-5135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This pull request contains no user-facing changes. The modifications are internal CI/CD configuration updates to improve test workflow handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->