### PR TITLE
[rhoai-2.25] RHAIENG-5133: backport manifests/tools and odh/rhoai base from main

### DIFF
--- a/ci/generate_code.sh
+++ b/ci/generate_code.sh
@@ -7,5 +7,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 uv --version || pip install "uv==0.8.12"
 
 "${REPO_ROOT}/uv" run scripts/dockerfile_fragments.py
-"${REPO_ROOT}/uv" run manifests/tools/generate_kustomization.py
+if [[ -d "${REPO_ROOT}/manifests/odh/base" ]]; then
+  "${REPO_ROOT}/uv" run manifests/tools/generate_kustomization.py
+else
+  "${REPO_ROOT}/uv" run manifests/tools/generate_kustomization.py --target base
+fi
 bash scripts/pylocks_generator.sh

--- a/manifests/tools/commit_env_refs.py
+++ b/manifests/tools/commit_env_refs.py
@@ -1,0 +1,34 @@
+"""Helpers for mapping manifest param keys to commit ConfigMap keys and env files."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def commit_field_key(base_key: str, suffix: str) -> str:
+    """ConfigMap key for a commit hash (e.g. ``...-commit-n``, ``...-commit-2025-2``)."""
+    return f"{base_key}-commit{suffix}"
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    """Load ``KEY=value`` lines from a ``*.env`` file."""
+    out: dict[str, str] = {}
+    if not path.is_file():
+        return out
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        out[k.strip()] = v.strip()
+    return out
+
+
+def commit_env_path_for_suffix(suffix: str) -> str:
+    """``-n`` (latest) uses ``commit-latest.env``; all other versions use ``commit.env``."""
+    return "commit-latest.env" if suffix == "-n" else "commit.env"

--- a/manifests/tools/generate_envs.py
+++ b/manifests/tools/generate_envs.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env -S ./uv run --script
+
+from __future__ import annotations
+
+"""
+Queries the Red Hat Ecosystem Catalog (catalog.redhat.com) for container image metadata
+using the Pyxis REST API to generate params.env and commit.env files.
+
+See docs/fetching_registry_redhat_io_index.md for API documentation and details.
+"""
+
+import json
+import re
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+import certifi
+import typer
+
+API_BASE = "https://catalog.redhat.com/api/containers/v1"
+REGISTRY = "registry.access.redhat.com"
+
+
+def get_json(url: str) -> dict[str, Any]:
+    # Use certifi's CA bundle so TLS verification works on macOS, where Python's
+    # bundled OpenSSL does not read from the system Keychain by default.
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, context=ctx, timeout=30) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def main(
+    version_tag: str = typer.Option(
+        "v3.3", "--version-tag", "-v", help="The version tag to filter by (e.g., v3.3)"
+    ),
+    suffix: str = typer.Option(
+        "2025-2", "--suffix", "-s", help="The suffix to append to variables (e.g., 2025-2)"
+    ),
+) -> None:
+    if not re.match(
+        r"""
+        ^v          # leading 'v'
+        \d+         # major
+        \.          # dot
+        \d+         # minor
+        (           # optional patch
+            \.
+            \d+
+        )?
+        $
+        """,
+        version_tag,
+        re.VERBOSE,
+    ):
+        print(f"Error: version_tag '{version_tag}' must match v<major>.<minor>[.<patch>] (e.g. v3.3)", file=sys.stderr)
+        raise typer.Exit(code=1)
+
+    try:
+        repos: list[str] = []
+        page = 0
+        page_size = 100
+        while True:
+            url = (
+                f"{API_BASE}/repositories?filter=repository=regex=rhoai/odh-workbench.*"
+                f"&page_size={page_size}&page={page}&include=data.repository"
+            )
+            batch = get_json(url).get("data", [])
+            repos.extend(item["repository"] for item in batch)
+            if len(batch) < page_size:
+                break
+            page += 1
+    except Exception as e:
+        print(f"Error fetching repos: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    params_env_lines = []
+    commit_env_lines = []
+    failures: list[str] = []
+
+    for repo in sorted(repos):
+        # NOTE: We filter by architecture==amd64 here merely to isolate a single
+        # result entry for the API call. The `manifest_list_digest` field returned
+        # represents the multi-arch manifest and is identical across all architectures.
+        filter_str = f"architecture==amd64;repositories.tags.name=={version_tag}"
+        encoded_filter = urllib.parse.quote(filter_str)
+
+        img_url = f"{API_BASE}/repositories/registry/{REGISTRY}/repository/{repo}/images?page_size=1&page=0&filter={encoded_filter}&include=data.repositories.manifest_list_digest,data.parsed_data.labels"
+
+        try:
+            img_resp = get_json(img_url)
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"{repo}: {e}")
+            continue
+
+        data = img_resp.get("data", [])
+        if not data:
+            failures.append(f"{repo}: no image found for tag {version_tag}")
+            continue
+
+        img_data = data[0]
+
+        manifest_list_digest = None
+        for r in img_data.get("repositories", []):
+            if "manifest_list_digest" in r:
+                manifest_list_digest = r["manifest_list_digest"]
+                break
+
+        vcs_ref = None
+        labels = img_data.get("parsed_data", {}).get("labels", [])
+        for label in labels:
+            if label.get("name") == "vcs-ref":
+                vcs_ref = label.get("value")
+                break
+
+        if not manifest_list_digest or not vcs_ref:
+            failures.append(f"{repo}: missing manifest_list_digest or vcs-ref")
+            continue
+
+        repo_name = repo.split("/")[-1]
+        var_base_name = repo_name.replace("rhel9", "ubi9")
+
+        param_line = f"{var_base_name}-{suffix}=registry.redhat.io/{repo}@{manifest_list_digest}"
+        commit_line = f"{var_base_name}-commit-{suffix}={vcs_ref[:7]}"
+
+        params_env_lines.append(param_line)
+        commit_env_lines.append(commit_line)
+
+    if failures:
+        for failure in failures:
+            print(f"Error: {failure}", file=sys.stderr)
+        raise typer.Exit(code=1)
+
+    print("=== params.env ===")
+    for line in params_env_lines:
+        print(line)
+
+    print("\n=== commit.env ===")
+    for line in commit_env_lines:
+        print(line)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/manifests/tools/generate_envs.py
+++ b/manifests/tools/generate_envs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S ./uv run --script
+#!/usr/bin/env -S uv run --project=../..
 
 from __future__ import annotations
 

--- a/manifests/tools/generate_kustomization.py
+++ b/manifests/tools/generate_kustomization.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env -S uv run --project=../..
+"""Generate kustomization.yaml for manifests/base/.
+
+Like the "99 bottles" or "12 days of Christmas" kata, the kustomization.yaml
+is a highly repetitive file where each stanza follows the same template with
+different parameters. This script expresses that pattern as code.
+
+Works on both origin/main (2 versions per image) and rhds/main (up to 8
+versions per image with py311/py312 split).  Image lists, version depths,
+and ImageStream names are auto-discovered from the sibling .env and YAML
+files -- no hardcoded image list to keep in sync.
+
+Usage:
+    uv run manifests/tools/generate_kustomization.py              # write kustomization.yaml
+    uv run manifests/tools/generate_kustomization.py --target rhoai
+                                                            # write only manifests/rhoai/base/kustomization.yaml
+    uv run manifests/tools/generate_kustomization.py --check      # verify existing file matches
+    uv run manifests/tools/generate_kustomization.py --stdout     # print to stdout instead
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from manifests.tools.commit_env_refs import parse_env_file
+from ntb.strings import process_template_with_indents
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MANIFESTS_DIR = SCRIPT_DIR.parent
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Workbench:
+    """A workbench image with a variable-length version chain.
+
+    Each entry in *versions* is a ``(base_key, suffix)`` tuple for that tag
+    index.  The suffix is the full version suffix including the leading dash
+    (e.g. ``"-n"``, ``"-2025-2"``, ``"-1-2"``).  This makes the script
+    agnostic to the suffix style used on a given branch.
+
+    For example, on rhds/main ``s2i-minimal-notebook`` has::
+
+        versions = [
+            ("odh-workbench-jupyter-minimal-cpu-py312-ubi9", "-n"),       # tag 0
+            ("odh-workbench-jupyter-minimal-cpu-py312-ubi9", "-2025-2"),  # tag 1
+            ("odh-workbench-jupyter-minimal-cpu-py311-ubi9", "-2025-1"),  # tag 2
+            ...
+        ]
+    """
+
+    imagestream: str
+    resource_file: str
+    versions: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class Runtime:
+    """A runtime image: single tag, params replacement only."""
+
+    base_key: str
+    suffix: str
+    imagestream: str
+    resource_file: str
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery from .env and ImageStream YAML files
+# ---------------------------------------------------------------------------
+
+# Regex matching a params key like "odh-workbench-jupyter-minimal-cpu-py312-ubi9-2024-2"
+#   group 1: everything before the version suffix (e.g. "odh-workbench-...-ubi9")
+#   group 2: the "-n", "-n-<N>", or "-<version_major/year>-<version_minor>" suffix
+_PARAM_KEY_RE = re.compile(
+    r"""
+    ^                   # Match the start of the string
+    ( .+? )             # Group 1: Everything before the version suffix (non-greedy match)
+    (                   # Group 2: The complete suffix
+        -n-\d+          # rhoai-2.25 historical tags (e.g., "-n-1", "-n-6")
+      |                 # OR
+        -n              # Match the exact string "-n" (latest / placeholder)
+      |                 # OR
+        -\d+-\d+        # Match a major/year and minor version (e.g., "-2024-2")
+    )
+    $                   # Match the end of the string
+    """,
+    re.VERBOSE
+)
+
+
+def _parse_imagestream_name(yaml_path: Path) -> str | None:
+    """Extract ``metadata.name`` from an ImageStream YAML file.
+
+    Uses a simple regex to avoid a PyYAML dependency at runtime.
+    Multi-line annotation values (e.g. folded ``notebook-image-desc``) break a
+    naive walk from ``metadata:`` to ``name:``; we isolate the metadata block
+    up to ``spec:`` and match ``name`` there instead.
+    """
+    text = yaml_path.read_text()
+    m = re.search(r"(?ms)^metadata:.*?(?=^spec:)", text)
+    if not m:
+        return None
+    block = m.group(0)
+    m2 = re.search(r"^  name:\s+(\S+)", block, re.MULTILINE)
+    return m2.group(1) if m2 else None
+
+
+def discover_config(base_dir: Path) -> tuple[list[str], list[Workbench], list[str], list[Runtime]]:
+    """Auto-discover workbenches, runtimes, resource files, and version chains.
+
+    Returns (resource_files, workbenches, runtime_resource_files, runtimes)
+    where *resource_files* is the workbench+extra resource list and
+    *runtime_resource_files* is the runtime resource list (both in the order
+    found in the existing kustomization.yaml).
+    """
+    # 1) Read the existing kustomization.yaml to get the resource ordering
+    kustomization = (base_dir / "kustomization.yaml").read_text()
+    resource_section = re.search(r"^resources:\n((?:\s+-\s+\S+\n)+)", kustomization, re.MULTILINE)
+    assert resource_section, "Could not find resources section in kustomization.yaml"
+    all_resources = [line.strip().lstrip("- ") for line in resource_section.group(1).splitlines() if line.strip()]
+
+    # 1b) Build imagestream name -> resource file mapping from YAML metadata
+    imagestream_to_resource = _build_imagestream_to_resource(base_dir, all_resources)
+
+    # 2) Collect all param keys from .env files
+    param_keys = set(parse_env_file(base_dir / "params.env").keys()) | set(parse_env_file(base_dir / "params-latest.env").keys())
+
+    # 3) Parse param keys into (base_key, suffix) pairs.
+    #    e.g. "odh-workbench-...-ubi9-n"      -> ("odh-workbench-...-ubi9", "-n")
+    #         "odh-workbench-...-ubi9-2025-2"  -> ("odh-workbench-...-ubi9", "-2025-2")
+    #    We group by imagestream because different py versions share the same imagestream.
+
+    # First, figure out which resource file each param key belongs to by matching
+    # against the kustomization.yaml replacement blocks.  We do this by reading the
+    # existing file structure.
+    #
+    # Simpler approach: parse the existing kustomization.yaml replacements section
+    # to extract the ordered (key, imagestream) pairs.  This gives us exact ordering.
+
+    replacements_text = kustomization[kustomization.index("replacements:"):]
+    field_path_pattern = re.compile(r"fieldPath: data\.(\S+)")
+    imagestream_pattern = re.compile(r"kind: ImageStream\n\s+name: (\S+)")
+
+    # Extract pairs of (fieldPath_key, imagestream_name) from replacement blocks
+    field_paths = field_path_pattern.findall(replacements_text)
+    imagestreams = imagestream_pattern.findall(replacements_text)
+    assert len(field_paths) == len(imagestreams), (
+        f"Mismatch: {len(field_paths)} fieldPaths vs {len(imagestreams)} imagestreams"
+    )
+
+    # Split into params and commit blocks
+    replacement_params_pairs: list[tuple[str, str]] = []  # (full_key, imagestream)
+    for key, istream in zip(field_paths, imagestreams, strict=True):
+        if "-commit-" not in key:
+            replacement_params_pairs.append((key, istream))
+
+    replacement_param_keys = {full_key for full_key, _imagestream in replacement_params_pairs}
+    missing_param_keys = sorted(param_keys - replacement_param_keys)
+    assert not missing_param_keys, (
+        "Missing imagestream replacement for params key(s): "
+        + ", ".join(missing_param_keys)
+    )
+
+    # Keep only keys that still exist in params*.env.
+    #
+    # This lets the generator recover after tag removals where stale replacements
+    # still exist in kustomization.yaml (the script should remove those blocks).
+    params_pairs = [
+        (full_key, istream) for full_key, istream in replacement_params_pairs if full_key in param_keys
+    ]
+
+    # 5) Build workbenches and runtimes from the params pairs
+    workbench_resource_files: list[str] = []
+    runtime_resource_files: list[str] = []
+    workbenches: list[Workbench] = []
+    runtimes: list[Runtime] = []
+
+    # Track which imagestreams we've seen to group versions
+    seen_workbench_imagestreams: dict[str, Workbench] = {}
+
+    for full_key, istream in params_pairs:
+        m = _PARAM_KEY_RE.match(full_key)
+        assert m, f"Could not parse param key: {full_key}"
+        base_key = m.group(1)
+        suffix = m.group(2)
+
+        if full_key.startswith("odh-pipeline-runtime-"):
+            res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
+            runtimes.append(Runtime(base_key, suffix, istream, res_file))
+            if res_file not in runtime_resource_files:
+                runtime_resource_files.append(res_file)
+        else:
+            if istream not in seen_workbench_imagestreams:
+                res_file = _find_resource_file(all_resources, istream, imagestream_to_resource)
+                wb = Workbench(istream, res_file)
+                seen_workbench_imagestreams[istream] = wb
+                workbenches.append(wb)
+                if res_file not in workbench_resource_files:
+                    workbench_resource_files.append(res_file)
+            wb = seen_workbench_imagestreams[istream]
+            wb.versions.append((base_key, suffix))
+
+    # 6) Collect non-imagestream resources (buildconfigs, etc.) that are in
+    #    the resource list but not matched to any workbench/runtime
+    extra_resources: list[str] = []
+    wb_and_rt_files = set(workbench_resource_files) | set(runtime_resource_files)
+    for res in all_resources:
+        if res not in wb_and_rt_files:
+            extra_resources.append(res)
+
+    # Build final resource list: workbench files + extra files + runtime files
+    # Match the ordering in the existing kustomization.yaml
+    ordered_resources = _order_resources(all_resources)
+
+    return ordered_resources, workbenches, runtime_resource_files, runtimes
+
+
+def _build_imagestream_to_resource(base_dir: Path, all_resources: list[str]) -> dict[str, str]:
+    """Build a mapping from imagestream metadata.name to resource filename.
+
+    Parses each YAML resource file to extract its ``metadata.name`` field,
+    producing a reverse lookup so that imagestream names that don't match
+    their filenames (e.g. ``s2i-minimal-notebook`` living inside
+    ``jupyter-minimal-notebook-imagestream.yaml``) can still be resolved.
+    """
+    mapping: dict[str, str] = {}
+    for res in all_resources:
+        res_path = base_dir / res
+        if not res_path.exists() or not res.endswith(".yaml"):
+            continue
+        istream_name = _parse_imagestream_name(res_path)
+        if istream_name:
+            if istream_name in mapping:
+                raise ValueError(
+                    f"Duplicate imagestream metadata.name {istream_name!r}: "
+                    f"found in both {mapping[istream_name]!r} and {res!r}"
+                )
+            mapping[istream_name] = res
+    return mapping
+
+
+def _find_resource_file(
+    all_resources: list[str],
+    imagestream_name: str,
+    imagestream_to_resource: dict[str, str],
+) -> str:
+    """Find the resource file for a given imagestream name.
+
+    Tries exact match first, then the parsed metadata.name mapping,
+    then falls back to substring matching.
+    """
+    # Common patterns: imagestream "runtime-minimal" -> "runtime-minimal-imagestream.yaml"
+    exact = f"{imagestream_name}-imagestream.yaml"
+    if exact in all_resources:
+        return exact
+    # Use the parsed metadata.name -> filename mapping
+    if imagestream_name in imagestream_to_resource:
+        return imagestream_to_resource[imagestream_name]
+    # Fall back: find any resource containing the imagestream name
+    for res in all_resources:
+        if imagestream_name in res:
+            return res
+    raise ValueError(
+        f"Could not find resource file for imagestream {imagestream_name!r} "
+        f"in {all_resources}"
+    )
+
+
+def _order_resources(all_resources: list[str]) -> list[str]:
+    """Deduplicate resources while preserving the existing kustomization.yaml order."""
+    return list(dict.fromkeys(all_resources))
+
+
+# ---------------------------------------------------------------------------
+# YAML generation
+# ---------------------------------------------------------------------------
+
+
+def _replacement_block(
+    field_path_key: str,
+    configmap_name: str,
+    target_field: str,
+    imagestream_name: str,
+) -> str:
+    """One replacement stanza."""
+    # language=yaml
+    return process_template_with_indents(t"""\
+  - source:
+      fieldPath: data.{field_path_key}
+      kind: ConfigMap
+      name: {configmap_name}
+      version: v1
+    targets:
+      - fieldPaths:
+          - {target_field}
+        select:
+          group: image.openshift.io
+          kind: ImageStream
+          name: {imagestream_name}
+          version: v1""")
+
+
+def _workbench_params_replacements(wb: Workbench) -> list[str]:
+    """Image-params replacements for all versions of a workbench."""
+    blocks: list[str] = []
+    for idx, (base_key, suffix) in enumerate(wb.versions):
+        blocks.append(
+            _replacement_block(
+                f"{base_key}{suffix}",
+                "notebook-image-params",
+                f"spec.tags.{idx}.from.name",
+                wb.imagestream,
+            )
+        )
+    return blocks
+
+
+def _workbench_commit_replacements(wb: Workbench) -> list[str]:
+    """Commit-hash replacements for all versions of a workbench."""
+    blocks: list[str] = []
+    for idx, (base_key, suffix) in enumerate(wb.versions):
+        blocks.append(
+            _replacement_block(
+                f"{base_key}-commit{suffix}",
+                "notebook-image-commithash",
+                f"spec.tags.{idx}.annotations.[opendatahub.io/notebook-build-commit]",
+                wb.imagestream,
+            )
+        )
+    return blocks
+
+
+def _runtime_params_replacement(rt: Runtime) -> str:
+    """Single image-params replacement for a runtime."""
+    return _replacement_block(
+        f"{rt.base_key}{rt.suffix}",
+        "notebook-image-params",
+        "spec.tags.0.from.name",
+        rt.imagestream,
+    )
+
+
+def generate(base_dir: Path) -> str:
+    """Produce the full kustomization.yaml content."""
+    all_resources, workbenches, _runtime_resource_files, runtimes = discover_config(base_dir)
+
+    resource_lines = "".join(f"  - {rf}\n" for rf in all_resources)
+    resources = resource_lines.rstrip("\n")
+
+    replacement_blocks: list[str] = []
+
+    # 1) Workbench image-params for all workbenches (all versions)
+    for wb in workbenches:
+        replacement_blocks.extend(_workbench_params_replacements(wb))
+
+    # 2) Workbench commit-hash for all workbenches (all versions)
+    for wb in workbenches:
+        replacement_blocks.extend(_workbench_commit_replacements(wb))
+
+    # 3) Runtime image-params for all runtimes
+    for rt in runtimes:
+        replacement_blocks.append(_runtime_params_replacement(rt))
+
+    # language=yaml
+    return process_template_with_indents(t"""\
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+{resources}
+
+configMapGenerator:
+  - envs:
+      - params.env
+      - params-latest.env
+    name: notebook-image-params
+  - envs:
+      - commit.env
+      - commit-latest.env
+    name: notebook-image-commithash
+generatorOptions:
+  disableNameSuffixHash: true
+
+labels:
+  - includeSelectors: true
+    pairs:
+      component.opendatahub.io/name: notebooks
+      opendatahub.io/component: "true"
+replacements:
+{"\n".join(replacement_blocks)}
+""")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="Verify existing kustomization.yaml matches generated output")
+    group.add_argument("--stdout", action="store_true", help="Print to stdout instead of writing to file")
+    parser.add_argument(
+        "--target",
+        choices=("all", "base", "odh", "rhoai"),
+        default="all",
+        help="Generate only one manifests base directory (default: all)",
+    )
+    args = parser.parse_args()
+
+    targets = {
+        "base": (MANIFESTS_DIR / "base", MANIFESTS_DIR / "base" / "kustomization.yaml"),
+        "odh": (MANIFESTS_DIR / "odh" / "base", MANIFESTS_DIR / "odh" / "base" / "kustomization.yaml"),
+        "rhoai": (MANIFESTS_DIR / "rhoai" / "base", MANIFESTS_DIR / "rhoai" / "base" / "kustomization.yaml"),
+    }
+    if args.target == "all":
+        selected_targets = [(name, targets[name]) for name in ("odh", "rhoai") if targets[name][0].is_dir()]
+    else:
+        selected_targets = [(args.target, targets[args.target])]
+
+    for _target_name, (base_dir, output_file) in selected_targets:
+        content = generate(base_dir=base_dir)
+
+        if args.check:
+            existing = output_file.read_text()
+            if existing == content:
+                print(f"OK: {output_file} is up to date.")
+            else:
+                print(f"MISMATCH: {output_file} differs from generated output.", file=sys.stderr)
+                _print_first_difference(existing, content)
+                sys.exit(1)
+        elif args.stdout:
+            sys.stdout.write(content)
+        else:
+            output_file.write_text(content)
+            print(f"Wrote {output_file}")
+
+
+def _print_first_difference(existing: str, generated: str) -> None:
+    """Print a diagnostic showing the first line that differs."""
+    existing_lines = existing.splitlines()
+    generated_lines = generated.splitlines()
+    for i, (e, g) in enumerate(zip(existing_lines, generated_lines, strict=False), 1):
+        if e != g:
+            print(f"  First difference at line {i}:", file=sys.stderr)
+            print(f"    existing:  {e!r}", file=sys.stderr)
+            print(f"    generated: {g!r}", file=sys.stderr)
+            return
+    shorter, longer = (
+        ("existing", "generated")
+        if len(existing_lines) < len(generated_lines)
+        else ("generated", "existing")
+    )
+    print(f"  {shorter} has {abs(len(existing_lines) - len(generated_lines))} fewer lines than {longer}",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/manifests/tools/package_names.py
+++ b/manifests/tools/package_names.py
@@ -1,0 +1,69 @@
+"""Shared mapping from ImageStream manifest display names to Python package names.
+
+Used by:
+- ``tests/test_main.py`` — static pylock version alignment checks
+- ``tests/containers/manifest_validation_test.py`` — SBOM/pip-list validation
+- ``manifests/tools/update_imagestream_annotations_from_pylock.py`` — annotation refresh
+"""
+
+from __future__ import annotations
+
+# Manifest display names that need explicit translation to pip/pylock names.
+MANIFEST_TO_PIP: dict[str, str] = {
+    "Elyra": "elyra-server",  # old (pre-odh-elyra) package name in 2023.x images
+    "LLM-Compressor": "llmcompressor",
+    "PyTorch": "torch",
+    "ROCm-PyTorch": "torch",
+    "Sklearn-onnx": "skl2onnx",
+    "Nvidia-CUDA-CU12-Bundle": "nvidia-cuda-runtime-cu12",
+    "MySQL Connector/Python": "mysql-connector-python",
+    "ROCm-TensorFlow": "tensorflow-rocm",  # old name used in 2024.2 and earlier
+    "TensorFlow-ROCm": "tensorflow-rocm",
+}
+
+# Manifest display names where ``.lower()`` gives the pip package name.
+MANIFEST_LOWER_NAMES: frozenset[str] = frozenset(
+    {
+        "Accelerate",
+        "Boto3",
+        "Codeflare-SDK",
+        "Datasets",
+        "Feast",
+        "JupyterLab",
+        "Kafka-Python-ng",
+        "Kfp",
+        "Kubeflow-Training",
+        "Matplotlib",
+        "MLflow",
+        "Numpy",
+        "Odh-Elyra",
+        "Pandas",
+        "Psycopg",
+        "PyMongo",
+        "Pyodbc",
+        "Scikit-learn",
+        "Scipy",
+        "TensorFlow",
+        "Tensorboard",
+        "Torch",
+        "Transformers",
+        "TrustyAI",
+    }
+)
+
+
+def manifest_name_to_pip(name: str) -> str:
+    """Convert a manifest display name to a pip/pylock package name."""
+    translated = MANIFEST_TO_PIP.get(name)
+    if translated is not None:
+        return translated
+    if name in MANIFEST_LOWER_NAMES:
+        return name.lower()
+    return name
+
+
+def all_workbench_pip_names() -> frozenset[str]:
+    """Return the set of pip package names that should appear in imagestream annotations."""
+    names = {v.lower() for v in MANIFEST_TO_PIP.values()}
+    names |= {n.lower() for n in MANIFEST_LOWER_NAMES}
+    return frozenset(names)

--- a/manifests/tools/update_imagestream_annotations_from_pylock.py
+++ b/manifests/tools/update_imagestream_annotations_from_pylock.py
@@ -1,0 +1,684 @@
+"""Refresh ``notebook-python-dependencies`` (and Python stack in ``notebook-software``) from pylock files at git commits recorded in commit env files.
+
+For each workbench ImageStream tag, resolves the git tree-ish as:
+
+- Latest tag (suffix ``-n``): versions are taken from the **working tree** lockfile first (same files
+  ``make test`` uses: ``uv.lock.d/pylock.<cpu|cuda|rocm>.toml`` or ``pylock.toml``). That matches local
+  ``pylock.toml`` pins. If no file exists on disk, the SHA from ``commit-latest.env`` is used with
+  ``git show`` (fetching from the canonical repo if needed): ``https://github.com/opendatahub-io/notebooks.git``
+  (``--variant odh``) or ``https://github.com/red-hat-data-services/notebooks.git`` (``--variant rhoai``).
+- Older tags (e.g. ``-2025-2``): SHA from ``commit.env`` (``<base>-commit-2025-2``).
+
+Those SHAs match ``manifests/tools/generate_kustomization.py`` / ConfigMap keys.
+
+Dependency *names* and ordering are taken from the existing manifest; versions are updated from
+the resolved lockfile at each ref (same translation rules as ``tests/test_main.py``). Older commits may only have ``requirements.txt`` or flavor files such as ``requirements.cpu.txt``
+instead of ``pylock.toml`` / ``uv.lock.d/pylock.*.toml``; those are parsed as pinned PEP 508 requirements.
+Some historical trees use pipenv only: ``Pipfile.lock`` (or ``Pipfile.lock.cpu`` / ``Pipfile.lock.gpu``); the ``default`` section is parsed for pinned versions.
+Image directories are discovered via ``pyproject.toml`` or those requirements files at the
+``<os>-python-<ver>/`` root. If that Python version exists only in git history, the path is derived
+from a sibling on-disk tree so ``git show <sha>:…`` can load lockfiles.
+
+JSON annotations are written as YAML literal blocks (``|``) with the same bracket layout as
+``opendatahub-io`` / ``mtchoum1`` ImageStreams: opening ``[`` on the first line of the block, two
+spaces before each ``{...}`` line, closing ``]`` aligned with ``[`` — see e.g.
+https://github.com/mtchoum1/notebooks/blob/main/manifests/odh/base/jupyter-datascience-notebook-imagestream.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import packaging.markers
+import packaging.version
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from manifests.tools.commit_env_refs import parse_env_file  # noqa: E402
+from manifests.tools.generate_kustomization import Workbench, discover_config  # noqa: E402
+from manifests.tools.package_names import manifest_name_to_pip  # noqa: E402
+from tests.manifests import (  # noqa: E402
+    extract_metadata_from_path,
+    get_source_of_truth_filepath,
+)
+
+logger = logging.getLogger(__name__)
+
+# Force accelerator flavor when resolving ImageStream paths. ``extract_metadata_from_path`` may
+# infer "cuda" from Dockerfile.konflux.cuda even for the CPU ImageStream (same tree builds both).
+_ACCELERATOR_OVERRIDE_FOR_RESOURCE: dict[str, str | None] = {
+    "jupyter-minimal-notebook-imagestream.yaml": None,
+    "jupyter-minimal-gpu-notebook-imagestream.yaml": "cuda",
+    "jupyter-datascience-notebook-imagestream.yaml": None,
+    "jupyter-pytorch-notebook-imagestream.yaml": "cuda",
+    "jupyter-tensorflow-notebook-imagestream.yaml": "cuda",
+    "jupyter-trustyai-notebook-imagestream.yaml": None,
+    "code-server-notebook-imagestream.yaml": None,
+    "jupyter-rocm-minimal-notebook-imagestream.yaml": "rocm",
+    "jupyter-rocm-pytorch-notebook-imagestream.yaml": "rocm",
+    "jupyter-rocm-tensorflow-notebook-imagestream.yaml": "rocm",
+    "jupyter-pytorch-llmcompressor-imagestream.yaml": "cuda",
+}
+
+# Canonical Git URLs for ``git fetch`` when the ``-n`` tag commit is not already in the local object DB.
+_CANONICAL_REPO_URL: dict[str, str] = {
+    "odh": "https://github.com/opendatahub-io/notebooks.git",
+    "rhoai": "https://github.com/red-hat-data-services/notebooks.git",
+}
+
+# Commit values from *.env must look like hex object IDs before passing to git (avoid ref injection).
+# Repo env files use short SHAs (7+ chars); full 40-char hashes are also accepted.
+_GIT_HEX_OBJECT_ID = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def _is_under_jupyter_rocm_tree(directory: Path) -> bool:
+    parts = directory.parts
+    try:
+        j = parts.index("jupyter")
+    except ValueError:
+        return False
+    return len(parts) > j + 1 and parts[j + 1] == "rocm"
+
+
+def _is_under_jupyter_minimal_tree(directory: Path) -> bool:
+    """``jupyter/minimal/<os>-python-*/`` (ROCm minimal uses the same tree as CPU; lockfile is ``pylock.rocm.toml``)."""
+    parts = directory.parts
+    try:
+        j = parts.index("jupyter")
+    except ValueError:
+        return False
+    return len(parts) > j + 1 and parts[j + 1] == "minimal"
+
+
+def _workbench_dir_consistent_with_rocm_policy(wb: Workbench, directory: Path) -> bool:
+    """Skip ``jupyter/rocm/...`` source trees when the ImageStream is not a ROCm workbench."""
+    rf = wb.resource_file
+    rocm_tree = _is_under_jupyter_rocm_tree(directory)
+
+    # ROCm minimal ImageStream is built from jupyter/minimal/..., not jupyter/rocm/minimal/...
+    if rf == "jupyter-rocm-minimal-notebook-imagestream.yaml":
+        return _is_under_jupyter_minimal_tree(directory)
+
+    if rf.startswith("jupyter-rocm-"):
+        return rocm_tree
+    if rf.startswith("jupyter-") and rocm_tree:
+        return False
+    return True
+
+
+def _is_image_directory(directory: Path) -> bool:
+    try:
+        _ubi, _lang, _python = directory.name.split("-")
+    except ValueError:
+        return False
+    else:
+        return True
+
+
+def _manifests_variant_dir(variant: str) -> Path:
+    return ROOT / "manifests" / variant
+
+
+def _discover_candidate_dirs() -> list[Path]:
+    """Discover ``<os>-python-<ver>/`` trees via ``pyproject.toml`` or requirements lockfiles.
+
+    Marker filenames match what :func:`pylock_candidate_rel_paths` may read (no unrelated
+    ``requirements.*.txt`` such as dev/build-only files).
+    """
+    marker_names = (
+        "pyproject.toml",
+        "requirements.txt",
+        "requirements.cpu.txt",
+        "requirements.cuda.txt",
+        "requirements.rocm.txt",
+        "Pipfile.lock",
+        "Pipfile.lock.cpu",
+        "Pipfile.lock.gpu",
+    )
+    roots = ("jupyter", "codeserver")
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for root in roots:
+        for name in marker_names:
+            for marker in ROOT.glob(f"{root}/**/{name}"):
+                d = marker.parent
+                if not _is_image_directory(d):
+                    continue
+                key = d.resolve()
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(d)
+    return out
+
+
+def _dirs_for_workbench(manifests_dir: Path, wb: Workbench, candidate_dirs: list[Path]) -> list[Path]:
+    target = (manifests_dir / "base" / wb.resource_file).resolve()
+
+    found: list[Path] = []
+    for d in candidate_dirs:
+        if not _workbench_dir_consistent_with_rocm_policy(wb, d):
+            continue
+        try:
+            meta = extract_metadata_from_path(d)
+            if wb.resource_file in _ACCELERATOR_OVERRIDE_FOR_RESOURCE:
+                meta = dataclasses.replace(
+                    meta,
+                    accelerator_flavor=_ACCELERATOR_OVERRIDE_FOR_RESOURCE[wb.resource_file],
+                )
+            truth = get_source_of_truth_filepath(manifests_dir, meta)
+        except ValueError:
+            continue
+        if truth.resolve() == target:
+            found.append(d)
+    return found
+
+
+def notebook_dirname_from_base_key(base_key: str) -> str | None:
+    """Return ``<os>-python-<major.minor>`` when ``base_key`` encodes it (e.g. ``...-py311-ubi9``).
+
+    Historical Python 3.8 workbench keys still use ``-py38-ubi9-`` in params, but source trees at the
+    pinned commits use ``ubi8-python-3.8`` paths; that case is normalized to ``ubi8`` here so
+    ``git show <sha>:jupyter/.../ubi8-python-3.8/...`` resolves.
+    """
+    m_os = re.search(r"-py(\d)(\d+)-([^-]+)(?:$|-)", base_key)
+    if not m_os:
+        return None
+    py = f"{m_os.group(1)}.{m_os.group(2)}"
+    os_name = m_os.group(3)
+    if py == "3.8":
+        os_name = "ubi8"
+    return f"{os_name}-python-{py}"
+
+
+def pick_notebook_dir_for_base_key(candidates: list[Path], base_key: str) -> Path | None:
+    """Return an on-disk notebook tree path when it exists for this tag's Python/OS."""
+    if not candidates:
+        return None
+
+    want = notebook_dirname_from_base_key(base_key)
+    if want is not None:
+        for d in candidates:
+            if d.name == want:
+                return d
+        return None
+
+    m = re.search(r"-py(\d)(\d+)-", base_key)
+    if m:
+        py = f"{m.group(1)}.{m.group(2)}"
+        matching = [d for d in candidates if f"python-{py}" in d.name]
+        if len(matching) == 1:
+            return matching[0]
+        if len(matching) > 1:
+            return None
+        return None
+
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def resolve_notebook_directory(candidates: list[Path], base_key: str) -> Path | None:
+    """Resolve the notebook tree path for lockfile lookup (worktree or ``git show``).
+
+    Prefer an on-disk ``<os>-python-<ver>/`` directory. If it is missing locally but another Python
+    tree exists for the same ImageStream (e.g. only ``3.12`` on disk, tag is ``py311``), synthesize
+    ``…/<os>-python-3.11/`` from a sibling's parent so ``git show <commit>:jupyter/.../ubi9-python-3.11/…``
+    can still succeed. If the tag expects ``ubi8-python-3.8`` but only ``ubi9`` trees exist locally
+    (py38 keys still say ``ubi9``), synthesize from any candidate under the same notebook subtree.
+    """
+    if not candidates:
+        return None
+    picked = pick_notebook_dir_for_base_key(candidates, base_key)
+    if picked is not None:
+        return picked
+    want = notebook_dirname_from_base_key(base_key)
+    if want is None:
+        return None
+    os_prefix, _, _ = want.partition("-python-")
+    if os_prefix:
+        for d in candidates:
+            if d.name.startswith(f"{os_prefix}-python-"):
+                return d.with_name(want)
+        return candidates[0].with_name(want)
+    return candidates[0].with_name(want)
+
+
+def _pylock_kind_from_tag(wb_resource_file: str, base_key: str) -> str:
+    if "-rocm-" in base_key or "jupyter-rocm-" in wb_resource_file:
+        return "rocm"
+    if "-cuda-" in base_key or "-minimal-cuda-" in base_key:
+        return "cuda"
+    if wb_resource_file in (
+        "jupyter-minimal-gpu-notebook-imagestream.yaml",
+        "jupyter-pytorch-notebook-imagestream.yaml",
+        "jupyter-tensorflow-notebook-imagestream.yaml",
+        "jupyter-pytorch-llmcompressor-imagestream.yaml",
+    ):
+        return "cuda"
+    return "cpu"
+
+
+def pylock_candidate_rel_paths(notebook_dir: Path, kind: str) -> list[str]:
+    """Paths to try: pylock TOMLs, requirements files, then pipenv ``Pipfile.lock*``."""
+    rel_uv = notebook_dir / "uv.lock.d" / f"pylock.{kind}.toml"
+    rel_legacy = notebook_dir / "pylock.toml"
+    rel_req_kind = notebook_dir / f"requirements.{kind}.txt"
+    rel_req = notebook_dir / "requirements.txt"
+    pipenv_flavor = notebook_dir / (
+        "Pipfile.lock.cpu" if kind == "cpu" else "Pipfile.lock.gpu"
+    )
+    rel_pipenv = notebook_dir / "Pipfile.lock"
+    out: list[str] = [
+        str(rel_uv.relative_to(ROOT)),
+        str(rel_legacy.relative_to(ROOT)),
+        str(rel_req_kind.relative_to(ROOT)),
+        str(rel_req.relative_to(ROOT)),
+        str(pipenv_flavor.relative_to(ROOT)),
+        str(rel_pipenv.relative_to(ROOT)),
+    ]
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for p in out:
+        if p not in seen:
+            seen.add(p)
+            deduped.append(p)
+    return deduped
+
+
+def _worktree_read_first_existing(rel_paths: list[str]) -> tuple[str, str] | None:
+    """Read the first existing path under ``ROOT`` (for ``-n`` tags: match ``make test`` / local pins)."""
+    for rel in rel_paths:
+        rel = rel.replace("\\", "/")
+        path = ROOT / rel
+        if not path.is_file():
+            continue
+        try:
+            return rel, path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+    return None
+
+
+def _git_show_first_existing(rev: str, rel_paths: list[str]) -> tuple[str, str] | None:
+    for rel in rel_paths:
+        text = _git_show_text(rev, rel)
+        if text is not None:
+            return rel, text
+    return None
+
+
+def _git_commit_exists(rev: str) -> bool:
+    p = subprocess.run(
+        ["git", "-C", str(ROOT), "cat-file", "-e", f"{rev}^{{commit}}"],
+        capture_output=True,
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def _git_fetch_commit_from(url: str, rev: str) -> bool:
+    p = subprocess.run(
+        ["git", "-C", str(ROOT), "fetch", "--quiet", "--no-tags", url, rev],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return p.returncode == 0
+
+
+def _ensure_n_tag_commit_from_canonical_upstream(variant: str, rev: str) -> bool:
+    """Ensure ``rev`` is available for ``git show`` using the ODH or RHDS canonical ``.git`` URL for ``-n`` tags."""
+    url = _CANONICAL_REPO_URL[variant]
+    if _git_commit_exists(rev):
+        return True
+    return _git_fetch_commit_from(url, rev)
+
+
+def _git_show_text(rev: str, rel_path: str) -> str | None:
+    rel_path = rel_path.replace("\\", "/")
+    p = subprocess.run(
+        ["git", "-C", str(ROOT), "show", f"{rev}:{rel_path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if p.returncode != 0:
+        return None
+    return p.stdout
+
+
+def _format_dep_version(pep440: str) -> str:
+    v = packaging.version.Version(pep440)
+    return f"{v.major}.{v.minor}"
+
+
+def _load_pylock_packages(pylock_text: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    doc = tomllib.loads(pylock_text)
+    marker_env = {
+        "python_full_version": f"{python_minor}.0",
+        "python_version": python_minor,
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+    }
+    packages: dict[str, dict[str, Any]] = {}
+    for p in doc.get("packages", []):
+        if "marker" in p and not packaging.markers.Marker(p["marker"]).evaluate(marker_env):
+            continue
+        name = p["name"]
+        if name in packages:
+            raise ValueError(f"duplicate package in lockfile: {name}")
+        packages[name] = p
+    return packages
+
+
+def _parse_requirements_txt_packages(text: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    """Parse pip-tools / pip ``requirements.txt`` (pinned ``pkg==ver`` lines; skips hash/index options)."""
+    marker_env = {
+        "python_full_version": f"{python_minor}.0",
+        "python_version": python_minor,
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+    }
+    packages: dict[str, dict[str, Any]] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("--"):
+            continue
+        if line.startswith("-"):
+            continue
+        if "\\" in line:
+            line = line.split("\\", 1)[0].strip()
+        if "@" in line and "==" not in line:
+            continue
+        if "==" not in line:
+            continue
+        try:
+            req = Requirement(line)
+        except (InvalidRequirement, ValueError) as e:
+            logger.debug("skip unparseable requirement line %r: %s", line, e)
+            continue
+        if req.marker is not None and not req.marker.evaluate(marker_env):
+            continue
+        pinned: str | None = None
+        for spec in req.specifier:
+            if spec.operator == "==":
+                pinned = spec.version
+                break
+        if pinned is None:
+            continue
+        key = canonicalize_name(req.name)
+        packages[key] = {"name": key, "version": pinned}
+    return packages
+
+
+def _parse_pipfile_lock_packages(text: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    """Parse pipenv ``Pipfile.lock`` JSON (``default`` section; pinned ``version`` fields)."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"invalid Pipfile.lock JSON: {e}") from e
+    marker_env = {
+        "python_full_version": f"{python_minor}.0",
+        "python_version": python_minor,
+        "implementation_name": "cpython",
+        "sys_platform": "linux",
+    }
+    packages: dict[str, dict[str, Any]] = {}
+    section = data.get("default")
+    if not isinstance(section, dict):
+        return packages
+    for name, meta in section.items():
+        if not isinstance(meta, dict):
+            continue
+        raw_markers = meta.get("markers")
+        if raw_markers:
+            try:
+                if not packaging.markers.Marker(str(raw_markers)).evaluate(marker_env):
+                    continue
+            except (AttributeError, TypeError, ValueError) as e:
+                logger.debug("skip Pipfile.lock package %r: bad markers %r (%s)", name, raw_markers, e)
+                continue
+        ver = meta.get("version")
+        if not ver or not isinstance(ver, str):
+            continue
+        ver_stripped = ver.strip()
+        if ver_stripped == "*":
+            continue
+        if not ver_stripped.startswith("=="):
+            logger.debug("skip Pipfile.lock package %r: non-pinned version %r", name, ver_stripped)
+            continue
+        pinned = ver_stripped[2:].split(",")[0].strip()
+        if not pinned:
+            continue
+        try:
+            packaging.version.Version(pinned)
+        except packaging.version.InvalidVersion:
+            logger.debug("skip Pipfile.lock package %r: invalid pinned version %r", name, pinned)
+            continue
+        key = canonicalize_name(name)
+        packages[key] = {"name": key, "version": pinned}
+    return packages
+
+
+def load_packages_from_lockfile(text: str, source_rel_path: str, python_minor: str) -> dict[str, dict[str, Any]]:
+    name = Path(source_rel_path).name
+    if name == "Pipfile.lock" or (name.startswith("Pipfile.lock.") and name.endswith((".cpu", ".gpu"))):
+        return _parse_pipfile_lock_packages(text, python_minor)
+    if name == "requirements.txt" or (name.startswith("requirements.") and name.endswith(".txt")):
+        return _parse_requirements_txt_packages(text, python_minor)
+    return _load_pylock_packages(text, python_minor)
+
+
+def _python_minor_from_dir(notebook_dir: Path) -> str:
+    _u, _l, py = notebook_dir.name.split("-")
+    return py.removeprefix("python-")
+
+
+# JSON inside YAML literal blocks: match upstream ImageStream style (``|`` not ``|2``); see
+# ``jupyter-datascience-notebook-imagestream.yaml`` in opendatahub-io / mtchoum1 forks.
+_JSON_OBJECT_SEP = (", ", ": ")
+
+
+def _format_notebook_annotation_json(items: list[dict[str, Any]]) -> LiteralScalarString:
+    """Format ``notebook-software`` / ``notebook-python-dependencies`` as a multiline literal block."""
+    lines = ["["]
+    pad = "  "
+    for i, item in enumerate(items):
+        blob = json.dumps(
+            {"name": item["name"], "version": item["version"]},
+            separators=_JSON_OBJECT_SEP,
+            ensure_ascii=False,
+        )
+        suffix = "," if i < len(items) - 1 else ""
+        lines.append(f"{pad}{blob}{suffix}")
+    lines.append("]")
+    text = "\n".join(lines) + "\n"
+    return LiteralScalarString(text)
+
+
+def _update_tag_annotations(
+    tag: dict[str, Any],
+    pylock_pkgs: dict[str, dict[str, Any]],
+    python_display: str,
+) -> None:
+    ann = tag.get("annotations") or {}
+    sw_raw = ann.get("opendatahub.io/notebook-software")
+    dep_raw = ann.get("opendatahub.io/notebook-python-dependencies")
+    if not sw_raw or not dep_raw:
+        return
+    sw = json.loads(str(sw_raw).strip())
+    deps = json.loads(str(dep_raw).strip())
+    for d in deps:
+        name = d.get("name")
+        if not name:
+            continue
+        norm = manifest_name_to_pip(name)
+        pkg = pylock_pkgs.get(norm)
+        if pkg is None:
+            pkg = pylock_pkgs.get(canonicalize_name(norm))
+        if pkg is None or "version" not in pkg:
+            continue
+        d["version"] = _format_dep_version(pkg["version"])
+
+    # Keep ``notebook-software`` in sync with ``notebook-python-dependencies`` for the same display
+    # name (``test_image_pyprojects`` requires matching strings). Only Python / accelerators are special-cased.
+    sw_version_skip = frozenset({"CUDA", "ROCm", "R", "code-server"})
+    dep_version_by_name = {d["name"]: d["version"] for d in deps if d.get("name")}
+    for s in sw:
+        n = s.get("name")
+        if n == "Python":
+            s["version"] = f"v{python_display}"
+        elif n in sw_version_skip:
+            continue
+        elif n in dep_version_by_name:
+            s["version"] = dep_version_by_name[n]
+
+    ann["opendatahub.io/notebook-software"] = _format_notebook_annotation_json(sw)
+    ann["opendatahub.io/notebook-python-dependencies"] = _format_notebook_annotation_json(deps)
+
+
+def _sha_for_tag(
+    base_key: str,
+    suffix: str,
+    latest: dict[str, str],
+    released: dict[str, str],
+) -> str | None:
+    ck = f"{base_key}-commit{suffix}"
+    sha = latest.get(ck) if suffix == "-n" else released.get(ck)
+    if sha is None:
+        return None
+    normalized = sha.strip().lower()
+    if not _GIT_HEX_OBJECT_ID.fullmatch(normalized):
+        print(
+            f"invalid commit SHA for {ck!r} (expected 7-40 hex chars): {sha!r}",
+            file=sys.stderr,
+        )
+        return None
+    return normalized
+
+
+def run_variant(variant: str, dry_run: bool) -> int:
+    manifests_dir = _manifests_variant_dir(variant)
+    base = manifests_dir / "base"
+    latest = parse_env_file(base / "commit-latest.env")
+    released = parse_env_file(base / "commit.env")
+    _all, workbenches, _rt_files, _runtimes = discover_config(base)
+
+    yml = YAML()
+    yml.preserve_quotes = True
+    # Default width is 80; long scalars (e.g. notebook-image-desc, DockerImage names) get reflowed
+    # onto the next line. Match manifests on main: single-line values where possible.
+    yml.width = 1024 * 1024
+    # Emit a YAML document start marker like other manifests in this repo (see main branch).
+    yml.explicit_start = True
+    yml.indent(mapping=2, sequence=4, offset=2)
+
+    changed = 0
+    lockfile_errors: list[str] = []
+    candidate_dirs = _discover_candidate_dirs()
+    for wb in workbenches:
+        candidates = _dirs_for_workbench(manifests_dir, wb, candidate_dirs)
+        path = base / wb.resource_file
+        if not path.is_file():
+            continue
+        with path.open("r", encoding="utf-8") as f:
+            docs = list(yml.load_all(f))
+        if not docs:
+            continue
+        doc = docs[0]
+        tags = doc.get("spec", {}).get("tags") or []
+        for idx, (base_key, suffix) in enumerate(wb.versions):
+            if idx >= len(tags):
+                break
+            sha = _sha_for_tag(base_key, suffix, latest, released)
+            nb_dir = resolve_notebook_directory(candidates, base_key)
+            if nb_dir is None:
+                want = notebook_dirname_from_base_key(base_key)
+                hint = f" (expected …/{want}/ in git or on disk)" if want else ""
+                print(
+                    f"skip {path.name} tag {idx}: no notebook dir for {base_key}{hint}",
+                    file=sys.stderr,
+                )
+                continue
+            kind = _pylock_kind_from_tag(wb.resource_file, base_key)
+            rel_paths = pylock_candidate_rel_paths(nb_dir, kind)
+
+            shown: tuple[str, str] | None
+            if suffix == "-n":
+                shown = _worktree_read_first_existing(rel_paths)
+            else:
+                shown = None
+
+            if shown is None:
+                if not sha:
+                    print(f"skip {path.name} tag {idx}: no SHA for {base_key}{suffix}", file=sys.stderr)
+                    continue
+                if suffix == "-n" and not _ensure_n_tag_commit_from_canonical_upstream(variant, sha):
+                    print(
+                        f"skip {path.name} tag {idx}: could not resolve commit {sha} via "
+                        f"{_CANONICAL_REPO_URL[variant]}",
+                        file=sys.stderr,
+                    )
+                    continue
+                shown = _git_show_first_existing(sha, rel_paths)
+            if shown is None:
+                print(
+                    f"skip {path.name} tag {idx}: no lockfile (tried worktree/git {'; '.join(rel_paths)})",
+                    file=sys.stderr,
+                )
+                continue
+            rel_used, text = shown
+            py_minor = _python_minor_from_dir(nb_dir)
+            try:
+                pkgs = load_packages_from_lockfile(text, rel_used, py_minor)
+            except Exception as e:
+                lockfile_errors.append(f"{path.name} tag {idx}: lockfile parse error: {e}")
+                continue
+            _update_tag_annotations(tags[idx], pkgs, py_minor)
+            changed += 1
+
+        if not dry_run:
+            with path.open("w", encoding="utf-8") as f:
+                if len(docs) > 1:
+                    yml.dump_all(docs, f)
+                else:
+                    yml.dump(docs[0], f)
+    if lockfile_errors:
+        for err in lockfile_errors:
+            print(err, file=sys.stderr)
+        print(
+            f"Aborting: {len(lockfile_errors)} lockfile parse error(s) for variant={variant!r}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Updated {changed} tag annotation block(s) for variant={variant!r} (dry_run={dry_run})")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=("odh", "rhoai"), required=True)
+    parser.add_argument("--dry-run", action="store_true", help="Parse and validate only; do not write YAML")
+    args = parser.parse_args()
+    raise SystemExit(run_variant(args.variant, args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dev = [
     "podman",
     "kubernetes",
     "openshift-python-wrapper",
+    "typer",
+    # certifi provides CA bundle needed on macOS where Python's bundled OpenSSL
+    # does not read from the system Keychain, causing CERTIFICATE_VERIFY_FAILED
+    "certifi",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -908,6 +917,7 @@ source = { editable = "." }
 [package.dev-dependencies]
 dev = [
     { name = "allure-pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "kubernetes", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "onnx", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (platform_machine != 's390x' and sys_platform == 'linux')" },
@@ -923,6 +933,7 @@ dev = [
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "testcontainers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [package.metadata]
@@ -930,6 +941,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "allure-pytest" },
+    { name = "certifi" },
     { name = "docker" },
     { name = "kubernetes" },
     { name = "onnx", marker = "platform_machine != 's390x'", specifier = ">=1.21.0" },
@@ -945,6 +957,7 @@ dev = [
     { name = "requests" },
     { name = "ruff" },
     { name = "testcontainers" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -1686,6 +1699,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1775,6 +1797,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "shellingham", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133) — PR-1 in the CI remediation queue.

Backports `manifests/tools/` from `main` and adapts the generator for **rhoai-2.25's existing `manifests/base/` layout** (2025.2 / `-n-N` tags). Unblocks `check-generated-code` (missing `manifests/tools/generate_kustomization.py`).

**Does not** add `manifests/odh/` or `manifests/rhoai/` from main — those carry 3.4/3.5 image tags inappropriate for rhoai-2.25.

**Ported from** `red-hat-data-services/notebooks@23f666837` (`main`). Upstream lineage:

- `b0a960caa` / #2971 — `generate_kustomization.py`
- `94ec6fffd` / #3035 — ImageStream-to-resource mapping
- `4a35839f8` / #3067 — `generate_envs.py` ([RHAIENG-3083](https://redhat.atlassian.net/browse/RHAIENG-3083))
- `a0fc6b4ee` / #3342 — `package_names` shared module
- `bac533a26` / #3391 — `commit_env_refs` parser
- `daba4293f` / #3599 — `update_imagestream_annotations_from_pylock` ([RHAIENG-5032](https://redhat.atlassian.net/browse/RHAIENG-5032))
- `8147de253` / #3978 — konflux Dockerfile annotation updates ([RHAIENG-5164](https://redhat.atlassian.net/browse/RHAIENG-5164))

**rhoai-2.25 adaptations:**
- `generate_kustomization.py`: `--target base` for `manifests/base/`; `-n-N` suffix support
- `ci/generate_code.sh`: use `--target base` when `manifests/odh/base` is absent

## Test plan

- [ ] `check-generated-code` passes (`bash ci/generate_code.sh` → clean `git status`)
- [ ] `manifests/base/kustomization.yaml` unchanged (generator `--check` passes)
- [ ] No 3.4/3.5 image tags introduced under `manifests/`

[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-3083]: https://redhat.atlassian.net/browse/RHAIENG-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5032]: https://redhat.atlassian.net/browse/RHAIENG-5032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5164]: https://redhat.atlassian.net/browse/RHAIENG-5164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ