### PR TITLE
[rhoai-2.25] RHAIENG-5133: fix Build Notebooks CI Go version and action deprecations

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -118,15 +118,10 @@ jobs:
           SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
           SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
 
-      # for bin/buildinputs in scripts/sandbox.py
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
-        with:
-          cache-dependency-path: "scripts/buildinputs/go.sum"
-
       - run: sudo apt-get update
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -163,6 +158,12 @@ jobs:
         uses: './.github/actions/install-podman-action'
         with:
           platform: ${{ inputs.platform }}
+
+      # After install-podman-action prepends linuxbrew to PATH (which ships go 1.25.1 on arm64).
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: scripts/buildinputs/go.mod
+          cache-dependency-path: scripts/buildinputs/go.mod
 
       - name: Calculate image name and tag
         id: calculated_vars


### PR DESCRIPTION
## Summary

Fixes [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133).

- Install Go 1.25.5 via `go-version-file` after Install Podman so linuxbrew's older `go` does not shadow it on arm64 runners
- Upgrade `docker/login-action` to v4.2.0 (Node 24) to clear deprecation warnings on all build matrix jobs

## Test plan

- [x] `cuda-jupyter-minimal-ubi9-python-3.12` (linux/arm64) passes `bin/buildinputs` and `podman build`
- [x] `rstudio-c9s-python-3.11` (linux/amd64) builds successfully
- [ ] Full Build Notebooks matrix green after merge


Made with [Cursor](https://cursor.com)

[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the notebook build workflow to use newer tooling for container registry login.
  * Added a package list refresh step before registry authentication to improve reliability.
  * Adjusted Go setup to run later in the workflow and to use a more complete version/cache configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->