### PR TITLE
[rhoai-2.25] fix(ci): sanitize Gitleaks SARIF before GitHub upload

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -43,13 +43,24 @@ jobs:
             "github:gitleaks/gitleaks" = "8.30.1"
 
       - name: Run Gitleaks
+        id: run-gitleaks
         # Exit code 0: no leaks, 1: leaks found. Don't fail the job on
         # findings -- the SARIF upload feeds GitHub code scanning which
         # handles baseline comparison and only alerts on net-new leaks.
         run: gitleaks git --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif --no-banner --exit-code 0
 
+      - name: Sanitize Gitleaks SARIF for upload
+        id: sanitize-gitleaks-sarif
+        # Run when Gitleaks produced a report (success or failure), not on cancel or if scan was skipped.
+        # Outcome check keeps this working if we later drop --exit-code 0 and fail the step on findings.
+        if: ${{ !cancelled() && (steps.run-gitleaks.outcome == 'success' || steps.run-gitleaks.outcome == 'failure') }}
+        # Gitleaks can emit endColumn=0; upload-sarif rejects that (needs endColumn >= 1).
+        # See scripts/ci/sanitize_gitleaks_sarif.py and docs/sarif.md.
+        run: python3 scripts/ci/sanitize_gitleaks_sarif.py gitleaks.sarif
+
       - name: Upload SARIF
-        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        # Do not upload on cancel or when scan/sanitize did not produce a valid SARIF.
+        if: ${{ !cancelled() && steps.sanitize-gitleaks-sarif.outcome == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e  # v4.35.4
         with:
           sarif_file: gitleaks.sarif

--- a/docs/sarif.md
+++ b/docs/sarif.md
@@ -1,0 +1,20 @@
+# SARIF (Static Analysis Results Interchange Format)
+
+[Introduction from Microsoft](https://github.com/microsoft/sarif-tutorials).
+
+SARIF is a format based on JSON, used to capture warning messages from software tools that work with source code.
+Most importantly it can hold compiler warnings and findings from security scanners.
+GitHub can then import these and maintain a browsable database of outstanding ones.
+
+## Helpful tooling
+
+- [SARIF validator](https://sarifweb.azurewebsites.net/Validation)
+- [SARIF multitool for merging and manipulating .sarif files](https://github.com/microsoft/sarif-sdk/blob/main/docs/multitool-usage.md)
+  - [GitHub action to invoke the tool](https://github.com/marketplace/actions/sarif-multitool)
+- [GitHub documentation about importing SARIF results](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github)
+
+## Gitleaks SARIF upload in this repo
+
+The [Gitleaks workflow](../.github/workflows/gitleaks.yaml) runs `scripts/ci/sanitize_gitleaks_sarif.py` before `upload-sarif` because Gitleaks 8.30.x can emit `endColumn: 0`, which GitHub rejects (`endColumn` must be ≥ 1; see [github/codeql-action#1715](https://github.com/github/codeql-action/issues/1715)).
+
+An alternative is `npx @microsoft/sarif-multitool rewrite … --normalize-for-ghas`, which also prepares SARIF for GitHub Advanced Security ingestion; that tool typically **removes** invalid column properties, whereas our script **clamps** them to valid values. We use the script to avoid a .NET runtime (via npm) in CI—see the module docstring in `scripts/ci/sanitize_gitleaks_sarif.py`.

--- a/scripts/ci/sanitize_gitleaks_sarif.py
+++ b/scripts/ci/sanitize_gitleaks_sarif.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Fix Gitleaks SARIF so GitHub code scanning upload accepts it.
+
+Gitleaks 8.30.x sometimes emits endColumn=0. upload-sarif requires endColumn >= 1
+(SARIF 2.1.0).
+
+Alternative: ``npx -y @microsoft/sarif-multitool rewrite INPUT.sarif
+--normalize-for-ghas --output OUTPUT.sarif`` also normalizes SARIF for GitHub
+Advanced Security ingestion (see docs/sarif.md). We use this small script instead:
+the multitool is a .NET application (pulled in via npm) and we avoid that runtime
+dependency in CI. The multitool typically *removes* invalid column properties rather
+than clamping them to valid values.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def sanitize_sarif(data: dict) -> tuple[dict, int]:
+    """Clamp invalid ``endColumn`` values in result regions to satisfy upload-sarif."""
+    fixed = 0
+    for run in data.get("runs", []):
+        for result in run.get("results", []):
+            for location in result.get("locations", []):
+                region = location.get("physicalLocation", {}).get("region")
+                if not region:
+                    continue
+                end_col = region.get("endColumn")
+                if end_col is None or end_col < 1:
+                    start_col = region.get("startColumn", 1) or 1
+                    region["endColumn"] = max(start_col, 1)
+                    fixed += 1
+    return data, fixed
+
+
+def main() -> int:
+    path = Path(sys.argv[1] if len(sys.argv) > 1 else "gitleaks.sarif")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data, fixed = sanitize_sarif(data)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    if fixed:
+        print(f"Sanitized {fixed} SARIF region(s) with invalid endColumn in {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/ci/test_sanitize_gitleaks_sarif.py
+++ b/tests/unit/scripts/ci/test_sanitize_gitleaks_sarif.py
@@ -1,0 +1,76 @@
+"""Tests for scripts/ci/sanitize_gitleaks_sarif.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.ci.sanitize_gitleaks_sarif import sanitize_sarif
+
+
+@pytest.mark.parametrize("end_column", [0, None])
+def test_sanitize_sarif_fixes_invalid_end_column(end_column: int | None) -> None:
+    data = _sarif_data_with_region(
+        region={
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 1,
+            "endColumn": end_column,
+        }
+    )
+    _, fixed = sanitize_sarif(data)
+    region = _get_region(sarif_data=data)
+    assert fixed == 1
+    assert region["endColumn"] == 1
+
+
+def test_sanitize_sarif_sets_missing_end_column_from_start_column() -> None:
+    data = _sarif_data_with_region(
+        region={
+            "startLine": 3,
+            "startColumn": 7,
+            "endLine": 3,
+        }
+    )
+    _, fixed = sanitize_sarif(data)
+    region = _get_region(sarif_data=data)
+    assert fixed == 1
+    assert region["endColumn"] == 7
+
+
+@pytest.mark.parametrize(
+    ("region", "expected_end_column"),
+    [
+        ({"startLine": 1, "endLine": 1, "endColumn": 0}, 1),
+        ({"startLine": 1, "startColumn": 0, "endLine": 1, "endColumn": 0}, 1),
+    ],
+    ids=["missing_start_column", "zero_start_column"],
+)
+def test_sanitize_sarif_defaults_end_column_when_start_column_unusable(
+    region: dict,
+    expected_end_column: int,
+) -> None:
+    data = _sarif_data_with_region(region=region)
+    _, fixed = sanitize_sarif(data)
+    assert fixed == 1
+    assert _get_region(sarif_data=data)["endColumn"] == expected_end_column
+
+
+def test_sanitize_sarif_leaves_valid_regions() -> None:
+    data = _sarif_data_with_region(
+        region={
+            "startLine": 10,
+            "startColumn": 5,
+            "endLine": 10,
+            "endColumn": 20,
+        }
+    )
+    _, fixed = sanitize_sarif(data)
+    assert fixed == 0
+
+
+def _sarif_data_with_region(region: dict) -> dict:
+    return {"runs": [{"results": [{"locations": [{"physicalLocation": {"region": region}}]}]}]}
+
+
+def _get_region(sarif_data: dict) -> dict:
+    return sarif_data["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]


### PR DESCRIPTION
## Summary

Cherry-pick of opendatahub-io/notebooks#3774 (`be81e2470800`) onto `rhoai-2.25`.

Gitleaks on this branch fails at **Upload SARIF** because Gitleaks 8.30.x emits `endColumn: 0` (see failing runs on `rhoai-2.25`). This adds the stdlib sanitizer, workflow guards, tests, and `docs/sarif.md`.

## Test plan

- [ ] Gitleaks secret scan workflow green on this PR
- [ ] `pytest tests/unit/scripts/ci/test_sanitize_gitleaks_sarif.py` (CI)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security scanning reliability by fixing scan result validation to comply with GitHub requirements.

* **Documentation**
  * Added documentation on security scan result handling and the SARIF format.

* **Tests**
  * Expanded test coverage for security scan result processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->