### PR TITLE
[rhoai-3.3] RHAIENG-5134: fix(codeserver): align Dockerfile.cpu with konflux.cpu

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -176,7 +176,7 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # Install useful OS packages
-RUN --mount=type=cache,target=/var/cache/dnf ./utils/install_with_retry.sh dnf-install jq git-lfs libsndfile
+RUN --mount=type=cache,target=/var/cache/dnf ./utils/install_with_retry.sh dnf-install jq git-lfs libsndfile gettext
 
 # wait for rpm-base stage (rpm builds for ppc64le and s390x)
 COPY --from=rpm-base /tmp/control /dev/null

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -72,9 +72,9 @@ pip install --no-cache-dir uv
 source ./devel_env_setup.sh
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-# pin meson version for pandas>=2.3.3
-echo "meson<1.11" >> constraint.txt
-UV_NO_CACHE=false UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint constraint.txt
+# RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
+echo "meson<1.11" > build_constraints.txt
+UV_NO_CACHE=false UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 EOF
 
 # dummy file to make image build wait for this stage


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-5134

## Summary

Fixes `make test` / `check_dockerfile_alignment.sh` failure on `rhoai-3.3` (see [pytest-tests log](https://github.com/red-hat-data-services/notebooks/actions/runs/26627223398/job/78466817539#step:7:616)).

`codeserver/ubi9-python-3.12/Dockerfile.cpu` drifted from `Dockerfile.konflux.cpu`:

| Area | `Dockerfile.cpu` (before) | `Dockerfile.konflux.cpu` (before) |
|------|---------------------------|-----------------------------------|
| Meson pin | `build_constraints.txt` (`>`) | `constraint.txt` (`>>`) |
| OS packages | missing `gettext` | `gettext` present |

**Approach:** align **konflux → cpu**, not the other way around.

- Meson pin follows the same `build_constraints.txt` pattern already used in `jupyter/datascience` and `runtimes/datascience` on `rhoai-3.3` (from #2126 / [RHOAIENG-58277](https://redhat.atlassian.net/browse/RHOAIENG-58277))
- `gettext` added to `Dockerfile.cpu` to match konflux; `rhoai-3.4` also ships `gettext` in both cpu/konflux runtime package lists

Root cause: #2125 updated konflux only; #2126 updated cpu with a different constraint filename.

## Validation

- [x] `./scripts/check_dockerfile_alignment.sh` — all directories pass locally

## Test plan

- [ ] CI `pytest-tests` job passes Dockerfile alignment step
- [ ] Codeserver build behaviour unchanged (gettext already present in konflux builds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added system package support to the container image.
  * Optimized build constraints handling for improved cross-architecture compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->