### PR TITLE
[rhoai-3.3] RHAIENG-5134: test: remove stale wheel ignored_exceptions entry

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -308,7 +308,6 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
     ignored_exceptions: tuple[tuple[str, tuple[str, ...]], ...] = (
         # ("package name", ("allowed specifier 1", "allowed specifier 2", ...))
         ("setuptools", ("~=80.9.0", "==80.9.0")),
-        ("wheel", ("==0.46.2", "~=0.46.2")),
         ("tensorboard", ("~=2.18.0", "~=2.20.0")),
         ("torch", ("==2.7.1", "==2.7.1+cu128", "==2.7.1+rocm6.3")),
         ("torchvision", ("==0.22.1", "~=0.22.1", "==0.22.1+cu128", "==0.22.1+rocm6.3")),


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5134

## Summary

- Remove the `wheel` entry from `ignored_exceptions` in `test_image_pyprojects_version_alignment`.
- All image `pyproject.toml` files now use `wheel~=0.46.2` only (#1899); the dual-specifier exception (`==0.46.2` + `~=0.46.2`) causes the test to fail once alignment is complete.

## Validation

- [x] `pytest tests/test_main.py::test_image_pyprojects_version_alignment` passes locally

## Test plan

- [ ] CI `pytest-tests` job green (or only unrelated baseline failures remain)


Made with [Cursor](https://cursor.com)