### PR TITLE
[rhoai-2.25] RHAIENG-5986: fix pkg_resources in TrustyAI final uv pip stage

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -165,6 +165,7 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 
 # Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml ./
+COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml ./
 
 # install openblas for ppc64le
 RUN --mount=type=cache,from=whl-cache,source=/root/OpenBLAS/,target=/OpenBlas/,rw \
@@ -185,8 +186,11 @@ RUN --mount=type=cache,from=whl-cache,source=/wheelsdir/,target=/wheelsdir/,rw \
         fi '
 RUN --mount=type=cache,target=/root/.cache/uv \
     echo "Installing softwares and packages" && \
+    # RHAIENG-5986: pandas 1.5.3 needs setuptools/pkg_resources at build time; pyproject.toml
+    # supplies [tool.uv] extra-build-dependencies and must remain discoverable (no --no-config).
+    printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
     # we can ensure wheels are consumed from the cache only by restricting internet access for uv install with '--offline' flag
-    UV_LINK_MODE=copy uv pip install --cache-dir /root/.cache/uv --requirements=./pylock.toml && \
+    UV_LINK_MODE=copy uv pip install --cache-dir /root/.cache/uv --requirements=./pylock.toml --build-constraint build_constraints.txt && \
     # Note: debugpy wheel availabe on pypi (in uv cache) is none-any but bundles amd64.so files
     #       Build debugpy from source instead
     UV_LINK_MODE=copy uv pip install --no-cache git+https://github.com/microsoft/debugpy.git@v$(grep -A1 '\"debugpy\"' ./pylock.toml | grep -Eo '\b[0-9\.]+\b') && \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -163,6 +163,7 @@ RUN INSTALL_PKGS="java-17-openjdk" && \
 
 # Install Python packages and Jupyterlab extensions from requirements.txt
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml ./
+COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml ./
 
 # install openblas for ppc64le
 RUN --mount=type=cache,from=whl-cache,source=/root/OpenBLAS/,target=/OpenBlas/,rw \
@@ -181,8 +182,11 @@ RUN --mount=type=cache,from=whl-cache,source=/wheelsdir/,target=/wheelsdir/,rw \
         fi '
 RUN --mount=type=cache,target=/root/.cache/uv \
     echo "Installing softwares and packages" && \
+    # RHAIENG-5986: pandas 1.5.3 needs setuptools/pkg_resources at build time; pyproject.toml
+    # supplies [tool.uv] extra-build-dependencies and must remain discoverable (no --no-config).
+    printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \
     # we can ensure wheels are consumed from the cache only by restricting internet access for uv install with '--offline' flag
-    UV_LINK_MODE=copy uv pip install --cache-dir /root/.cache/uv --requirements=./pylock.toml && \
+    UV_LINK_MODE=copy uv pip install --cache-dir /root/.cache/uv --requirements=./pylock.toml --build-constraint build_constraints.txt && \
     # Note: debugpy wheel availabe on pypi (in uv cache) is none-any but bundles amd64.so files
     #       Build debugpy from source instead
     UV_LINK_MODE=copy uv pip install --no-cache git+https://github.com/microsoft/debugpy.git@v$(grep -A1 '\"debugpy\"' ./pylock.toml | grep -Eo '\b[0-9\.]+\b') && \


### PR DESCRIPTION
## Summary

[#2428](https://github.com/red-hat-data-services/notebooks/pull/2428) fixed the `pkg_resources` / `ModuleNotFoundError` build failure for `pandas==1.5.3` in the TrustyAI `whl-cache` stage only. The **final** `jupyter-trustyai` install stage (`uv pip install --requirements=./pylock.toml`) still only copied `pylock.toml`, without `pyproject.toml` or a `setuptools` build constraint, so it hit the same failure:

```
ModuleNotFoundError: No module named 'pkg_resources'
hint: pandas@1.5.3 depends on pkg_resources ...
```

This broke both the GHA `jupyter-trustyai-ubi9-python-3.12` (amd64) build and the Konflux `odh-workbench-jupyter-trustyai-cpu-py312-v2-25-on-push` pipeline after `781b7ee31` merged. Reported in Slack ([internal thread](https://redhat-internal.slack.com/archives/C0BD6LZUEGJ/p1783086163349359), [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133) channel).

## Changes

In both `jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu` and `Dockerfile.konflux.cpu`, final `jupyter-trustyai` stage:

- `COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml ./` so uv can discover `[tool.uv] extra-build-dependencies` for pandas
- Generate `build_constraints.txt` with `setuptools>=80.9.0,<82` (pkg_resources removed in setuptools 82+)
- Pass `--build-constraint build_constraints.txt` to the `uv pip install --requirements=./pylock.toml` invocation

No `--no-config` flag is used, matching the whl-cache stage fix from #2428, so uv config from `pyproject.toml` remains discoverable.

## Test plan

- [ ] GHA `jupyter-trustyai-ubi9-python-3.12` (amd64) build passes
- [ ] Konflux `odh-workbench-jupyter-trustyai-cpu-py312-v2-25-on-push` build passes
- [x] Confirmed the fix mirrors the working whl-cache stage pattern established in #2428

Made with [Cursor](https://cursor.com)

[RHAIENG-5133]: https://redhat.atlassian.net/browse/RHAIENG-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image build reliability by including project configuration during dependency setup.
  * Added a build-time constraint to keep Python package installation consistent and avoid incompatible dependency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->