### PR TITLE
[rhoai-3.3] RHAIENG-5134: chore(align-dockerfile-script): bash 3.2 compat for alignment check

### DIFF
--- a/scripts/check_dockerfile_alignment.sh
+++ b/scripts/check_dockerfile_alignment.sh
@@ -18,11 +18,12 @@ main() {
     echo "Scanning ${start_dirs[*]} for directories containing Dockerfile.konflux.*"
     echo "Comparing Dockerfiles, ignoring comments and LABEL blocks..."
 
-    # Populate array of directories
+    # Populate array of directories (while-read is portable; mapfile requires Bash 4+)
     local docker_dirs=()
     for dir in "${start_dirs[@]}"; do
-        mapfile -t dirs < <(find_docker_dirs "$dir")
-        docker_dirs+=("${dirs[@]}")
+        while IFS= read -r line; do
+            docker_dirs+=("$line")
+        done < <(find_docker_dirs "$dir")
     done
 
     # Process all directories and check for differences
@@ -111,9 +112,9 @@ find_diff() {
 
     echo "---- diff $file_orig $file_konflux ----"
 
-    # Use process substitution to feed stripped files to diff
+    # Use process substitution to feed stripped files to diff (plain diff for Mac/BSD and Linux/GNU portability)
     local diff_output
-    diff_output=$(diff --color=always <(strip <"$dir/$file_orig") <(strip <"$dir/$file_konflux") || true)
+    diff_output=$(diff <(strip <"$dir/$file_orig") <(strip <"$dir/$file_konflux") || true)
 
     if [ -n "$diff_output" ]; then
         echo "❌ Differences found between $file_orig and $file_konflux"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5134

## Summary

Backport [`cd703b704`](https://github.com/opendatahub-io/notebooks/commit/cd703b704) from ODH main: replace `mapfile` with a portable `while read` loop in `scripts/check_dockerfile_alignment.sh`.

Fixes local `gmake test` on macOS where `/bin/bash` is 3.2 and lacks `mapfile` (bash 4+):

```
./scripts/check_dockerfile_alignment.sh: line 24: mapfile: command not found
gmake: *** [Makefile:470: test] Error 127
```

Also drops `diff --color=always` for BSD/GNU portability (same as upstream commit).

## Validation

- [x] Cherry-pick applies cleanly onto current `rhoai-3.3`
- [x] `/bin/bash ./scripts/check_dockerfile_alignment.sh` runs without `mapfile` error on macOS

## Test plan

- [ ] CI `pytest-tests` / `make test` no longer fails at alignment script startup on macOS-style bash
- [ ] Alignment check behavior unchanged (still compares stripped Dockerfiles)


Made with [Cursor](https://cursor.com)