### PR TITLE
RHAIENG-5016: prefix Renovate PR titles on non-main branches (rhoai-3.3)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -136,6 +136,11 @@
 
   "packageRules": [
     {
+      "description": "Prefix PR titles with branch name for non-main branches",
+      "matchBaseBranches": ["!/^main$/"],
+      "commitMessagePrefix": "[{{{baseBranch}}}]",
+    },
+    {
       description: "RHDS fork: disable MintMaker by default (autosync main, EA, EOL, rhoai-2.24 — release-data may still list 2.24 until ops MR)",
       matchRepositories: ["red-hat-data-services/notebooks"],
       enabled: false,


### PR DESCRIPTION
## Summary

Cherry-pick `-x` of opendatahub-io/notebooks#3724 (`4f2bb92`) to add the Renovate
`commitMessagePrefix: "[{{{baseBranch}}}]"` rule for non-`main` branches.

MintMaker runs on `rhoai-3.3`; autosync only updates RHDS `main`, so release
branches need this backport for prefixed PR titles (e.g. `[rhoai-3.3] Update github-actions`).

## Test plan

- [ ] `renovate.json5` parses; prefix rule is first in `packageRules`
- [ ] Next MintMaker PR to `rhoai-3.3` uses `[rhoai-3.3]` title prefix


Made with [Cursor](https://cursor.com)