### PR TITLE
RHAIENG-6036: Add PRODUCT ?= rhoai guard to Makefile (PR 1/8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or lat
 endif
 .RECIPEPREFIX =
 
+# PRODUCT: rhoai-only on this branch (see RHAIENG-6036)
+PRODUCT ?= rhoai
+ifneq ($(filter rhoai,$(PRODUCT)),$(PRODUCT))
+$(error PRODUCT must be 'rhoai' on rhoai-2.25, got '$(PRODUCT)')
+endif
+
 IMAGE_REGISTRY   ?= quay.io/opendatahub/workbench-images
 RELEASE	 		 ?= 2025b
 RELEASE_PYTHON_VERSION	 ?= 3.12


### PR DESCRIPTION
## Description

First PR in the [RHAIENG-6036](https://redhat.atlassian.net/browse/RHAIENG-6036) CI consolidation sequence for `rhoai-2.25`.

Adds `PRODUCT ?= rhoai` to the Makefile with an error on any other value. This is vocabulary parity with `main` and prepares for follow-up PRs that thread `PRODUCT` through GHA workflows. **No behavior change** — the default satisfies the guard and no workflow currently sets `PRODUCT`.

Part of the planned sequence:
1. **This PR** — `PRODUCT` flag (Makefile only)
2. Delete dead ODH-only `.tekton` PR pipelineruns + fix README
3. Cherry-pick fork-PR guidance into `CONTRIBUTING.md`
4. (optional) `docs/konflux.md`
5. Migrate PR builds off `pull_request_target`
6. Switch Makefile to `Dockerfile.konflux.*`
7. Green checkpoint
8. Diff/reconcile/delete legacy Dockerfiles

## How Has This Been Tested?

- Verified `git diff rhoai-2.25...HEAD` contains only the 6-line Makefile addition.
- No runtime/build behavior change expected.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — N/A (Makefile variable only, no test impact)
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` — N/A; this is `rhoai-2.25`-only CI consolidation work tracked in [RHAIENG-6036](https://redhat.atlassian.net/browse/RHAIENG-6036)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

[RHAIENG-6036]: https://redhat.atlassian.net/browse/RHAIENG-6036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ