### PR TITLE
[rhoai-2.25] RHAIENG-5133: bootstrap setuptools before uv pip builds

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -143,6 +143,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         make install -j$(nproc) && \
         cd ../../python && \
         pip install --no-cache-dir -r requirements-build.txt && \
+        pip install --upgrade pip && \
+        # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
+        pip install --force-reinstall setuptools==80.9.0 wheel && \
         PYARROW_WITH_PARQUET=1 \
         PYARROW_WITH_DATASET=1 \
         PYARROW_WITH_FILESYSTEM=1 \
@@ -337,9 +340,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
-    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
-        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -337,8 +337,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
-    echo "meson<1.11" > build_constraints.txt && \
+    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
+        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -337,8 +337,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
-    echo "meson<1.11" > build_constraints.txt && \
+    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
+        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -144,6 +144,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         cd ../../python && \
         pip install --no-cache-dir -r requirements-build.txt && \
         pip install --upgrade pip  && \
+        # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
         pip install --force-reinstall setuptools==80.9.0 wheel  && \
         PYARROW_WITH_PARQUET=1 \
         PYARROW_WITH_DATASET=1 \
@@ -337,9 +338,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
-    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
-        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # We need special flags and environment variables when building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -27,16 +27,20 @@ WORKDIR /root
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
+COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv setuptools wheel && \
+    pip install --no-cache uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
-    printf '%s\n' 'setuptools>=80.9.0,<82' 'wheel' > build_constraints.txt && \
+    # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
+    printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
+    # [tool.uv.pip] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
+    # do not use --no-config here — uv must read pyproject.toml (build isolation, not host env).
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
+    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
 
 ####################
 # cpu-base         #

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -30,12 +30,13 @@ COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache uv setuptools wheel && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
+    printf '%s\n' 'setuptools>=80.9.0,<82' 'wheel' > build_constraints.txt && \
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
 
 ####################
 # cpu-base         #

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -37,8 +37,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
-    # [tool.uv.pip] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
-    # do not use --no-config here — uv must read pyproject.toml (build isolation, not host env).
+    # [tool.uv] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
+    # pylock.toml is the install input; pyproject.toml is copied for uv config only.
+    # do not use --no-config — uv must discover pyproject.toml in this directory.
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -27,17 +27,21 @@ WORKDIR /root
 ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
+COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv setuptools wheel && \
+    pip install --no-cache uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
-    printf '%s\n' 'setuptools>=80.9.0,<82' 'wheel' > build_constraints.txt && \
+    # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
+    printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
 
+    # [tool.uv.pip] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
+    # do not use --no-config here — uv must read pyproject.toml (build isolation, not host env).
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
-    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
+    UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
 
 ####################
 # cpu-base         #

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -37,7 +37,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
-
     # [tool.uv.pip] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
     # do not use --no-config here — uv must read pyproject.toml (build isolation, not host env).
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -37,8 +37,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
-    # [tool.uv.pip] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
-    # do not use --no-config here — uv must read pyproject.toml (build isolation, not host env).
+    # [tool.uv] extra-build-dependencies in pyproject.toml supplies setuptools for pandas;
+    # pylock.toml is the install input; pyproject.toml is copied for uv config only.
+    # do not use --no-config — uv must discover pyproject.toml in this directory.
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -30,11 +30,11 @@ COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache uv setuptools wheel && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
-    echo "setuptools<82" > build_constraints.txt && \
+    printf '%s\n' 'setuptools>=80.9.0,<82' 'wheel' > build_constraints.txt && \
 
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     UV_LINK_MODE=copy uv pip install --strict --no-deps --refresh --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml --build-constraint build_constraints.txt

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -75,6 +75,13 @@ dependencies = [
 environments = [
     "sys_platform == 'linux' and implementation_name == 'cpython'",
 ]
+
+# RHAIENG-5986: pandas 1.5.3 setup.py imports pkg_resources but does not declare
+# setuptools as a PEP 517 build dependency. uv advises extra-build-dependencies
+# (injected into the isolated build env — not a host-env pip install).
+[tool.uv.pip]
+extra-build-dependencies = { pandas = ["setuptools>=80.9.0,<82", "wheel"] }
+
 override-dependencies = [
     # RHAIENG-3211: CVE-2026-26007 cryptography Subgroup Attack
     "cryptography>=46.0.5",

--- a/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pyproject.toml
@@ -75,13 +75,10 @@ dependencies = [
 environments = [
     "sys_platform == 'linux' and implementation_name == 'cpython'",
 ]
-
 # RHAIENG-5986: pandas 1.5.3 setup.py imports pkg_resources but does not declare
-# setuptools as a PEP 517 build dependency. uv advises extra-build-dependencies
-# (injected into the isolated build env — not a host-env pip install).
-[tool.uv.pip]
+# setuptools as a PEP 517 build dependency. uv reads this from pyproject.toml even
+# when installing locked requirements via `uv pip install --requirements=pylock.toml`.
 extra-build-dependencies = { pandas = ["setuptools>=80.9.0,<82", "wheel"] }
-
 override-dependencies = [
     # RHAIENG-3211: CVE-2026-26007 cryptography Subgroup Attack
     "cryptography>=46.0.5",

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -334,12 +334,14 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing softwares and packages" && \
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
-    echo "meson<1.11" > build_constraints.txt && \
+    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ]; then \
+        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; \
         export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH && \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     elif [ "$TARGETARCH" = "s390x" ]; then \
+        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # For s390x, we need special flags and environment variables for building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -153,6 +153,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         cd ../../python && \
         # Install Python build requirements
         pip install --no-cache-dir -r requirements-build.txt && \
+        pip install --upgrade pip && \
+        # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
+        pip install --force-reinstall setuptools==80.9.0 wheel && \
         # Build Python package
         PYARROW_WITH_PARQUET=1 \
         PYARROW_WITH_DATASET=1 \
@@ -334,14 +337,12 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing softwares and packages" && \
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
-    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ]; then \
-        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; \
         export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH && \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     elif [ "$TARGETARCH" = "s390x" ]; then \
-        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # For s390x, we need special flags and environment variables for building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -337,12 +337,14 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing softwares and packages" && \
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
-    echo "meson<1.11" > build_constraints.txt && \
+    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ]; then \
+        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; \
         export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH && \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     elif [ "$TARGETARCH" = "s390x" ]; then \
+        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # For s390x, we need special flags and environment variables for building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -154,6 +154,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         # Install Python build requirements
         pip install --no-cache-dir -r requirements-build.txt && \
 		pip install --upgrade pip && \
+		# RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
 		pip install --force-reinstall setuptools==80.9.0 wheel && \
         # Build Python package
         PYARROW_WITH_PARQUET=1 \
@@ -337,14 +338,12 @@ COPY ${DATASCIENCE_SOURCE_CODE}/utils ./utils/
 RUN --mount=type=cache,target=/root/.cache/pip \
     echo "Installing softwares and packages" && \
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
-    printf '%s\n' 'meson<1.11' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
+    echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ]; then \
-        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig; \
         export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH && \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml; \
     elif [ "$TARGETARCH" = "s390x" ]; then \
-        pip install --no-cache-dir 'setuptools>=80.9.0,<82' wheel && \
         # For s390x, we need special flags and environment variables for building packages
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \


### PR DESCRIPTION
## Summary

Fix `ModuleNotFoundError: No module named 'pkg_resources'` during image builds.

Sub-task: [RHAIENG-5986](https://redhat.atlassian.net/browse/RHAIENG-5986) (under [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133)).

Part of [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133) remediation — **PR-8**.

Previous fix for the same problem
* https://github.com/red-hat-data-services/notebooks/pull/1904

## Root cause (per-image)

| Image | Arch | Failure stage | Fix |
|-------|------|---------------|-----|
| `jupyter-trustyai` | amd64 | whl-cache `uv pip` (pandas 1.5.3 sdist) | `[tool.uv.pip] extra-build-dependencies` — injected into **isolated** build env |
| `jupyter-datascience` | ppc64le | pyarrow-builder (`setup.py`) | Pin `setuptools==80.9.0` after `requirements-build.txt` in `Dockerfile.cpu` (konflux already had it) |
| `runtime-datascience` | s390x | s390x-builder pyarrow | Same setuptools pin (`requirements-build.txt` pulled setuptools 82+) |

CI runs: [28484294179](https://github.com/red-hat-data-services/notebooks/actions/runs/28484294179), [28464164759](https://github.com/red-hat-data-services/notebooks/actions/runs/28464164759).

**Not a host-env problem:** uv uses build isolation — side `pip install setuptools` before `uv pip` does not affect isolated sdist builds. TrustyAI fix uses uv's `extra-build-dependencies`; datascience/runtime fixes target the pyarrow builder stages where `python setup.py` runs outside uv.

## TrustyAI changes

**`pyproject.toml`:**
```toml
[tool.uv.pip]
extra-build-dependencies = { pandas = ["setuptools>=80.9.0,<82", "wheel"] }
```

**Dockerfile.cpu + Dockerfile.konflux.cpu** (whl-cache):
- `COPY pyproject.toml` alongside `pylock.toml`
- Drop `--no-config` so uv reads `[tool.uv.pip]`
- `build_constraints.txt`: `setuptools>=80.9.0,<82` (cap version when setuptools is a build dep)
- No host-env `pip install setuptools`

## Datascience / runtime-datascience changes

- **pyarrow builder**: `pip install --force-reinstall setuptools==80.9.0 wheel` after `requirements-build.txt` ([RHAIENG-5986](https://redhat.atlassian.net/browse/RHAIENG-5986) comment)
- **uv pip stage**: unchanged (reverted host-env bootstrap; `meson<1.11` build-constraint only)

## Test plan

- [ ] CI: `jupyter-trustyai` amd64 build
- [ ] CI: `jupyter-datascience` ppc64le build
- [ ] CI: `runtime-datascience` s390x build

[RHAIENG-5986]: https://redhat.atlassian.net/browse/RHAIENG-5986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5986]: https://redhat.atlassian.net/browse/RHAIENG-5986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for data science and TrustyAI images on non-x86 architectures (including wheel building and caching).
  * Added stronger safeguards to ensure isolated build environments use a consistent, supported `setuptools`/`wheel` range.
  * Updated build constraints so dependency resolution during installation completes more consistently and avoids build-time failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->