### PR TITLE
RHAIENG-5016: prefix Renovate PR titles on non-main branches (rhoai-3.4)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -133,6 +133,11 @@
 
   "packageRules": [
     {
+      "description": "Prefix PR titles with branch name for non-main branches",
+      "matchBaseBranches": ["!/^main$/"],
+      "commitMessagePrefix": "[{{{baseBranch}}}]",
+    },
+    {
       description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL, rhoai-2.24 — release-data may still list 2.24 until ops MR)",
       matchRepositories: ["red-hat-data-services/notebooks"],
       enabled: false,


### PR DESCRIPTION
## Summary

Cherry-pick `-x` of opendatahub-io/notebooks#3724 (`4f2bb92`) to add the Renovate
`commitMessagePrefix: "[{{{baseBranch}}}]"` rule for non-`main` branches.

MintMaker runs on `rhoai-3.4`; autosync only updates RHDS `main`, so release
branches need this backport for prefixed PR titles (e.g. `[rhoai-3.4] Update github-actions`).

## Test plan

- [ ] `renovate.json5` parses; prefix rule is first in `packageRules`
- [ ] Branch-specific rhoai-3.4 customManagers / versioning rules unchanged
- [ ] Next MintMaker PR to `rhoai-3.4` uses `[rhoai-3.4]` title prefix


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration to improve commit message organization for development branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->