### PR TITLE
[rhoai-3.3] RHAIENG-3787, RHAIENG-3789, RHAIENG-3791: chore(deps): update Code Se…

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -17,9 +17,9 @@ ENV HOME=/root
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
-ARG NODE_VERSION=22.18.0
+ARG NODE_VERSION=22.22.0
 
-ARG CODESERVER_VERSION=v4.104.0
+ARG CODESERVER_VERSION=v4.112.0
 
 COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
 COPY ${CODESERVER_SOURCE_CODE}/s390x.patch /tmp/
@@ -159,7 +159,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
-ARG CODESERVER_VERSION=v4.104.0
+ARG CODESERVER_VERSION=v4.112.0
 
 LABEL name="odh-notebook-code-server-ubi9-python-3.12" \
       summary="code-server image with python 3.12 based on UBI 9" \
@@ -201,8 +201,8 @@ EOF
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 mkdir -p /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.14.0.vsix --extensions-dir /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.8.0.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2026.4.0.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.9.1.vsix --extensions-dir /opt/app-root/extensions-temp
 EOF
 
 # Install NGINX to proxy code-server and pass probes check

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -17,9 +17,9 @@ ENV HOME=/root
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
-ARG NODE_VERSION=22.18.0
+ARG NODE_VERSION=22.22.0
 
-ARG CODESERVER_VERSION=v4.104.0
+ARG CODESERVER_VERSION=v4.112.0
 
 COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
 COPY ${CODESERVER_SOURCE_CODE}/s390x.patch /tmp/
@@ -159,7 +159,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
-ARG CODESERVER_VERSION=v4.104.0
+ARG CODESERVER_VERSION=v4.112.0
 
 LABEL name="rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
       com.redhat.component="odh-workbench-codeserver-datascience-cpu-py312-rhel9" \
@@ -199,8 +199,8 @@ EOF
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 mkdir -p /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2025.14.0.vsix --extensions-dir /opt/app-root/extensions-temp
-code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.8.0.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-python.python-2026.4.0.vsix --extensions-dir /opt/app-root/extensions-temp
+code-server --install-extension /opt/app-root/bin/utils/ms-toolsai.jupyter-2025.9.1.vsix --extensions-dir /opt/app-root/extensions-temp
 EOF
 
 # Install NGINX to proxy code-server and pass probes check

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -20,8 +20,8 @@ ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
 if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" || "$ARCH" == "ppc64le" || "$ARCH" == "s390x" ]]; then
 
 	export MAX_JOBS=${MAX_JOBS:-$(($(nproc) * 2))}
-	export NODE_VERSION=${NODE_VERSION:-22}
-	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.104.0}
+	export NODE_VERSION=${NODE_VERSION:-22.22.0}
+	export CODESERVER_VERSION=${CODESERVER_VERSION:-v4.112.0}
 
 	export NVM_DIR=/root/.nvm VENV=/opt/.venv
 	export PATH=${VENV}/bin:$PATH

--- a/codeserver/ubi9-python-3.12/run-code-server.sh
+++ b/codeserver/ubi9-python-3.12/run-code-server.sh
@@ -52,6 +52,10 @@ universal_json_settings='// vscode settings are written in json-with-comments
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
 
+  // Disable GitHub Copilot in code-server
+  // official doc https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code
+  "chat.disableAIFeatures": true,
+
   // RHOAIENG-14518: Disable the "Do you trust the authors [...]" startup prompt
   "security.workspace.trust.enabled": false,
   "security.workspace.trust.startupPrompt": "never"

--- a/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.14.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.python-2025.14.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d561d57f5820c0bdbc2b822f417e524afba256c60b28a9a1670f7923b1bddabc
-size 6771811

--- a/codeserver/ubi9-python-3.12/utils/ms-python.python-2026.4.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-python.python-2026.4.0.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:232aeafb01f069824fdd92d3e628c1c442bbcfa1d3cc945ff97076340bb2b4a6
+size 6826731

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.8.0.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.8.0.vsix
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e0373fe1b309660e6e53189ab7ad34f7e374d3c7a76b8e4621d6a5b93d4caae
-size 12619222

--- a/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.9.1.vsix
+++ b/codeserver/ubi9-python-3.12/utils/ms-toolsai.jupyter-2025.9.1.vsix
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:110660656944c4ab0ff687db488c2e8c59c67ec121dcf09bcaa54b6edd9ce71f
+size 12619012

--- a/manifests/base/code-server-notebook-imagestream.yaml
+++ b/manifests/base/code-server-notebook-imagestream.yaml
@@ -19,7 +19,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "code-server", "version": "4.104"},
+            {"name": "code-server", "version": "4.112"},
             {"name": "Python", "version": "v3.12"}
           ]
         # language=json
@@ -50,7 +50,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "code-server", "version": "4.98"},
+            {"name": "code-server", "version": "4.104"},
             {"name": "Python", "version": "v3.11"}
           ]
         # language=json
@@ -82,7 +82,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "code-server", "version": "4.92"},
+            {"name": "code-server", "version": "4.98"},
             {"name": "Python", "version": "v3.11"}
           ]
         # language=json
@@ -113,7 +113,7 @@ spec:
         # language=json
         opendatahub.io/notebook-software: |
           [
-            {"name": "code-server", "version": "4.22"},
+            {"name": "code-server", "version": "4.92"},
             {"name": "Python", "version": "v3.9"}
           ]
         # language=json


### PR DESCRIPTION
This PR aims to fix three Jiras ([RHAIENG-3787](https://redhat.atlassian.net/browse/RHAIENG-3787), [RHAIENG-3789](https://redhat.atlassian.net/browse/RHAIENG-3789) and [RHAIENG-3791](https://redhat.atlassian.net/browse/RHAIENG-3791)) by upgrading Code Server from v4.104.0 to v4.112.0 and Node.js from version 22.18.0 to 22.22.0

## Description

`CodeServer` has a direct dependency on `VSCode`, which has a direct dependency on `undici` library.

```mermaid
graph LR
  A[CodeServer] --> B[VSCode]
  B --> C[undici]
```

For past versions of CodeServer, `undici` was fixed on `7.9.0`.

The CVE that is attached to these Jira tickets mentions that undici version 7.9.0 is under the range of the vulnerability affected versions `< 6.24.0; 7.0.0 < 7.24.0`, which will require a proper update of CodeServer, of at least `v4.112.0` (the choice at this moment for build and constraint reasons), in our RHOAI 3.3 z-stream.

<div align="center">

<br />

 | version | undici | code server | vscode |
 |:--- |:--- |:--- |:--- |
| v4.104.0 | 7.9.0 | https://github.com/coder/code-server/tree/v4.104.0/lib | [vscode @ f220831](https://github.com/microsoft/vscode/blob/f220831ea2d946c0dcb0f3eaa480eb435a2c1260/package-lock.json#L17653-L17661) |
| ... | 7.9.0 | ... | ... |
| v4.108.2 | 7.9.0 | https://github.com/coder/code-server/tree/v4.108.2/lib | [vscode @ c9d7799](https://github.com/microsoft/vscode/blob/c9d77990917f3102ada88be140d28b038d1dd7c7/package-lock.json#L16940-L16948) |
| v4.109.0 | 7.18.2 | https://github.com/coder/code-server/tree/v4.109.0/lib | [vscode @ bdd88df](https://github.com/microsoft/vscode/blob/bdd88df003631aaa0bcbe057cb0a940b80a476fa/package-lock.json#L17180-L17188) |
| ... | 7.18.2 | ... | ... |
| v4.111.0 | 7.18.2 | https://github.com/coder/code-server/tree/v4.111.0/lib | [vscode @ ce099c1](https://github.com/microsoft/vscode/blob/ce099c1ed25d9eb3076c11e4a280f3eb52b4fbeb/package-lock.json#L19803-L19811) |
| v4.112.0 | 7.24.0 | https://github.com/coder/code-server/tree/v4.112.0/lib | [vscode @ 07ff9d6](https://github.com/microsoft/vscode/blob/07ff9d6178ede9a1bd12ad3399074d726ebe6e43/package-lock.json#L20091-L20099) |
| ... | 7.24.4 | ... | ... |
| v4.115.0 | 7.24.4 | https://github.com/coder/code-server/tree/v4.115.0/lib | [vscode @ 41dd792](https://github.com/microsoft/vscode/blob/41dd792b5e652393e7787322889ed5fdc58bd75b/package-lock.json#L18907-L18915) |

<br />

</div>

Among the supported versions (`v4.112.0` and `v4.115.0`), I have tried both and the latest version is giving some issues regarding the build (memory constraints, new process, etc), as they have removed the `npm run build:standalone` command and the new command is really heavy memory consuming with the Gulp process.

The build with `v4.112.0` worked as expected and looks like a safe path to go for now.

## Extensions and settings

Also, the following changes have been done regarding extensions:

- Disabled GitHub Copilot in code-server ([official doc](https://code.visualstudio.com/docs/copilot/faq#_how-can-i-remove-copilot-from-vs-code))
- Downloaded the latest version of the [ms-python.python](https://open-vsx.org/extension/ms-python/python) extension (going from `2025.14.0` to `2026.4.0`)
- Downloaded the latest version of the [ms-toolsai.jupyter](https://open-vsx.org/extension/ms-toolsai/jupyter) extension (going from `2025.8.0` to `2025.9.1`)

## Build and run the image locally

#### Configure your environment variables:

```bash
$ export QUAY_USER="myuser"
$ export QUAY_IO="quay.io/$QUAY_USER/workbench-images"
$ export WORKBENCH_RELEASE="2025b"
```

#### Build the CodeServer image

```bash
$ make codeserver-ubi9-python-3.12 \
               -e IMAGE_REGISTRY=$QUAY_IO \
               -e RELEASE=$WORKBENCH_RELEASE \
               -e RELEASE_PYTHON_VERSION="3.12" \
               -e PUSH_IMAGES="yes" \
               -e CONTAINER_BUILD_CACHE_ARGS=""
```

#### Run locally with Podman

```bash
$ export LATEST_TAG=`podman images --format "{{.Repository}}:{{.Tag}}" | grep "$QUAY_IO:codeserver-ubi9-python-3.12-$WORKBENCH_RELEASE" | sort -r | head -n1 | cut -d':' -f2`
$ podman run -it --platform linux/amd64 -p 8880:8787 $QUAY_IO:$LATEST_TAG
```

Now, open [http://localhost:8080](http://localhost:8080) and test your CodeServer instance

## Run remote image in a local container

A CodeServer image was already built and you can simply reference to it to test it:

```bash
$ podman run -it --platform linux/amd64 -p 8880:8787 quay.io/dlutz/workbench-images:codeserver-ubi9-python-3.12-2025b_20260610
```

Now, open [http://localhost:8080](http://localhost:8080) and test your CodeServer instance

## How Has This Been Tested?
This image has been built and uploaded to a cluster (they are short-lived, 36h), but here are the about info and screenshots of the workbench running on v4.112.0 with latest extensions:

```
code-server: v4.112.0
Code: 1.112.0
Commit: d7599ae360900ad55b503e3c840b417a1eae4798
Date: 2026-03-17T18:09:23Z
Browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36
```

| About | Jupyter | Python | Highlighting |
| ------ | ------- | ------- | ------------ |
| <img alt="codeserver-upgrade-about" src="https://github.com/user-attachments/assets/70339b43-dd3e-40fc-9c3c-8cf5749d1c8b" /> | <img alt="codeserver-upgrade-jupyter-extension" src="https://github.com/user-attachments/assets/e77ae0e0-3f8d-4e84-ba65-c61187f0c131" /> | <img alt="codeserver-upgrade-python-extension" src="https://github.com/user-attachments/assets/a4c6e826-2c45-4c75-b4e0-ab66acb6504e" /> | <img alt="codeserver-upgrade-python-code-highlighting" src="https://github.com/user-attachments/assets/dacfb35f-0b89-4bda-904d-426100c4d5e6" /> |

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work

[RHAIENG-3787]: https://redhat.atlassian.net/browse/RHAIENG-3787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-3789]: https://redhat.atlassian.net/browse/RHAIENG-3789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-3791]: https://redhat.atlassian.net/browse/RHAIENG-3791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime from 22.18.0 to 22.22.0
  * Updated code-server platform from v4.104.0 to v4.112.0
  * Updated Python extension from 2025.14.0 to 2026.4.0
  * Updated Jupyter extension from 2025.8.0 to 2025.9.1
  * Disabled GitHub Copilot and related AI features in code-server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->