### PR TITLE
[rhoai-2.25] RHAIENG-6036: migrate PR CI to pull_request and Dockerfile.konflux (PR 5+6)

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -28,6 +28,10 @@ name: Build & Publish Notebook Servers (TEMPLATE)
         default: false
         description: "add RHEL subscription from github secret"
         type: boolean
+      product:
+        required: false
+        description: "product variant override (odh/rhoai); defaults to odh on opendatahub-io/notebooks, rhoai elsewhere"
+        type: string
 
 jobs:
   build:
@@ -50,6 +54,7 @@ jobs:
       # Makefile variables
       BUILD_ARCH: ${{ inputs.platform }}
       RELEASE_PYTHON_VERSION: ${{ inputs.python }}
+      PRODUCT: ${{ inputs.product || (github.repository == 'opendatahub-io/notebooks' && 'odh' || 'rhoai') }}
 
     steps:
 
@@ -82,6 +87,27 @@ jobs:
           platform: ${{ inputs.platform }}
 
       - run: mkdir -p $TMPDIR
+
+      - name: Verify subscription secrets are available
+        if: ${{ inputs.subscription }}
+        env:
+          SUBSCRIPTION_ORG: ${{ secrets.SUBSCRIPTION_ORG }}
+          SUBSCRIPTION_ACTIVATION_KEY: ${{ secrets.SUBSCRIPTION_ACTIVATION_KEY }}
+          AIPCC_QUAY_BOT_USERNAME: ${{ secrets.AIPCC_QUAY_BOT_USERNAME }}
+          AIPCC_QUAY_BOT_PASSWORD: ${{ secrets.AIPCC_QUAY_BOT_PASSWORD }}
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for var in SUBSCRIPTION_ORG SUBSCRIPTION_ACTIVATION_KEY AIPCC_QUAY_BOT_USERNAME AIPCC_QUAY_BOT_PASSWORD GIT_CRYPT_KEY; do
+            if [[ -z "${!var:-}" ]]; then
+              echo "::error::${var} secret is not available in this context (likely a fork PR). Push to a same-repo branch for full CI validation."
+              missing=1
+            fi
+          done
+          if [[ $missing -ne 0 ]]; then
+            exit 1
+          fi
 
       # do this early because it's fast and why not
       - name: Unlock encrypted secrets with git-crypt

--- a/.github/workflows/build-notebooks-pr-aipcc.yaml
+++ b/.github/workflows/build-notebooks-pr-aipcc.yaml
@@ -93,4 +93,5 @@ jobs:
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
       subscription: "${{ matrix.subscription }}"
+      product: rhoai
     secrets: inherit

--- a/.github/workflows/build-notebooks-pr-rhel.yaml
+++ b/.github/workflows/build-notebooks-pr-rhel.yaml
@@ -90,4 +90,5 @@ jobs:
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
       subscription: "${{ matrix.subscription }}"
+      product: rhoai
     secrets: inherit

--- a/.github/workflows/build-notebooks-pr.yaml
+++ b/.github/workflows/build-notebooks-pr.yaml
@@ -22,15 +22,31 @@ jobs:
   gen:
     name: Generate job matrix
     runs-on: ubuntu-latest
-    # rhds/notebooks builds from quay.io/aipcc bases and requires pull_request_target trigger
-    if: ${{ github.repository != 'red-hat-data-services/notebooks' }}
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       has_jobs: ${{ steps.gen.outputs.has_jobs }}
+      is_fork: ${{ steps.fork-check.outputs.is_fork }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false  # https://github.com/actions/checkout/issues/2312
+
+      - name: Check if PR is from a fork
+        id: fork-check
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        run: |
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Flag fork PR in workflow summary
+        if: steps.fork-check.outputs.is_fork == 'true'
+        run: |
+          echo "::error title=Fork PR — subscription builds will fail::This PR is from a fork. Subscription builds (RHEL, AIPCC) need secrets unavailable to forks. Push your branch to the main repo for full CI."
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
@@ -39,19 +55,33 @@ jobs:
       - name: Determine targets to build based on changed files
         run: |
           set -x
-          git fetch --no-tags origin 'pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}'
-          git fetch --no-tags origin '+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}'
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head:${HEAD_REF}"
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
           python3 ci/cached-builds/gen_gha_matrix_jobs.py \
-            --from-ref 'origin/${{ github.event.pull_request.base.ref }}' \
-            --to-ref '${{ github.event.pull_request.head.ref }}' \
-            --rhel-images exclude \
+            --from-ref "origin/${BASE_REF}" \
+            --to-ref "${HEAD_REF}" \
+            --rhel-images include \
             --s390x-images include
         id: gen
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: bash
 
+      - name: Annotate PR for fork guidance
+        if: steps.fork-check.outputs.is_fork == 'true'
+        run: |
+          FIRST_FILE=$(git diff --name-only "origin/${BASE_REF}...${HEAD_REF}" | head -1)
+          FIRST_FILE="${FIRST_FILE:-CONTRIBUTING.md}"
+          echo "::warning file=${FIRST_FILE},line=1,title=Fork PR — subscription builds will fail::Push your branch to the main repo for full CI. See CONTRIBUTING.md."
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+
   build:
+    name: "${{ matrix.target }} · ${{ matrix.platform }} [rhoai]"
     needs: ["gen"]
     strategy:
       fail-fast: false
@@ -63,5 +93,6 @@ jobs:
       python: "${{ matrix.python }}"
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
-      subscription: "${{ matrix.subscription }}"
+      subscription: ${{ true }}
+      product: rhoai
     secrets: inherit

--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -60,4 +60,5 @@ jobs:
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
       subscription: "${{ matrix.subscription }}"
+      product: rhoai
     secrets: inherit

--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -1,0 +1,37 @@
+---
+name: Test Build Notebooks Template
+
+permissions:
+  contents: read
+  packages: write
+
+"on":
+  push:
+    branches: ['rhoai-*']
+    paths: &template-self-test-paths
+      - '.github/workflows/build-notebooks-TEMPLATE.yaml'
+      - '.github/workflows/test-build-notebooks-template.yaml'
+      - '.github/actions/install-podman-action/**'
+      - '.github/actions/provision-k8s/**'
+      - 'ci/cached-builds/**'
+      - 'Makefile'
+  pull_request:
+    paths: *template-self-test-paths
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test-template-minimal:
+    name: Test Template with Minimal Notebook
+    uses: ./.github/workflows/build-notebooks-TEMPLATE.yaml
+    with:
+      target: jupyter-minimal-ubi9-python-3.12
+      python: "3.12"
+      github: ${{ toJson(github) }}
+      platform: linux/amd64
+      subscription: ${{ true }}
+      product: rhoai
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ define build_image
 	# Checks if there’s a build-args/*.conf matching the Dockerfile
 	$(eval BUILD_DIR := $(dir $(2)))
 	$(eval DOCKERFILE_NAME := $(notdir $(2)))
-	$(eval CONF_FILE := $(BUILD_DIR)build-args/$(shell echo $(DOCKERFILE_NAME) | cut -d. -f2).conf)
+	$(eval CONF_FILE := $(BUILD_DIR)build-args/$(shell echo $(DOCKERFILE_NAME) | awk -F. '{print $$NF}').conf)
 
 	# if the conf file exists, transform it into --build-arg KEY=VALUE flags
 	$(eval BUILD_ARGS := $(shell \
@@ -132,55 +132,55 @@ bin/buildinputs: scripts/buildinputs/buildinputs.go scripts/buildinputs/go.mod s
 
 .PHONY: jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: jupyter-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,jupyter/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: cuda-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: cuda-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: cuda-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION)
 cuda-jupyter-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,jupyter/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION)
 jupyter-trustyai-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/trustyai/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,jupyter/trustyai/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: runtime-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,runtimes/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: runtime-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-datascience-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,runtimes/datascience/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 .PHONY: runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,runtimes/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-pytorch-llmcompressor-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,runtimes/pytorch+llmcompressor/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 runtime-cuda-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cuda)
+	$(call image,$@,runtimes/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cuda)
 
 .PHONY: codeserver-ubi9-python-$(RELEASE_PYTHON_VERSION)
 codeserver-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,codeserver/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.cpu)
+	$(call image,$@,codeserver/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.cpu)
 
 ####################################### Buildchain for Python using C9S #######################################
 
@@ -205,23 +205,23 @@ cuda-rstudio-rhel9-python-$(RELEASE_PYTHON_VERSION):
 ####################################### Buildchain for AMD Python using UBI9 #######################################
 .PHONY: rocm-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-jupyter-minimal-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,jupyter/minimal/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-jupyter-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/rocm/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,jupyter/rocm/tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-jupyter-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,jupyter/rocm/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,jupyter/rocm/pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-runtime-pytorch-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/rocm-pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,runtimes/rocm-pytorch/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 .PHONY: rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION)
 rocm-runtime-tensorflow-ubi9-python-$(RELEASE_PYTHON_VERSION):
-	$(call image,$@,runtimes/rocm-tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.rocm)
+	$(call image,$@,runtimes/rocm-tensorflow/ubi9-python-$(RELEASE_PYTHON_VERSION)/Dockerfile.konflux.rocm)
 
 ####################################### Deployments #######################################
 


### PR DESCRIPTION
## Description

PR 5+6 in the [RHAIENG-6036](https://redhat.atlassian.net/browse/RHAIENG-6036) CI consolidation sequence for `rhoai-2.25`.

**Commit 1 — PR builds (`pull_request` + fail-fast)**
- Rewrite `build-notebooks-pr.yaml` for `red-hat-data-services/notebooks`: fork detection with explicit failure (not silent skip), `--rhel-images include` to cover former `pr-aipcc` + `pr-rhel` matrices, `subscription: true` and `product: rhoai` on all build jobs
- Add `product` input and fail-fast secrets guard to `build-notebooks-TEMPLATE.yaml` before RHSM/AIPCC steps
- Add `test-build-notebooks-template.yaml` (adapted from main) so TEMPLATE/Makefile changes are exercised before merge
- `build-notebooks-pr-aipcc.yaml` and `build-notebooks-pr-rhel.yaml` left unchanged for later removal

**Commit 2 — Makefile konflux switch**
- Point 16 shipped image targets at `Dockerfile.konflux.*`
- Fix build-args conf lookup to use last dot-field (`cpu`/`cuda`/`rocm`) for 3-part filenames
- RStudio rhel9 and c9s targets unchanged

Replaces #2438 (which was opened from a fork and could not access secrets).

## How Has This Been Tested?

- Same-repo branch so `pull_request` workflows get full secret access
- `test-build-notebooks-template.yaml` triggers on this PR (TEMPLATE + Makefile paths)

Self checklist:
- [x] Changes are `rhoai-2.25`-only CI consolidation ([RHAIENG-6036](https://redhat.atlassian.net/browse/RHAIENG-6036))
- [x] PR opened from same-repo branch, not a fork

## Merge criteria:

- [x] Commits are cohesive with meaningful messages (2 commits: workflows, then Makefile)
- [x] Testing instructions in PR body
- [ ] Developer verifies GHA green on this PR

Made with [Cursor](https://cursor.com)

[RHAIENG-6036]: https://redhat.atlassian.net/browse/RHAIENG-6036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6036]: https://redhat.atlassian.net/browse/RHAIENG-6036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added product-specific build support, letting notebook workflows target different product variants automatically.
  * Added a new workflow to validate the reusable notebook build process.

* **Bug Fixes**
  * Improved PR build handling by detecting forked pull requests and showing clearer guidance in workflow summaries.
  * Added checks that fail early when required subscription settings are missing.

* **Tests**
  * Expanded automated coverage for the shared notebook build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->