### PR TITLE
[rhoai-2.25] RHAIENG-5948: fix llmcompressor requests/chardet conflict

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -4579,10 +4579,10 @@ wheels = [
 
 [[packages]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", upload-time = 2025-08-18T20:46:02Z, size = 134517, hashes = { sha256 = "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", upload-time = 2025-08-18T20:46:00Z, size = 64738, hashes = { sha256 = "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", upload-time = 2026-05-14T19:25:27Z, size = 142856, hashes = { sha256 = "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", upload-time = 2026-05-14T19:25:26Z, size = 73075, hashes = { sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0" } }]
 
 [[packages]]
 name = "requests-oauthlib"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -102,6 +102,8 @@ override-dependencies = [
     "pillow>=12.1.1",
     # RHOAIENG-53183: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
     "black>=26.3.1",
+    # RHAIENG-5948 / RHAIENG-5267: requests==2.32 dep conflict with chardet
+    "requests>=2.33.1",
 ]
 
 # from https://redhat-internal.slack.com/archives/C079FE5H94J/p1756934476976759?thread_ts=1756933154.294109&cid=C079FE5H94J
@@ -109,7 +111,7 @@ constraint-dependencies = [
     "loguru==0.7.3",
     "pyyaml==6.0.2",
     "numpy==2.2.6",
-    "requests==2.32.5",
+    "requests>=2.33.1",
     "tqdm==4.67.1",
     # apicc is still on torch 2.7.1
     # "torch==2.8.0",

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -3794,10 +3794,10 @@ wheels = [
 
 [[packages]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 marker = "python_full_version >= '3.12' and implementation_name == 'cpython' and sys_platform == 'linux'"
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", upload-time = 2025-08-18T20:46:02Z, size = 134517, hashes = { sha256 = "dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", upload-time = 2025-08-18T20:46:00Z, size = 64738, hashes = { sha256 = "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", upload-time = 2026-05-14T19:25:27Z, size = 142856, hashes = { sha256 = "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", upload-time = 2026-05-14T19:25:26Z, size = 73075, hashes = { sha256 = "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0" } }]
 
 [[packages]]
 name = "rouge-score"

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "papermill~=2.6.0",
     "pyzmq~=27.1.0",
     "prompt-toolkit~=3.0.52",
-    "requests~=2.32.5",
+    "requests>=2.33.1",
     "tornado~=6.5.2",
     "traitlets~=5.14.3",
     "urllib3~=2.6.0",
@@ -78,6 +78,8 @@ override-dependencies = [
     # RHAIENG-3209: CVE-2026-25990  Pillow: Out-of-bounds Write
     # Upstream: https://github.com/vllm-project/llm-compressor/releases/tag/0.7.1.1
     "pillow>=12.1.1",
+    # RHAIENG-5948 / RHAIENG-5267: requests==2.32 dep conflict with chardet
+    "requests>=2.33.1",
 ]
 
 # from https://redhat-internal.slack.com/archives/C079FE5H94J/p1756934476976759?thread_ts=1756933154.294109&cid=C079FE5H94J
@@ -85,7 +87,7 @@ constraint-dependencies = [
     "loguru==0.7.3",
     "pyyaml==6.0.2",
     "numpy==2.2.6",
-    "requests==2.32.5",
+    "requests>=2.33.1",
     "tqdm==4.67.1",
     # apicc is still on torch 2.7.1
     # "torch==2.8.0",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -297,7 +297,7 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
         ("ipython-genutils", (">=0.2.0", "~=0.2.0")),
         ("jinja2", (">=3.1.6", "~=3.1.6")),
         ("jupyter-client", ("~=8.6.3", ">=8.6.3")),
-        ("requests", ("~=2.32.3", ">=2.0.0")),
+        ("requests", ("~=2.32.5", ">=2.33.1")),
         ("urllib3", ("~=2.5.0", "~=2.3.0")),
         ("transformers", ("<5.0,>4.0", "~=4.55.0")),
         ("datasets", ("", "~=3.4.1")),


### PR DESCRIPTION
## Summary

Fix `RequestsDependencyWarning` (chardet/requests) blocking `cuda-jupyter-pytorch-llmcompressor` Testcontainers in Build Notebooks CI.

Backports [RHAIENG-5267](https://redhat.atlassian.net/browse/RHAIENG-5267) from [opendatahub-io/notebooks#3689](https://github.com/opendatahub-io/notebooks/pull/3689) (commit `7b8923e3b`). rhoai-2.25 tracking issue: [RHAIENG-5948](https://redhat.atlassian.net/browse/RHAIENG-5948).

Part of [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133) remediation — **PR-6b** (follows merged #2426 deploy9 fix).

## Problem

`cuda-jupyter-pytorch-llmcompressor` amd64 fails at Testcontainers before `make_test` ([run 28462376591](https://github.com/red-hat-data-services/notebooks/actions/runs/28462376591)):

```text
RequestsDependencyWarning: Unable to find acceptable character detection dependency (chardet or charset_normalizer).
```

Root cause: `requests==2.32.5` (from `constraint-dependencies` and runtime direct dep) is incompatible with `chardet==6.0.0.post1` in the lockfile. requests ≥ 2.33.1 declares chardet 6.x support.

## Fix

| File | Change |
|------|--------|
| `jupyter/pytorch+llmcompressor/.../pyproject.toml` | `override-dependencies`: add `requests>=2.33.1` (main fix); `constraint-dependencies`: `requests==2.32.5` → `>=2.33.1` |
| `runtimes/pytorch+llmcompressor/.../pyproject.toml` | Same override + constraint; direct dep `requests~=2.32.5` → `>=2.33.1` |
| Both `pylock.toml` | Regenerated — `requests` **2.32.5 → 2.34.2** |

Cherry-pick of `7b8923e3b` conflicted (rhoai-2.25 uses `pylock.toml`, not `uv.lock.d`/`requirements.cuda.txt`); equivalent pyproject change applied manually with `(cherry picked from commit 7b8923e3b...)` in commit message.

## Why rhoai-2.25 needed more than main

`main` only added the **override** — it has no `constraint-dependencies` block pinning `requests==2.32.5`.

On `rhoai-2.25`, the AIPCC alignment `constraint-dependencies` list hard-pinned `requests==2.32.5`, which prevented the resolver from selecting a chardet-compatible version on its own. Verified locally:

- `constraint-dependencies` bump alone → resolves to **requests 2.34.2**
- override alone (with old constraint) → also **2.34.2** (override wins)

This PR does **both** (override for upstream parity + constraint/direct-dep relax so requests slots in naturally when overrides are eventually trimmed, per main’s “autoheal” comment).

## Test plan

- [x] `uv pip compile` regen for jupyter + runtimes llmcompressor → `requests==2.34.2` in both `pylock.toml`
- [ ] CI: `cuda-jupyter-pytorch-llmcompressor` amd64 Testcontainers + `make_test` pass
- [ ] CI: `runtime-cuda-pytorch-llmcompressor` amd64 still green (lockfile-only change)

Made with [Cursor](https://cursor.com)

[RHAIENG-5267]: https://redhat.atlassian.net/browse/RHAIENG-5267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5948]: https://redhat.atlassian.net/browse/RHAIENG-5948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dependency requirements to a newer `requests` release, resolving a version conflict during environment setup.
  * Improved package resolution consistency so installs are less likely to fail in the affected Python 3.12 runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->