### PR TITLE
RHAIENG-5136: chore(ci) Add fail_ci_if_error to Codecov actions [rhoai-3.5]

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -55,10 +55,23 @@ jobs:
         id: install-deps
         run: uv sync --locked
 
+      - name: Set up Go
+        if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: scripts/buildinputs/go.mod
+
+      - name: Build buildinputs binary for Dockerfile dependency tests
+        if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
+        run: make bin/buildinputs
+
       - name: Static tests (pytest + Dockerfile alignment)
         run: make test
         if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
         env:
+          # Use the locally built bin/buildinputs instead of pulling the GHCR image
+          # (no podman/GHCR auth in this job; see scripts/buildinputs_runner.py).
+          CI: 'false'
           # PR: compare to the PR base (fork PRs vs upstream main, not the fork default branch).
           # Push: compare to the previous tip of this branch (not origin/main on stable/rhoai-*).
           NOTEBOOKS_DOWNGRADE_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -78,6 +91,7 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   go-tests:
     runs-on: ubuntu-26.04
@@ -120,6 +134,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: scripts/buildinputs/junit-go.xml
+          fail_ci_if_error: false
 
   code-static-analysis:
     runs-on: ubuntu-26.04

--- a/jupyter/trustyai/ubi9-python-3.12/requirements.cpu.txt
+++ b/jupyter/trustyai/ubi9-python-3.12/requirements.cpu.txt
@@ -333,7 +333,11 @@ matplotlib==3.10.9 ; python_full_version == '3.12.*' and implementation_name == 
     --hash=sha256:206a1bfcce6c6aff0af2a0cfad59234f33ac8ead0ba1f9cdf86a941b44781aa0 \
     --hash=sha256:e75b0b211e1d110be98ef8b34afa10d7d23d14065ba831604b0ddc8c8cfc7811 \
     --hash=sha256:8435191e897ab0ae448c81f5370b3282c21610b4a7715af62be1adbc64922c99 \
-    --hash=sha256:aca4d6b1600faf935b1998f57171af86b9ab1aed36e8d3630f40368337a3170c
+    --hash=sha256:aca4d6b1600faf935b1998f57171af86b9ab1aed36e8d3630f40368337a3170c \
+    --hash=sha256:895e57efd6fae038e25ae3f257f9282ee25e8720cc9036243047b816bbe86b7a \
+    --hash=sha256:5c0224b62acbbb0ce91e62868bedb034168a3472242f3ea9770ed81f51d0cb36 \
+    --hash=sha256:f0b5b2055a45597ef48f5c9fcdd2f63fdabbcaf53931a13bbea14bcd188c6cf4 \
+    --hash=sha256:0bbb8dd9f9dfa7748b399be015ba0eb97625e4d185dc235cccaf168d74ce3f49
 matplotlib-inline==0.2.2 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0889cb2a3fed2f825c78994574114144bac789234cb4542781dc31b59d60e908
 mccabe==0.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -949,6 +949,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-06-08T11:29:42Z, size = 8499958, hashes = { sha256 = "e75b0b211e1d110be98ef8b34afa10d7d23d14065ba831604b0ddc8c8cfc7811" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-06-08T11:29:42Z, size = 9900436, hashes = { sha256 = "8435191e897ab0ae448c81f5370b3282c21610b4a7715af62be1adbc64922c99" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-2-cp312-cp312-linux_x86_64.whl", upload-time = 2026-06-08T11:29:42Z, size = 8403788, hashes = { sha256 = "aca4d6b1600faf935b1998f57171af86b9ab1aed36e8d3630f40368337a3170c" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-06-24T01:07:01Z, size = 8840313, hashes = { sha256 = "895e57efd6fae038e25ae3f257f9282ee25e8720cc9036243047b816bbe86b7a" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-06-24T01:39:26Z, size = 9200193, hashes = { sha256 = "5c0224b62acbbb0ce91e62868bedb034168a3472242f3ea9770ed81f51d0cb36" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-06-24T01:48:44Z, size = 10678035, hashes = { sha256 = "f0b5b2055a45597ef48f5c9fcdd2f63fdabbcaf53931a13bbea14bcd188c6cf4" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/matplotlib-3.10.9-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-06-24T01:04:51Z, size = 9033811, hashes = { sha256 = "0bbb8dd9f9dfa7748b399be015ba0eb97625e4d185dc235cccaf168d74ce3f49" } },
 ]
 
 [[packages]]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Greenify push CI on rhoai-3.5 by fixing the Code static analysis workflow 

pytest-tests failures ([example run](https://github.com/red-hat-data-services/notebooks/actions/runs/28377434702/job/84114767675)):
gen_gha_matrix_jobs tests failed because buildinputs_runner.py tried to podman run ghcr.io/.../buildinputs:main without podman/GHCR auth (exit 125).
Fix: build bin/buildinputs locally in the job and set CI: 'false' so tests use the local binary (same as local dev).
Codecov upload noise on protected branches:

codecov/test-results-action failed with Token required because branch is protected even when tests passed.
Fix: add fail_ci_if_error: false to both Python and Go test-results upload steps (matching coverage upload behavior).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/mtchoum1/notebooks/actions/runs/28391710484/job/84120186161

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work