### PR TITLE
[rhoai-2.25] RHAIENG-5133: fix deploy9 path for pytorch+llmcompressor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,9 @@ endif
 deploy9-%: bin/kubectl bin/yq
 	$(eval TARGET := $(shell echo $* | sed 's/-ubi9-python.*//'))
 	$(eval PYTHON_VERSION := $(shell echo $* | sed 's/.*-python-//'))
-	$(eval NOTEBOOK_DIR := $(subst -,/,$(subst cuda-,,$(TARGET)))/ubi9-python-$(PYTHON_VERSION)/kustomize/base)
+	$(eval NOTEBOOK_PATH := $(subst -,/,$(subst cuda-,,$(TARGET))))
+	$(eval NOTEBOOK_PATH := $(subst pytorch/llmcompressor,pytorch+llmcompressor,$(NOTEBOOK_PATH)))
+	$(eval NOTEBOOK_DIR := $(NOTEBOOK_PATH)/ubi9-python-$(PYTHON_VERSION)/kustomize/base)
 ifndef NOTEBOOK_TAG
 	$(eval NOTEBOOK_TAG := $*-$(IMAGE_TAG))
 endif
@@ -257,7 +259,9 @@ endif
 undeploy9-%: bin/kubectl
 	$(eval TARGET := $(shell echo $* | sed 's/-ubi9-python.*//'))
 	$(eval PYTHON_VERSION := $(shell echo $* | sed 's/.*-python-//'))
-	$(eval NOTEBOOK_DIR := $(subst -,/,$(subst cuda-,,$(TARGET)))/ubi9-python-$(PYTHON_VERSION)/kustomize/base)
+	$(eval NOTEBOOK_PATH := $(subst -,/,$(subst cuda-,,$(TARGET))))
+	$(eval NOTEBOOK_PATH := $(subst pytorch/llmcompressor,pytorch+llmcompressor,$(NOTEBOOK_PATH)))
+	$(eval NOTEBOOK_DIR := $(NOTEBOOK_PATH)/ubi9-python-$(PYTHON_VERSION)/kustomize/base)
 	$(info # Undeploying notebook from $(NOTEBOOK_DIR) directory...)
 	$(KUBECTL_BIN) delete -k $(NOTEBOOK_DIR)
 


### PR DESCRIPTION
## Summary

Fix `deploy9-%` / `undeploy9-%` path mapping for llmcompressor images.

`deploy9-%` derives a kustomize directory from the make target by replacing `-` with `/`. For llmcompressor targets that yields `pytorch/llmcompressor`, but the on-disk tree uses `pytorch+llmcompressor` (the `+` cannot appear in make target names).

**Fix:** map `pytorch/llmcompressor` → `pytorch+llmcompressor` in `NOTEBOOK_PATH` before building `NOTEBOOK_DIR`.

Part of [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133) — **PR-6** (queue commit `47f7dcaa9`).

## Problem (CI)

Build Notebooks matrix legs fail at deploy before tests run ([run 28432195684](https://github.com/red-hat-data-services/notebooks/actions/runs/28432195684)):

```text
# Deploying notebook from jupyter/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base directory...
Error: stat jupyter/pytorch/llmcompressor/ubi9-python-3.12/kustomize/base/kustomization.yaml: no such file or directory
gmake: *** [Makefile:245: deploy9-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12] Error 1
```

| Make target | Broken `deploy9` path | Actual directory |
|-------------|----------------------|------------------|
| `deploy9-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12` | `jupyter/pytorch/llmcompressor/...` | `jupyter/pytorch+llmcompressor/...` |
| `deploy9-runtimes-cuda-pytorch-llmcompressor-ubi9-python-3.12` | `runtimes/pytorch/llmcompressor/...` | `runtimes/pytorch+llmcompressor/...` |

Unblocks `runtime-cuda-pytorch-llmcompressor` deploy in `make_test`. Jupyter workbench leg has a **separate** failure — [RHAIENG-5948](https://redhat.atlassian.net/browse/RHAIENG-5948) (`RequestsDependencyWarning` / requests+chardet), tracked as **PR-6b** in the remediation plan.

## Remote verification (`jdanek@100.105.65.25`, k3s)

Reproduced on `rhoai-2.25` @ `d005a0ce1` (pre-fix): same `stat ... kustomization.yaml: no such file` at `yq`, exit 2.

With this branch on k3s:

- `gmake deploy9-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12` → resolves to `jupyter/pytorch+llmcompressor/...`, `kubectl apply -k` creates StatefulSet + Service
- `gmake deploy9-runtimes-cuda-pytorch-llmcompressor-ubi9-python-3.12` → resolves to `runtimes/pytorch+llmcompressor/...`, `kubectl apply -k` creates runtime pod

Pods stay `0/1` without a real image in the cluster (test uses `localhost/notebooks`); that is expected — this PR only fixes kustomize path resolution through `deploy9`.

## CI verification ([run 28462376591](https://github.com/red-hat-data-services/notebooks/actions/runs/28462376591), push from this branch)

| Matrix leg | Result | Notes |
|------------|--------|-------|
| `runtime-cuda-pytorch-llmcompressor` amd64 | **PASS** | `deploy9-runtimes-cuda-pytorch-llmcompressor-...` → `runtimes/pytorch+llmcompressor/...`; `[INFO] Finished testing runtime-cuda-pytorch-llmcompressor-ubi9-python-3.12` |
| `cuda-jupyter-pytorch-llmcompressor` amd64 | **FAIL** (not deploy9) | Testcontainers failed on `RequestsDependencyWarning` before K8s/`make_test` ran — [RHAIENG-5948](https://redhat.atlassian.net/browse/RHAIENG-5948) |

Push workflow runs Testcontainers (step 26) before `Run image tests`; jupyter `deploy9` was skipped when Testcontainers failed.

## Kubernetes name length (out of scope)

This PR does **not** change CI namespace/pod naming. llmcompressor is already the longest matrix target; derived names remain under the DNS-1123 **63-character** limit:

| Derived name | Length |
|--------------|--------|
| `ns-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3-12` | 54 |
| `cuda-jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-0` (`make_test` pod var) | 62 |
| `jupyter-pytorch-llmcompressor-ubi9-python-3-12-notebook-0` (actual StatefulSet pod) | 57 |

**Follow-up (separate from this PR):** `main` added DNS-1123 namespace validation and llmcompressor deploy-target special-casing in `ci/cached-builds/make_test.py` via [RHAIENG-5011](https://redhat.atlassian.net/browse/RHAIENG-5011) / [opendatahub-io/notebooks#3581](https://github.com/opendatahub-io/notebooks/pull/3581). Worth backporting to `rhoai-2.25` so overlong targets fail fast; llmcompressor itself should pass with 1 character of headroom on the `make_test` pod string.

## Test plan

- [x] Pre-fix repro on remote: `deploy9-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12` fails at missing `jupyter/pytorch/llmcompressor/.../kustomization.yaml`
- [x] Post-fix: `deploy9-cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12` applies `jupyter/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base` (remote k3s)
- [x] Post-fix: `deploy9-runtimes-cuda-pytorch-llmcompressor-ubi9-python-3.12` applies `runtimes/pytorch+llmcompressor/ubi9-python-3.12/kustomize/base` (remote k3s)
- [x] CI: `runtime-cuda-pytorch-llmcompressor` amd64 — deploy + `make_test` pass ([run 28462376591](https://github.com/red-hat-data-services/notebooks/actions/runs/28462376591))
- [ ] CI: `cuda-jupyter-pytorch-llmcompressor` amd64 full leg — blocked by [RHAIENG-5948](https://redhat.atlassian.net/browse/RHAIENG-5948) (PR-6b), not this PR

[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5948]: https://redhat.atlassian.net/browse/RHAIENG-5948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ