### PR TITLE
RHAIENG-5355: updates starlette to address to CVE-2026-48710 [rhoai-2.25]

### DIFF
--- a/codeserver/ubi9-python-3.12/pylock.toml
+++ b/codeserver/ubi9-python-3.12/pylock.toml
@@ -359,9 +359,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "feast"
@@ -2408,9 +2408,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -2481,6 +2481,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -18,3 +18,5 @@ onnx>=1.21.0 ; platform_machine != 's390x'
 onnxconverter-common~=1.16.0
 # RHAIENG-3793:CVE-2026-31958 Tornado: Denial of Service via large multipart bodies
 tornado>=6.5.5
+# RHAIENG-5355: CVE-2026-48710 Starlette: Security restriction bypass via malformed HTTP Host header
+starlette>=1.0.1

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -902,9 +902,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4455,9 +4455,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -4552,6 +4552,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -851,9 +851,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4821,9 +4821,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "sympy"
@@ -5044,6 +5044,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -903,9 +903,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4588,9 +4588,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "sympy"
@@ -4760,6 +4760,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -903,9 +903,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4462,9 +4462,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "sympy"
@@ -4603,6 +4603,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -909,9 +909,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4625,9 +4625,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -4746,6 +4746,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -909,9 +909,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4730,9 +4730,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -4872,6 +4872,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/runtimes/datascience/ubi9-python-3.12/pylock.toml
+++ b/runtimes/datascience/ubi9-python-3.12/pylock.toml
@@ -814,9 +814,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -3841,9 +3841,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -3920,6 +3920,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -692,9 +692,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4016,9 +4016,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "sympy"
@@ -4221,6 +4221,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/runtimes/pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/pylock.toml
@@ -810,9 +810,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -3961,9 +3961,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "sympy"
@@ -4115,6 +4115,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/pylock.toml
@@ -810,9 +810,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -3835,9 +3835,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "sympy"
@@ -3958,6 +3958,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/pylock.toml
@@ -816,9 +816,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -3992,9 +3992,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -4101,6 +4101,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"

--- a/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/pylock.toml
@@ -816,9 +816,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/28/3c/bc3819dd8b1a158
 
 [[packages]]
 name = "fastapi"
-version = "0.128.0"
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", upload-time = 2025-12-27T15:21:13Z, size = 365682, hashes = { sha256 = "1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", upload-time = 2025-12-27T15:21:12Z, size = 103094, hashes = { sha256 = "aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d" } }]
+version = "0.136.3"
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", upload-time = 2026-05-23T18:53:15Z, size = 396410, hashes = { sha256 = "e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", upload-time = 2026-05-23T18:53:16Z, size = 117481, hashes = { sha256 = "3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620" } }]
 
 [[packages]]
 name = "fastjsonschema"
@@ -4109,9 +4109,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852
 
 [[packages]]
 name = "starlette"
-version = "0.50.0"
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", upload-time = 2025-11-01T15:25:27Z, size = 2646985, hashes = { sha256 = "a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", upload-time = 2025-11-01T15:25:25Z, size = 74033, hashes = { sha256 = "9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca" } }]
+version = "1.2.0"
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", upload-time = 2026-05-28T11:42:50Z, size = 2668923, hashes = { sha256 = "3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", upload-time = 2026-05-28T11:42:48Z, size = 73213, hashes = { sha256 = "36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7" } }]
 
 [[packages]]
 name = "tabulate"
@@ -4239,6 +4239,12 @@ name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", upload-time = 2025-08-25T13:49:24Z, size = 44614, hashes = { sha256 = "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" } }]
+
+[[packages]]
+name = "typing-inspection"
+version = "0.4.2"
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", upload-time = 2025-10-01T02:14:41Z, size = 75949, hashes = { sha256 = "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", upload-time = 2025-10-01T02:14:40Z, size = 14611, hashes = { sha256 = "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" } }]
 
 [[packages]]
 name = "tzdata"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
adds starlette to cve-constraints.txt
ran `gmake refresh-pipfilelock-files PYTHON_VERSION=3.12 INCLUDE_OPT_DIRS=false`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added security constraints for `tornado` (≥6.5.5) and `starlette` (≥1.0.1) to address CVE vulnerabilities.

* **Chores**
  * Updated `fastapi` to 0.136.3 and `starlette` to 1.2.0 across all runtime environments.
  * Added `typing-inspection` 0.4.2 as a new dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-data-services/notebooks/pull/2317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->