### PR TITLE
[rhoai-3.3] RHAIENG-3840: update ONNX and ONNXConverter-Common for CVE-2026-28500

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -2972,10 +2972,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/jupyter/datascience/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
     "codeflare-sdk~=0.34.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "feast~=0.59.0",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -3346,10 +3346,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "packaging"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "kubeflow-training==1.9.3",
     "feast~=0.59.0",
 

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -3238,10 +3238,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "kubeflow-training==1.9.3",
     "feast~=0.59.0",

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -3100,10 +3100,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "kubeflow-training==1.9.3",
     "feast~=0.59.0",

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2697,10 +2697,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "kubeflow-training==1.9.3",
 
@@ -71,7 +71,6 @@ override-dependencies = [
 
 constraint-dependencies = [
     # AttributeError: module 'ml_dtypes' has no attribute 'float4_e2m1fn'
-    "onnx<1.19.0",
 ]
 
 environments = [

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -3302,10 +3302,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
 

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -2771,10 +2771,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "scikit-learn~=1.7.2", # Should be pinned down to this version in order to be compatible with trustyai
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0; platform_machine != 'ppc64le' and platform_machine != 's390x'",
     "kubeflow-training==1.9.3",
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -87,7 +87,7 @@ if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFIL
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.1
+export ONNX_VERSION=1.21.0
 export PYARROW_VERSION=21.0.0
 export PATH="$HOME/.cargo/bin:$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
@@ -276,7 +276,7 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.1
+ENV ONNX_VERSION=1.21.0
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -87,7 +87,7 @@ if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFIL
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.1
+export ONNX_VERSION=1.21.0
 export PYARROW_VERSION=21.0.0
 export PATH="$HOME/.cargo/bin:$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
@@ -276,7 +276,7 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.1
+ENV ONNX_VERSION=1.21.0
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -2451,10 +2451,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/runtimes/datascience/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0; platform_machine != 's390x' and platform_machine != 'ppc64le'",
     "feast~=0.59.0",
 

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -2712,10 +2712,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "packaging"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "feast~=0.59.0",
 
     # DB connectors

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -2617,10 +2617,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -2479,10 +2479,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "scikit-learn~=1.7.2",
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
-    "onnxconverter-common~=1.13.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
+    "onnxconverter-common>=1.16.0", # Required for skl2onnx, as upgraded version is not compatible with protobuf
     "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -2115,10 +2115,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "onnxconverter-common~=1.13.0",
+    "onnxconverter-common>=1.16.0",
     "codeflare-sdk~=0.34.0",
 
     # DB connectors
@@ -52,7 +52,6 @@ override-dependencies = [
 
 constraint-dependencies = [
     # AttributeError: module 'ml_dtypes' has no attribute 'float4_e2m1fn'
-    "onnx<1.19.0",
 ]
 
 environments = [

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -2673,10 +2673,9 @@ wheels = [
 
 [[packages]]
 name = "onnxconverter-common"
-version = "1.13.0"
+version = "1.16.0"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/ec/44/54c6b7f1a28d919a15caf642113fb44651087d1bb0658f028c54b93df8e3/onnxconverter-common-1.13.0.tar.gz", upload-time = 2022-11-03T12:11:37Z, size = 73935, hashes = { sha256 = "03db8a6033a3d6590f22df3f64234079caa826375d1fcb0b37b8123c06bf598c" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/51/a4/4439174c879c33557eab08e4dd480c1e096bc26c487c85a62e4c0d8f78ff/onnxconverter_common-1.13.0-py2.py3-none-any.whl", upload-time = 2022-11-03T12:11:35Z, size = 83796, hashes = { sha256 = "5ee1c025ef6c3b4abaede8425bc6b393248941a6cf8c21563d0d0e3f04634a0a" } }]
+wheels = [{ url = "https://files.pythonhosted.org/packages/4a/67/8dca1868a6e226f8d3f7d666cb6a48b79a60aad5267b16b24627cd8d9eb8/onnxconverter_common-1.16.0-py2.py3-none-any.whl", upload-time = 2025-08-28T19:37:46Z, size = 89511, hashes = { sha256 = "df39ee96f17fff119dff10dd245467651b60b9e8a96020eb93402239794852f7" } }]
 
 [[packages]]
 name = "opencensus"

--- a/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "scipy~=1.16.2",
     "skl2onnx~=1.19.1",
     # Required for skl2onnx, as upgraded version is not compatible with protobuf
-    "onnxconverter-common~=1.13.0",
+    "onnxconverter-common>=1.16.0",
     "codeflare-sdk~=0.34.0",
     "feast~=0.59.0",
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes for https://redhat.atlassian.net/browse/RHAIENG-3840
## Description
<!--- Describe your changes in detail -->
update and add onnx to 1.21.0 and onnxconverter-common to 1.16.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `onnxconverter-common` package dependency to version 1.16.0 or higher across all Jupyter and runtime environments
  * Upgraded ONNX version to 1.21.0 for datascience builds
  * Removed outdated version constraints in select configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->