### PR TITLE
RHAIENG-6002: fix(jupyter): bind-mount base-images/utils directory for dnf-helper

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
     - linux-d160-m2xlarge/arm64
   - name: image-expires-after
     value: 5d

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false # Set to false, pending AIPCC-7795
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m4xlarge/amd64
+    - linux/x86_64
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -48,7 +48,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
     - linux-d160-m8xlarge/arm64
     - linux/ppc64le
     - linux/s390x

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: RPMs from prefetch-input/rhds; pip from requirements.cpu.txt (see opendatahub-io/notebooks/.tekton minimal CPU PR pipeline)
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -48,7 +48,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
     - linux-d160-m8xlarge/arm64
   - name: image-expires-after
     value: 5d

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: RPMs from prefetch-input/rhds; pip from requirements.cuda.txt (see opendatahub-io/notebooks/.tekton minimal CUDA PR pipeline)
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -48,7 +48,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -43,7 +43,7 @@ spec:
     value: true
   # Hermetic: RPMs from prefetch-input/rhds; pip from requirements.rocm.txt (see opendatahub-io/notebooks/.tekton minimal ROCm PR pipeline)
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
     - linux-d160-m8xlarge/arm64
   - name: image-expires-after
     value: 5d

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -47,7 +47,7 @@ spec:
     value: true
   - name: build-platforms
     value:
-    - linux-d160-m8xlarge/amd64
+    - linux/x86_64
     - linux-d160-m8xlarge/arm64
     - linux/s390x
   - name: image-expires-after

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -42,7 +42,7 @@ spec:
   - name: enable-cache-proxy
     value: true
   - name: hermetic
-    value: false
+    value: 'true'
   - name: build-image-index
     value: true
   - name: build-platforms

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -130,7 +130,7 @@ USER 0
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -26,7 +26,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -25,7 +25,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -23,7 +23,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -56,7 +56,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Other apps and tools installed as default user
@@ -117,7 +117,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 # Copy dynamically-linked mongocli built in earlier build stage

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -48,7 +48,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 
@@ -105,7 +105,7 @@ WORKDIR /opt/app-root/bin
 COPY prefetch-input/odh/rpms.lock.yaml /tmp/.docker-stamp-rpms-lock
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/mongocli

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -50,7 +50,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 
@@ -105,7 +105,7 @@ USER 0
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -56,7 +56,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Other apps and tools installed as default user
@@ -117,7 +117,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 # Copy dynamically-linked mongocli built in earlier build stage

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -56,7 +56,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required for FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Other apps and tools installed as default user
@@ -117,7 +117,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 # Copy dynamically-linked mongocli built in earlier build stage

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -54,7 +54,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # hadolint ignore=DL3041
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 
@@ -111,7 +111,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -53,7 +53,7 @@ USER 0
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 COPY --chown=1001:0 ${DATASCIENCE_SOURCE_CODE}/uv.lock.d/pylock.${PYLOCK_FLAVOR}.toml ./pylock.toml

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -21,7 +21,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients libxcrypt-compat
 
 

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -23,7 +23,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients libxcrypt-compat
 
 

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -19,7 +19,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat compat-openssl11 openshift-clients
 
 

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -19,7 +19,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat compat-openssl11 openshift-clients
 
 

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -21,7 +21,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     bash /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients libxcrypt-compat
 
 

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -98,8 +98,8 @@ def main():
         "upgrade first to avoid fixable vulnerabilities": textwrap.dedent(
             ntb.process_template_with_indents(rt"""
             {subscription_manager_register_refresh}
-            RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
-                /utils/dnf-helper.sh upgrade
+            RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
+                bash /utils/dnf-helper.sh upgrade
 
         """)
         ),


### PR DESCRIPTION
## Summary

Fixes Konflux `build-images` failures on stone-prod-p02 where buildah errors on file-level `RUN --mount=type=bind` for `dnf-helper.sh`:

```text
sanitizing bind subdirectory "…/dnf-helper.sh":
opening non-directory "base-images/utils/dnf-helper.sh": value too large for defined data type
```

Mount `base-images/utils` directory instead of `dnf-helper.sh` file (buildah [#6631](https://github.com/containers/buildah/issues/6631)).

Same change as opendatahub-io/notebooks#3994, cherry-picked onto `rhoai-3.5` for Konflux validation.

Jira: https://redhat.atlassian.net/browse/RHAIENG-6002

## Test plan

- [ ] Comment `/build-konflux` and confirm hermetic workbench builds pass `build-images` past dnf-helper step
- [ ] Compare with control PR (README-only, no fix)


Made with [Cursor](https://cursor.com)