### PR TITLE
[rhoai-2.25] RHAIENG-5133: fix RStudio Konflux paths, flexiblas pin, and httpd configs

### DIFF
--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
@@ -76,15 +76,15 @@ ARG BASEURL_DEFAULT=""
 
 LABEL name="rhoai/odh-workbench-rstudio-minimal-cpu-py312-rhel9" \
       com.redhat.component="odh-workbench-rstudio-minimal-cpu-py312-rhel9" \
-      summary="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      description="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
+      summary="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      description="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
       maintainer="Red Hat AI Notebooks Team" \
-      io.k8s.display-name="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      io.k8s.description="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
+      io.k8s.display-name="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      io.k8s.description="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
       authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
       io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.12" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.12"
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.11" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.11"
 
 USER 0
 
@@ -247,7 +247,7 @@ echo "Installing softwares and packages"
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
 # Fix permissions to support pip in Openshift environments
-chmod -R g+w /opt/app-root/lib/python3.12/site-packages
+chmod -R g+w /opt/app-root/lib/python3.11/site-packages
 fix-permissions /opt/app-root -P
 EOF
 

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
@@ -74,8 +74,8 @@ ARG SERVERURL_DEFAULT=""
 ARG BASEURL_DEFAULT=""
 # TILL HERE
 
-LABEL name="rhoai/odh-workbench-rstudio-minimal-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-rstudio-minimal-cpu-py312-rhel9" \
+LABEL name="rhoai/odh-workbench-rstudio-minimal-cpu-py311-rhel9" \
+      com.redhat.component="odh-workbench-rstudio-minimal-cpu-py311-rhel9" \
       summary="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
       description="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
       maintainer="Red Hat AI Notebooks Team" \

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
@@ -62,7 +62,7 @@ WORKDIR /opt/app-root/src
 #####################
 FROM cpu-base AS cpu-rstudio
 
-ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.12
+ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.11
 ARG TARGETARCH
 
 WORKDIR /opt/app-root/bin
@@ -136,7 +136,7 @@ chmod 1777 /var/run/rstudio-server
 mkdir -p /usr/share/doc/R
 # package installation
 # install necessary texlive-framed package to make Knit R markup to PDF rendering possible
-dnf install -y libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed
+dnf install -y libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake flexiblas-3.0.4-8.el9 flexiblas-openblas-openmp-3.0.4-8.el9 flexiblas-devel-3.0.4-8.el9 texlive-framed
 # install npm to run cve_remediation script
 dnf install -y npm
 dnf clean all

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
@@ -74,8 +74,8 @@ ARG SERVERURL_DEFAULT=""
 ARG BASEURL_DEFAULT=""
 # TILL HERE
 
-LABEL name="rhoai/odh-workbench-rstudio-minimal-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-rstudio-minimal-cuda-py312-rhel9" \
+LABEL name="rhoai/odh-workbench-rstudio-minimal-cuda-py311-rhel9" \
+      com.redhat.component="odh-workbench-rstudio-minimal-cuda-py311-rhel9" \
       summary="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
       description="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
       maintainer="Red Hat AI Notebooks Team" \

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
@@ -62,7 +62,7 @@ WORKDIR /opt/app-root/src
 ################
 FROM cuda-base AS cuda-rstudio
 
-ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.12
+ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.11
 ARG TARGETARCH
 
 WORKDIR /opt/app-root/bin
@@ -150,7 +150,7 @@ chmod 1777 /var/run/rstudio-server
 mkdir -p /usr/share/doc/R
 # package installation
 # install necessary texlive-framed package to make Knit R markup to PDF rendering possible
-dnf install -y libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake "flexiblas-*" texlive-framed
+dnf install -y libgit2-devel.x86_64 libcurl-devel harfbuzz-devel.x86_64 fribidi-devel.x86_64 cmake flexiblas-3.0.4-8.el9 flexiblas-openblas-openmp-3.0.4-8.el9 flexiblas-devel-3.0.4-8.el9 texlive-framed
 # install npm to run cve_remediation script
 dnf install -y npm
 dnf clean all

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
@@ -76,15 +76,15 @@ ARG BASEURL_DEFAULT=""
 
 LABEL name="rhoai/odh-workbench-rstudio-minimal-cuda-py312-rhel9" \
       com.redhat.component="odh-workbench-rstudio-minimal-cuda-py312-rhel9" \
-      summary="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      description="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
+      summary="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      description="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
       maintainer="Red Hat AI Notebooks Team" \
-      io.k8s.display-name="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      io.k8s.description="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
+      io.k8s.display-name="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      io.k8s.description="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
       authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
       io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.12" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.12"
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.11" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.11"
 
 USER 0
 
@@ -261,7 +261,7 @@ echo "Installing softwares and packages"
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
 # Fix permissions to support pip in Openshift environments
-chmod -R g+w /opt/app-root/lib/python3.12/site-packages
+chmod -R g+w /opt/app-root/lib/python3.11/site-packages
 fix-permissions /opt/app-root -P
 EOF
 

--- a/rstudio/rhel9-python-3.11/httpd/httpd.conf
+++ b/rstudio/rhel9-python-3.11/httpd/httpd.conf
@@ -1,0 +1,54 @@
+# Basic httpd configuration for CGI processing
+ServerRoot "/etc/httpd"
+Listen 8080
+
+# Load modules
+LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+# User and Group - run as the container user (OpenShift assigns random UIDs)
+User default
+Group root
+
+# PidFile for process management
+PidFile /var/run/httpd/httpd.pid
+
+# Server configuration
+ServerAdmin root@localhost
+ServerName localhost
+
+# Document root
+DocumentRoot "/opt/app-root"
+
+# Directory configuration
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+<Directory "/opt/app-root">
+    AllowOverride None
+    Options +ExecCGI
+    Require all granted
+    AddHandler cgi-script .cgi
+</Directory>
+
+# Error and access logs
+ErrorLog "/var/log/httpd/error_log"
+LogLevel warn
+
+# Types configuration
+TypesConfig /etc/mime.types
+
+# Include additional configurations (exclude SSL)
+IncludeOptional conf.d/autoindex.conf
+IncludeOptional conf.d/userdir.conf
+IncludeOptional conf.d/welcome.conf
+IncludeOptional conf.d/rstudio-cgi.conf

--- a/rstudio/rhel9-python-3.11/httpd/rstudio-cgi.conf
+++ b/rstudio/rhel9-python-3.11/httpd/rstudio-cgi.conf
@@ -1,0 +1,27 @@
+# RStudio-server CGI configuration
+# This configuration handles the /api/ endpoints for culling and health checks
+
+# Set the CGI script paths
+ScriptAlias /api/kernels/ /opt/app-root/api/kernels/access.cgi
+ScriptAlias /api/probe /opt/app-root/api/probe.cgi
+ScriptAlias /api /opt/app-root/api/probe.cgi
+
+# Enable CGI for the API endpoints
+<LocationMatch "^/api/?">
+    SetHandler cgi-script
+    Options +ExecCGI
+    Require all granted
+</LocationMatch>
+
+# Ensure the CGI scripts are executable
+<Directory "/opt/app-root/api">
+    Options +ExecCGI
+    AddHandler cgi-script .cgi
+    Require all granted
+</Directory>
+
+<Directory "/opt/app-root/api/kernels">
+    Options +ExecCGI
+    AddHandler cgi-script .cgi
+    Require all granted
+</Directory>


### PR DESCRIPTION
## Summary
- `RSTUDIO_SOURCE_CODE`: `rstudio/rhel9-python-3.12` → `rstudio/rhel9-python-3.11` in Konflux Dockerfiles (rhoai-2.25 builds from 3.11 tree; see #2370).
- Pin `flexiblas-3.0.4-8.el9` instead of `flexiblas-*` to avoid -9 vs -8 RPM conflict during `dnf install`.
- Restore `rstudio/rhel9-python-3.11/httpd/httpd.conf` and `rstudio-cgi.conf` (from `33456243b`) — required by Konflux Dockerfiles, unblocks `go-tests`.

Part of [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133) CI remediation — **PR-3** after #2415.

Unblocks: `go-tests`; also helps `rstudio-rhel9` / `cuda-rstudio-rhel9` Build Notebooks matrix legs (flexiblas).

## Test plan
- [ ] `go-tests` — `TestParseAllDockerfiles` passes for RStudio Konflux Dockerfiles
- [ ] `hadolint` on `rstudio/rhel9-python-3.11/Dockerfile.konflux.*` clean
- [ ] Build Notebooks `rstudio-rhel9` amd64 no longer hits flexiblas conflict


Made with [Cursor](https://cursor.com)

[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ