### PR TITLE
[rhoai-2.25] RHAIENG-5608: Add patch to fix vsce-sign package for CodeServer on PPC64LE builds

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -26,6 +26,7 @@ ARG NODE_VERSION=22.22.0
 ARG CODESERVER_VERSION=v4.112.0
 
 COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
+COPY ${CODESERVER_SOURCE_CODE}/patches/ ./patches/
 
 # create dummy file to ensure this stage is awaited before installing rpm
 RUN ./get_code_server_rpm.sh && touch /tmp/control

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -26,6 +26,7 @@ ARG NODE_VERSION=22.22.0
 ARG CODESERVER_VERSION=v4.112.0
 
 COPY ${CODESERVER_SOURCE_CODE}/get_code_server_rpm.sh .
+COPY ${CODESERVER_SOURCE_CODE}/patches/ ./patches/
 
 # create dummy file to ensure this stage is awaited before installing rpm
 RUN ./get_code_server_rpm.sh && touch /tmp/control

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -64,6 +64,14 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 	cd code-server
 	source ${NVM_DIR}/nvm.sh
 	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
+
+	# Apply ODH overlay patches (flat filenames; avoid patches/lib/ — matched by .gitignore).
+	ODH_PATCHES_DIR="${ODH_PATCHES_DIR:-/root/patches}"
+	if [[ -f "${ODH_PATCHES_DIR}/vscode-tsgo.ts" ]]; then
+		echo "Applying ODH overlay: lib/vscode/build/lib/tsgo.ts"
+		install -D "${ODH_PATCHES_DIR}/vscode-tsgo.ts" lib/vscode/build/lib/tsgo.ts
+	fi
+
 	nvm use ${NODE_VERSION}
 
 	# ppc64le/s390x: disable @vscode/vsce-sign's postinstall (same fix as prefetch-input/patches/apply-patch.sh on main).

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -65,6 +65,35 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 	source ${NVM_DIR}/nvm.sh
 	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
 	nvm use ${NODE_VERSION}
+
+	# ppc64le/s390x: disable @vscode/vsce-sign's postinstall (same fix as prefetch-input/patches/apply-patch.sh on main).
+	# Online build: fetch tarball via npm pack and point the lockfile at the patched file (no cachi2 cache).
+	if [[ "$ARCH" == "ppc64le" || "$ARCH" == "s390x" ]]; then
+		vsceSignVersion=$(jq -r '.packages["node_modules/@vscode/vsce-sign"].version' lib/vscode/build/package-lock.json)
+		if [[ -z "${vsceSignVersion}" || "${vsceSignVersion}" == "null" ]]; then
+			echo "ERROR: failed to read @vscode/vsce-sign version from lib/vscode/build/package-lock.json" >&2
+			exit 1
+		fi
+		patchdir=$(mktemp -d)
+		npm pack "@vscode/vsce-sign@${vsceSignVersion}" --pack-destination="$patchdir"
+		VSCE_TGZ="$patchdir/vscode-vsce-sign-${vsceSignVersion}.tgz"
+		echo "Patching vsce-sign: removing postinstall for ${ARCH} (${VSCE_TGZ})"
+		tmpdir=$(mktemp -d)
+		tar xzf "${VSCE_TGZ}" -C "$tmpdir"
+		jq 'del(.scripts.postinstall)' "$tmpdir/package/package.json" \
+			> /tmp/pkg-tmp.json && mv /tmp/pkg-tmp.json "$tmpdir/package/package.json"
+		tar czf "${VSCE_TGZ}" -C "$tmpdir" package
+		rm -rf "$tmpdir"
+		# Tell npm not to run vsce-sign's postinstall (hasInstallScript=false) and
+		# strip integrity so npm accepts the modified tarball.
+		jq --arg resolved "file:${VSCE_TGZ}" '
+			(.packages["node_modules/@vscode/vsce-sign"].hasInstallScript = false) |
+			(.packages["node_modules/@vscode/vsce-sign"].resolved = $resolved) |
+			del(.packages["node_modules/@vscode/vsce-sign"].integrity)
+		' lib/vscode/build/package-lock.json > /tmp/lock-tmp.json \
+			&& mv /tmp/lock-tmp.json lib/vscode/build/package-lock.json
+	fi
+
 	npm install
 	npm run build
 	VERSION=${CODESERVER_VERSION/v/} npm run build:vscode

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -80,18 +80,20 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 		echo "Patching vsce-sign: removing postinstall for ${ARCH} (${VSCE_TGZ})"
 		tmpdir=$(mktemp -d)
 		tar xzf "${VSCE_TGZ}" -C "$tmpdir"
+		pkg_tmp=$(mktemp)
 		jq 'del(.scripts.postinstall)' "$tmpdir/package/package.json" \
-			> /tmp/pkg-tmp.json && mv /tmp/pkg-tmp.json "$tmpdir/package/package.json"
+			> "$pkg_tmp" && mv "$pkg_tmp" "$tmpdir/package/package.json"
 		tar czf "${VSCE_TGZ}" -C "$tmpdir" package
 		rm -rf "$tmpdir"
 		# Tell npm not to run vsce-sign's postinstall (hasInstallScript=false) and
 		# strip integrity so npm accepts the modified tarball.
+		lock_tmp=$(mktemp)
 		jq --arg resolved "file:${VSCE_TGZ}" '
 			(.packages["node_modules/@vscode/vsce-sign"].hasInstallScript = false) |
 			(.packages["node_modules/@vscode/vsce-sign"].resolved = $resolved) |
 			del(.packages["node_modules/@vscode/vsce-sign"].integrity)
-		' lib/vscode/build/package-lock.json > /tmp/lock-tmp.json \
-			&& mv /tmp/lock-tmp.json lib/vscode/build/package-lock.json
+		' lib/vscode/build/package-lock.json > "$lock_tmp" \
+			&& mv "$lock_tmp" lib/vscode/build/package-lock.json
 	fi
 
 	npm install

--- a/codeserver/ubi9-python-3.12/patches/vscode-tsgo.ts
+++ b/codeserver/ubi9-python-3.12/patches/vscode-tsgo.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import ansiColors from 'ansi-colors';
+import * as cp from 'child_process';
+import es from 'event-stream';
+import fancyLog from 'fancy-log';
+import * as path from 'path';
+
+const root = path.dirname(path.dirname(import.meta.dirname));
+const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+const timestampRegex = /^\[\d{2}:\d{2}:\d{2}\]\s*/;
+
+// [ODH PATCH] @typescript/native-preview has no linux-ppc64/s390x binary on v4.112+.
+// Also fall back to tsc when tsgo is present but fails (e.g. under QEMU user emulation).
+function isTsgoAvailable(): boolean {
+	if (process.env.VSCODE_USE_TSC === '1') {
+		return false;
+	}
+	if (process.arch === 'ppc64' || process.arch === 's390x') {
+		return false;
+	}
+	try {
+		import.meta.resolve(`@typescript/native-preview-${process.platform}-${process.arch}/package.json`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function spawnCompiler(projectPath: string, config: { taskName: string; noEmit?: boolean }, useTsgo: boolean, onComplete?: () => Promise<void> | void): Promise<void> {
+	function runReporter(output: string) {
+		const lines = (output || '').split('\n');
+		const errorLines = lines.filter(line => /error \w+:/.test(line));
+		if (errorLines.length > 0) {
+			fancyLog(`Finished ${ansiColors.green(config.taskName)} ${projectPath} with ${errorLines.length} errors.`);
+			for (const line of errorLines) {
+				fancyLog(line);
+			}
+		}
+	}
+
+	const tool = useTsgo ? 'tsgo' : 'tsc';
+	const args = useTsgo ? ['tsgo', '--project', projectPath, '--pretty', 'false'] : ['tsc', '-p', projectPath, '--pretty', 'false'];
+	if (config.noEmit) {
+		args.push('--noEmit');
+	} else {
+		args.push('--sourceMap', '--inlineSources');
+	}
+	const child = cp.spawn(npx, args, {
+		cwd: root,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		shell: true
+	});
+
+	let stdoutData = '';
+	let stderrData = '';
+
+	child.stdout?.on('data', (data: Buffer) => {
+		stdoutData += data.toString();
+	});
+	child.stderr?.on('data', (data: Buffer) => {
+		stderrData += data.toString();
+	});
+
+	return new Promise<void>((resolve, reject) => {
+		child.on('exit', code => {
+			const allOutput = stdoutData + '\n' + stderrData;
+			const lines = allOutput
+				.split(/\r?\n/)
+				.map(line => line.replace(ansiRegex, '').trim())
+				.map(line => line.replace(timestampRegex, ''))
+				.filter(line => line.length > 0)
+				.filter(line => !/Starting compilation|File change detected|Compilation complete/i.test(line));
+
+			runReporter(lines.join('\n'));
+
+			if (code === 0) {
+				Promise.resolve(onComplete?.()).then(() => resolve(), reject);
+			} else {
+				const detail = allOutput.trim();
+				reject(new Error(`${tool} exited with code ${code ?? 'unknown'}${detail ? `\n${detail}` : ''}`));
+			}
+		});
+
+		child.on('error', err => {
+			reject(err);
+		});
+	});
+}
+
+export function spawnTsgo(projectPath: string, config: { taskName: string; noEmit?: boolean }, onComplete?: () => Promise<void> | void): Promise<void> {
+	const useTsgo = isTsgoAvailable();
+	return spawnCompiler(projectPath, config, useTsgo, onComplete).catch(err => {
+		if (!useTsgo) {
+			throw err;
+		}
+		fancyLog(`${ansiColors.yellow('tsgo failed, falling back to tsc')}: ${err instanceof Error ? err.message : err}`);
+		return spawnCompiler(projectPath, config, false, onComplete);
+	});
+}
+
+export function createTsgoStream(projectPath: string, config: { taskName: string; noEmit?: boolean }, onComplete?: () => Promise<void> | void): NodeJS.ReadWriteStream {
+	const stream = es.through();
+
+	spawnTsgo(projectPath, config, onComplete).then(() => {
+		stream.emit('end');
+	}).catch(err => {
+		stream.emit('error', err);
+	});
+
+	return stream;
+}


### PR DESCRIPTION
With the CodeServer upgrade introduced in #2340 and #2350, a new failures started to happen regarding vsce-sign packages on ppc64le builds.

More information can be found on https://redhat.atlassian.net/browse/RHAIENG-5608

## How Has This Been Tested?
Local builds have been done using Podman with PPC64LE emulation

#### Building `linux/ppc64le` images locally

First step is to install qemu on your podman machine VM and then restart it:

```bash
$ podman machine ssh -- sudo rpm-ostree install qemu-user-static
$ podman machine stop
$ podman machine start
```

After the installation and reboot, you can run the following quick test to ensure the emulation is working:

```bash
$ podman run --rm --platform linux/ppc64le registry.access.redhat.com/ubi9/ubi uname -m
```

#### Building the CodeServer image locally

To build the CodeServer image for PPC64LE, just send the BUILD_ARCH parameter to the make command:

```bash
$ make codeserver-ubi9-python-3.12 \
               -e BUILD_ARCH=linux/ppc64le \
               -e IMAGE_REGISTRY=quay.io/dlutz/workbench-images \
               -e RELEASE=2025b \
               -e RELEASE_PYTHON_VERSION="3.12" \
               -e PUSH_IMAGES="yes" \
               -e CONTAINER_BUILD_CACHE_ARGS=""
```

Self checklist (all need to be checked):
- [X] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [X] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the Code Server build process for **ppc64le** and **s390x** by applying a build-time workaround for a signing-related package to increase reliability and keep artifacts consistent.
  * Enhanced the build flow to optionally apply an ODH overlay when patch files are present.
  * Updated CPU-focused Docker build stages to include the repository’s `patches/` directory so patching steps can run successfully during RPM creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->