### PR TITLE
[rhoai-2.25] RHAIENG-6065/6037: fix RStudio go-tests and subscribed image build

### DIFF
--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -12,6 +12,14 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]==1.9.0" "uv==0.8.12"
 # OS Packages needs to be installed as root
 USER root
 
+# The base image ships UBI repositories (ubi.repo). UBI tracks latest RHEL 9, not an EUS minor.
+# Subscriptions may default to EUS (e.g. release 9.6 on the activation key), which skews RPM
+# NVRs against UBI appstream. release --set=9 aligns RHSM with UBI (RHAIENG-6037).
+RUN if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then \
+    subscription-manager release --set=9; \
+    dnf clean all; \
+  fi
+
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
@@ -56,6 +64,7 @@ USER 0
 #RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
 
 # If necessary, run the subscription manager command using the provided credentials. Only include --serverurl and --baseurl if they are provided
+# --release=9: base is UBI (latest RHEL 9); override EUS default on the activation key (RHAIENG-6037).
 RUN if [ -d "${SECRET_DIR}" ]; then \
     SERVERURL=$(cat ${SECRET_DIR}/SERVERURL 2>/dev/null || echo ${SERVERURL_DEFAULT}) && \
     BASEURL=$(cat ${SECRET_DIR}/BASEURL 2>/dev/null || echo ${BASEURL_DEFAULT}) && \
@@ -66,6 +75,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     ${BASEURL:+--baseurl=$BASEURL} \
     --username=$USERNAME \
     --password=$PASSWORD \
+    --release=9 \
     --force \
     --auto-attach; \
   fi

--- a/rstudio/rhel9-python-3.11/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cpu
@@ -12,12 +12,14 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]==1.9.0" "uv==0.8.12"
 # OS Packages needs to be installed as root
 USER root
 
-# The base image ships UBI repositories (ubi.repo). UBI tracks latest RHEL 9, not an EUS minor.
-# Subscriptions may default to EUS (e.g. release 9.6 on the activation key), which skews RPM
-# NVRs against UBI appstream. release --set=9 aligns RHSM with UBI (RHAIENG-6037).
+# RHSM: align release 9 with UBI appstream; drop EUS repos (RHAIENG-6037).
 RUN if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then \
-    subscription-manager release --set=9; \
-    dnf clean all; \
+    subscription-manager release --set=9 \
+    && subscription-manager repos --disable='*' \
+      --enable=rhel-9-for-x86_64-baseos-rpms \
+      --enable=rhel-9-for-x86_64-appstream-rpms \
+      --enable=codeready-builder-for-rhel-9-x86_64-rpms \
+    && dnf clean all; \
   fi
 
 # upgrade first to avoid fixable vulnerabilities begin
@@ -63,8 +65,7 @@ USER 0
 # uncomment the below line if you fall on this error: subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.
 #RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
 
-# If necessary, run the subscription manager command using the provided credentials. Only include --serverurl and --baseurl if they are provided
-# --release=9: base is UBI (latest RHEL 9); override EUS default on the activation key (RHAIENG-6037).
+# Register (BuildConfig); GHA uses mounted entitlement in base instead.
 RUN if [ -d "${SECRET_DIR}" ]; then \
     SERVERURL=$(cat ${SECRET_DIR}/SERVERURL 2>/dev/null || echo ${SERVERURL_DEFAULT}) && \
     BASEURL=$(cat ${SECRET_DIR}/BASEURL 2>/dev/null || echo ${BASEURL_DEFAULT}) && \
@@ -78,6 +79,15 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     --release=9 \
     --force \
     --auto-attach; \
+  fi
+
+RUN if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then \
+    subscription-manager release --set=9 \
+    && subscription-manager repos --disable='*' \
+      --enable=rhel-9-for-x86_64-baseos-rpms \
+      --enable=rhel-9-for-x86_64-appstream-rpms \
+      --enable=codeready-builder-for-rhel-9-x86_64-rpms \
+    && dnf clean all; \
   fi
 
 ENV R_VERSION=4.4.3

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -56,6 +56,7 @@ USER 0
 WORKDIR /opt/app-root/bin
 
 # If necessary, run the subscription manager command using the provided credentials. Only include --serverurl and --baseurl if they are provided
+# --release=9: base is UBI (latest RHEL 9); override EUS default on the activation key (RHAIENG-6037).
 RUN if [ -d "${SECRET_DIR}" ]; then \
     SERVERURL=$(cat ${SECRET_DIR}/SERVERURL 2>/dev/null || echo ${SERVERURL_DEFAULT}) && \
     BASEURL=$(cat ${SECRET_DIR}/BASEURL 2>/dev/null || echo ${BASEURL_DEFAULT}) && \
@@ -66,6 +67,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     ${BASEURL:+--baseurl=$BASEURL} \
     --username=$USERNAME \
     --password=$PASSWORD \
+    --release=9 \
     --force \
     --auto-attach; \
   fi
@@ -186,6 +188,7 @@ USER 0
 #RUN sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py
 
 # If necessary, run the subscription manager command using the provided credentials. Only include --serverurl and --baseurl if they are provided
+# --release=9: base is UBI (latest RHEL 9); override EUS default on the activation key (RHAIENG-6037).
 RUN if [ -d "${SECRET_DIR}" ]; then \
     SERVERURL=$(cat ${SECRET_DIR}/SERVERURL 2>/dev/null || echo ${SERVERURL_DEFAULT}) && \
     BASEURL=$(cat ${SECRET_DIR}/BASEURL 2>/dev/null || echo ${BASEURL_DEFAULT}) && \
@@ -196,6 +199,7 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     ${BASEURL:+--baseurl=$BASEURL} \
     --username=$USERNAME \
     --password=$PASSWORD \
+    --release=9 \
     --force \
     --auto-attach; \
   fi

--- a/rstudio/rhel9-python-3.11/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.cuda
@@ -14,6 +14,16 @@ RUN pip install --no-cache-dir -U "micropipenv[toml]==1.9.0" "uv==0.8.12"
 # OS Packages needs to be installed as root
 USER root
 
+# RHSM: align release 9 with UBI appstream; drop EUS repos (RHAIENG-6037).
+RUN if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then \
+    subscription-manager release --set=9 \
+    && subscription-manager repos --disable='*' \
+      --enable=rhel-9-for-x86_64-baseos-rpms \
+      --enable=rhel-9-for-x86_64-appstream-rpms \
+      --enable=codeready-builder-for-rhel-9-x86_64-rpms \
+    && dnf clean all; \
+  fi
+
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd
 #  (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
@@ -202,6 +212,15 @@ RUN if [ -d "${SECRET_DIR}" ]; then \
     --release=9 \
     --force \
     --auto-attach; \
+  fi
+
+RUN if command -v subscription-manager &>/dev/null && subscription-manager identity &>/dev/null; then \
+    subscription-manager release --set=9 \
+    && subscription-manager repos --disable='*' \
+      --enable=rhel-9-for-x86_64-baseos-rpms \
+      --enable=rhel-9-for-x86_64-appstream-rpms \
+      --enable=codeready-builder-for-rhel-9-x86_64-rpms \
+    && dnf clean all; \
   fi
 
 ENV R_VERSION=4.4.3

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cpu
@@ -62,7 +62,7 @@ WORKDIR /opt/app-root/src
 #####################
 FROM cpu-base AS cpu-rstudio
 
-ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.12
+ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.11
 ARG TARGETARCH
 
 WORKDIR /opt/app-root/bin
@@ -74,17 +74,17 @@ ARG SERVERURL_DEFAULT=""
 ARG BASEURL_DEFAULT=""
 # TILL HERE
 
-LABEL name="rhoai/odh-workbench-rstudio-minimal-cpu-py312-rhel9" \
-      com.redhat.component="odh-workbench-rstudio-minimal-cpu-py312-rhel9" \
-      summary="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      description="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
+LABEL name="rhoai/odh-workbench-rstudio-minimal-cpu-py311-rhel9" \
+      com.redhat.component="odh-workbench-rstudio-minimal-cpu-py311-rhel9" \
+      summary="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      description="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
       maintainer="Red Hat AI Notebooks Team" \
-      io.k8s.display-name="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      io.k8s.description="RStudio Server CPU image with python 3.12 based on Red Hat Enterprise Linux 9" \
+      io.k8s.display-name="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      io.k8s.description="RStudio Server CPU image with python 3.11 based on Red Hat Enterprise Linux 9" \
       authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
       io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.12" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.12"
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.11" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.11"
 
 USER 0
 
@@ -247,7 +247,7 @@ echo "Installing softwares and packages"
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
 # Fix permissions to support pip in Openshift environments
-chmod -R g+w /opt/app-root/lib/python3.12/site-packages
+chmod -R g+w /opt/app-root/lib/python3.11/site-packages
 fix-permissions /opt/app-root -P
 EOF
 

--- a/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
+++ b/rstudio/rhel9-python-3.11/Dockerfile.konflux.cuda
@@ -62,7 +62,7 @@ WORKDIR /opt/app-root/src
 ################
 FROM cuda-base AS cuda-rstudio
 
-ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.12
+ARG RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.11
 ARG TARGETARCH
 
 WORKDIR /opt/app-root/bin
@@ -74,17 +74,17 @@ ARG SERVERURL_DEFAULT=""
 ARG BASEURL_DEFAULT=""
 # TILL HERE
 
-LABEL name="rhoai/odh-workbench-rstudio-minimal-cuda-py312-rhel9" \
-      com.redhat.component="odh-workbench-rstudio-minimal-cuda-py312-rhel9" \
-      summary="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      description="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
+LABEL name="rhoai/odh-workbench-rstudio-minimal-cuda-py311-rhel9" \
+      com.redhat.component="odh-workbench-rstudio-minimal-cuda-py311-rhel9" \
+      summary="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      description="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
       maintainer="Red Hat AI Notebooks Team" \
-      io.k8s.display-name="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
-      io.k8s.description="RStudio Server CUDA image with python 3.12 based on Red Hat Enterprise Linux 9" \
+      io.k8s.display-name="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
+      io.k8s.description="RStudio Server CUDA image with python 3.11 based on Red Hat Enterprise Linux 9" \
       authoritative-source-url="https://github.com/opendatahub-io/notebooks" \
       io.openshift.build.commit.ref="main" \
-      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.12" \
-      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.12"
+      io.openshift.build.source-location="https://github.com/opendatahub-io/notebooks/tree/main/rstudio/rhel9-python-3.11" \
+      io.openshift.build.image="quay.io/opendatahub/workbench-images:rstudio-rhel9-python-3.11"
 
 USER 0
 
@@ -261,7 +261,7 @@ echo "Installing softwares and packages"
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
 # Fix permissions to support pip in Openshift environments
-chmod -R g+w /opt/app-root/lib/python3.12/site-packages
+chmod -R g+w /opt/app-root/lib/python3.11/site-packages
 fix-permissions /opt/app-root -P
 EOF
 

--- a/rstudio/rhel9-python-3.11/httpd/httpd.conf
+++ b/rstudio/rhel9-python-3.11/httpd/httpd.conf
@@ -1,0 +1,54 @@
+# Basic httpd configuration for CGI processing
+ServerRoot "/etc/httpd"
+Listen 8080
+
+# Load modules
+LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+# User and Group - run as the container user (OpenShift assigns random UIDs)
+User default
+Group root
+
+# PidFile for process management
+PidFile /var/run/httpd/httpd.pid
+
+# Server configuration
+ServerAdmin root@localhost
+ServerName localhost
+
+# Document root
+DocumentRoot "/opt/app-root"
+
+# Directory configuration
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+<Directory "/opt/app-root">
+    AllowOverride None
+    Options +ExecCGI
+    Require all granted
+    AddHandler cgi-script .cgi
+</Directory>
+
+# Error and access logs
+ErrorLog "/var/log/httpd/error_log"
+LogLevel warn
+
+# Types configuration
+TypesConfig /etc/mime.types
+
+# Include additional configurations (exclude SSL)
+IncludeOptional conf.d/autoindex.conf
+IncludeOptional conf.d/userdir.conf
+IncludeOptional conf.d/welcome.conf
+IncludeOptional conf.d/rstudio-cgi.conf

--- a/rstudio/rhel9-python-3.11/httpd/rstudio-cgi.conf
+++ b/rstudio/rhel9-python-3.11/httpd/rstudio-cgi.conf
@@ -1,0 +1,27 @@
+# RStudio-server CGI configuration
+# This configuration handles the /api/ endpoints for culling and health checks
+
+# Set the CGI script paths
+ScriptAlias /api/kernels/ /opt/app-root/api/kernels/access.cgi
+ScriptAlias /api/probe /opt/app-root/api/probe.cgi
+ScriptAlias /api /opt/app-root/api/probe.cgi
+
+# Enable CGI for the API endpoints
+<LocationMatch "^/api/?">
+    SetHandler cgi-script
+    Options +ExecCGI
+    Require all granted
+</LocationMatch>
+
+# Ensure the CGI scripts are executable
+<Directory "/opt/app-root/api">
+    Options +ExecCGI
+    AddHandler cgi-script .cgi
+    Require all granted
+</Directory>
+
+<Directory "/opt/app-root/api/kernels">
+    Options +ExecCGI
+    AddHandler cgi-script .cgi
+    Require all granted
+</Directory>


### PR DESCRIPTION
## Summary

Two related RStudio RHEL9 fixes on `rhoai-2.25`:

### [RHAIENG-6065](https://redhat.atlassian.net/browse/RHAIENG-6065) — `go-tests` / `TestParseAllDockerfiles`

The failure is **not** `ARG BASE_IMAGE` / `InvalidDefaultArgInFrom` (harmless parser warning). The test fails when `os.Stat` cannot find COPY sources resolved from `RSTUDIO_SOURCE_CODE=rstudio/rhel9-python-3.12` (directory does not exist on this branch).

- Point `RSTUDIO_SOURCE_CODE` at `rstudio/rhel9-python-3.11` in `Dockerfile.konflux.cpu` and `Dockerfile.konflux.cuda`
- Add `httpd/httpd.conf` and `httpd/rstudio-cgi.conf` required by those Konflux Dockerfiles
- Align Konflux labels with the python 3.11 source tree

Konflux Dockerfiles are forward-compat only on 2.25; they will be removed in a follow-up consolidation.

### [RHAIENG-6037](https://redhat.atlassian.net/browse/RHAIENG-6037) — `rstudio-rhel9-python-3.11` / `cuda-rstudio-rhel9-python-3.11` subscribed builds

**Problem:** `registry.redhat.io/rhel9/python-311` ships `ubi.repo` (latest RHEL 9). GHA/customer subscriptions attach EUS repos from the activation key. With `release=9`, leftover `*-eus-*` repos (including `codeready-builder-for-rhel-9-x86_64-eus-source-rpms`) 404 on `/eus/rhel9/9/...`, and flexiblas NVRs skew between EUS and UBI appstream.

**RStudio-only fix** in `Dockerfile.cpu` / `Dockerfile.cuda` — does **not** change `.github/workflows/build-notebooks-TEMPLATE.yaml` (other images keep EUS 9.6 from shared GHA registration):

When RHSM identity is present (`subscription-manager identity`):

1. `release --set=9` (latest within RHEL 9, aligned with UBI)
2. `repos --disable='*'` then enable only non-EUS **x86_64** repos:
   - `rhel-9-for-x86_64-baseos-rpms`
   - `rhel-9-for-x86_64-appstream-rpms`
   - `codeready-builder-for-rhel-9-x86_64-rpms`

Explicit repo IDs (not `*` wildcards in `--enable`) avoid re-enabling EUS variants such as `*-eus-source-rpms`.

| Path | When |
|------|------|
| **GHA** | `base` stage — entitlement mounted via `mounts.conf` before build |
| **BuildConfig** | `register … --release=9 --force --auto-attach` from `rhel-subscription-secret`, then the same repo block in `rstudio` / `cuda-rstudio` (auto-attach re-enables EUS repos) |

## Test plan

- [x] `go-tests` / `TestParseAllDockerfiles` — [pass](https://github.com/red-hat-data-services/notebooks/actions/runs/28944332538/job/85874174448)
- [x] GHA: `rstudio-rhel9-python-3.11` amd64 build — [pass, 18m](https://github.com/red-hat-data-services/notebooks/actions/runs/28944334855/job/85874281142)
- [x] GHA: `cuda-rstudio-rhel9-python-3.11` amd64 build — [pass, 33m](https://github.com/red-hat-data-services/notebooks/actions/runs/28944334855/job/85874281090)
- [x] OpenShift BuildConfig smoke (`rhaieng-2445-test`): `rstudio-server-rhel9` + `cuda-rstudio-server-rhel9` from this branch + `rhel-subscription-secret` — in progress
- [ ] `code-static-analysis` — still red on branch (pre-existing, unrelated to this PR)

[RHAIENG-6065]: https://redhat.atlassian.net/browse/RHAIENG-6065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6037]: https://redhat.atlassian.net/browse/RHAIENG-6037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ