### PR TITLE
[rhoai-2.25] NO Jira: chore(ci) update pyproject and sync-python-lockfiles

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -245,7 +245,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: uv.toml
+          version-file: pyproject.toml
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: uv.toml
+          version-file: pyproject.toml
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       
@@ -51,7 +51,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: uv.toml
+          version-file: pyproject.toml
           python-version: "3.14"
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: uv.toml
+          version-file: pyproject.toml
           enable-cache: true
           cache-dependency-glob: "uv.lock"
         

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: uv.toml
+          version-file: pyproject.toml
 
       - name: Run make refresh-pipfilelock-files
         run: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version-file: uv.toml
+          version-file: pyproject.toml
           activate-environment: false
           ignore-empty-workdir: true
           enable-cache: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
 ]
 
 [tool.uv]
+required-version = "==0.8.12"
 package = true
 environments = [
     "sys_platform == 'darwin'",

--- a/scripts/sync-python-lockfiles.sh
+++ b/scripts/sync-python-lockfiles.sh
@@ -15,6 +15,7 @@ error() {
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CVE_CONSTRAINTS_FILE="$ROOT_DIR/dependencies/cve-constraints.txt"
 # Default to the repo-root ./uv wrapper; override with UV=/path/to/your/wrapper
 UV="${UV:-$ROOT_DIR/uv}"
 export UV
@@ -56,18 +57,34 @@ if ! version_ge "$UV_VERSION" "$UV_MIN_VERSION"; then
   exit 1
 fi
 
+if [[ ! -f "$CVE_CONSTRAINTS_FILE" ]]; then
+  error "CVE constraints file not found: $CVE_CONSTRAINTS_FILE"
+  exit 1
+fi
+
 # The following will create a pylock.toml file for every pyproject.toml we have.
 ${UV} --version
-find . -name pylock.toml -execdir bash -c '
-  pwd
-  # derives python-version from directory suffix (e.g., "ubi9-python-3.12")
-  ${UV} pip compile pyproject.toml \
-   --output-file pylock.toml \
-   --format pylock.toml \
-   --generate-hashes \
-   --emit-index-url \
-   --python-version="${PWD##*-}" \
-   --python-platform linux \
-   --no-annotate \
-   ${ADDITIONAL_UV_FLAGS:-} \
-   --quiet' \;
+while IFS= read -r -d '' lockfile; do
+  lock_dir=$(dirname "$lockfile")
+  (
+    cd "$lock_dir"
+    # Relative path avoids absolute paths in pylock.toml headers (CI vs local).
+    constraints_path=$(
+      CVE_CONSTRAINTS_FILE="$CVE_CONSTRAINTS_FILE" python3 -c \
+        'import os; print(os.path.relpath(os.environ["CVE_CONSTRAINTS_FILE"], os.getcwd()))'
+    )
+    # derives python-version from directory suffix (e.g., "ubi9-python-3.12")
+    # shellcheck disable=SC2086
+    ${UV} pip compile pyproject.toml \
+      --output-file pylock.toml \
+      --format pylock.toml \
+      --generate-hashes \
+      --emit-index-url \
+      --python-version="${PWD##*-}" \
+      --python-platform linux \
+      --no-annotate \
+      --constraints "${constraints_path}" \
+      ${ADDITIONAL_UV_FLAGS:-} \
+      --quiet
+  )
+done < <(find . -name pylock.toml -print0)

--- a/uv
+++ b/uv
@@ -24,10 +24,10 @@ while IFS= read -r line; do
         version="${BASH_REMATCH[1]}"
         break
     fi
-done < "${SCRIPT_DIR}/uv.toml"
+done < "${SCRIPT_DIR}/pyproject.toml"
 
 if [[ -z "${version:-}" ]]; then
-    echo "error: could not read required-version from ${SCRIPT_DIR}/uv.toml" >&2
+    echo "error: could not read required-version from ${SCRIPT_DIR}/pyproject.toml" >&2
     exit 1
 fi
 

--- a/uv.toml
+++ b/uv.toml
@@ -1,1 +1,0 @@
-required-version = "==0.8.12"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
updates github action to pull uv version from `pyproject.toml` to fix ci error
add cve-constraints to `sync-python-lockfiles.sh` uv command to fully utilized `cve-constraints.txt` when locking files

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran gmake refresh-pipfilelock-files PYTHON_VERSION=3.12 with no error
check: https://github.com/red-hat-data-services/notebooks/pull/2305

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
