### PR TITLE
[rhoai-2.25] RHAIENG-6036: fix pyproject alignment test for llmcompressor pins

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -297,8 +297,20 @@ def test_image_pyprojects_version_alignment(subtests: pytest_subtests.plugin.Sub
         ("ipython-genutils", (">=0.2.0", "~=0.2.0")),
         ("jinja2", (">=3.1.6", "~=3.1.6")),
         ("jupyter-client", ("~=8.6.3", ">=8.6.3")),
-        ("requests", ("~=2.32.5", ">=2.33.1")),
-        ("urllib3", ("~=2.5.0", "~=2.3.0")),
+        (
+            "requests",
+            (
+                "~=2.32.5",  # runtimes and most images
+                "==2.34.2",  # RHAIIS 3.2.2 llmcompressor (jupyter + runtime)
+            ),
+        ),
+        (
+            "urllib3",
+            (
+                "~=2.6.0",  # runtimes and most images
+                ">=2.7.0",  # RHAIIS 3.2.2 llmcompressor (jupyter override + runtime direct dep)
+            ),
+        ),
         ("transformers", ("<5.0,>4.0", "~=4.55.0")),
         ("datasets", ("", "~=3.4.1")),
         ("accelerate", ("!=1.1.0,>=0.20.3", "~=1.5.2")),


### PR DESCRIPTION
## Summary

- Extend `test_image_pyprojects_version_alignment` allowed specifiers for `requests` and `urllib3` after RHAIIS 3.2.2 llmcompressor parity (#2443).
- Documents intentional cross-image specs: `requests==2.34.2` (llmcompressor) alongside `~=2.32.5` (runtimes); `urllib3>=2.7.0` (llmcompressor) alongside `~=2.6.0` (runtimes).
- Unblocks the `pytest-tests` job in code-static-analysis on `rhoai-2.25` (WS1 / PR-A).

## Test plan

- [x] Verified actual specifier sets on `rhds/rhoai-2.25` tip match the updated `ignored_exceptions` for `requests` and `urllib3`
- [ ] CI: `code-static-analysis` → `pytest-tests` passes on this PR


Made with [Cursor](https://cursor.com)