### PR TITLE
[rhoai-3.3] NO-JIRA: ci(tekton): disable blocking FIPS check on PR pipelines

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -50,6 +50,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -50,6 +50,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -51,6 +51,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -49,6 +49,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -56,6 +56,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -51,6 +51,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -50,6 +50,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -50,6 +50,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -50,6 +50,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -51,6 +51,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
@@ -49,6 +49,8 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -52,11 +52,11 @@ spec:
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
+  - name: fips-check-blocking
+    value: "false"
   timeouts:
     pipeline: 8h
     tasks: 4h
-  - name: fips-check-blocking
-    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
   timeouts:
     pipeline: 8h
     tasks: 4h
+  - name: fips-check-blocking
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

- Add `fips-check-blocking: "false"` to all 16 workbench/runtime PR PipelineRuns using `multi-arch-container-build.yaml`
- Push pipelines on `rhoai-3.3` already had this param; PR pipelines inherited konflux-central default `"true"` and were blocking on FIPS scan failures

## Context

Pre-3.5 workbench images are not FIPS compliant; FIPS scan should remain informational on maintained release branches.

Slack: https://redhat-internal.slack.com/archives/C0961HQ858Q/p1781166305289449?thread_ts=1780914786.183559

## Test plan

- [ ] Merge and re-trigger `/build-konflux` on a PR with known FIPS failures — pipeline should log failure but not block

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new configuration parameter to multiple runtime and workbench pipeline definitions to enable enhanced pipeline flexibility and control options across all build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->