### PR TITLE
[rhoai-2.25] RHAIENG-6039: fix codeserver mysql container test label detection

### DIFF
--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -82,7 +82,7 @@ def get_image_metadata(image: str) -> Image:
 def skip_if_not_workbench_image(image: str) -> Image:
     image_metadata = get_image_metadata(image)
 
-    ide_server_label_fragments = ("-code-server-", "-jupyter-", "-rstudio-")
+    ide_server_label_fragments = ("-code-server-", "-codeserver-", "-jupyter-", "-rstudio-")
     if not any(ide in image_metadata.labels["name"] for ide in ide_server_label_fragments):
         pytest.skip(
             f"Image {image} does not have any of '{ide_server_label_fragments=} in {image_metadata.labels['name']=}'"
@@ -204,9 +204,15 @@ def rstudio_image(image: str) -> Image:
 
 @pytest.fixture(scope="function")
 def codeserver_image(image: str) -> Image:
+    """Skip unless the image is a code-server workbench.
+
+    ODH labels use "code-server" (e.g. "odh-notebook-code-server-ubi9-python-3.12"),
+    RHOAI/RHDS labels use "codeserver" (e.g. "rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9").
+    """
     image_metadata = skip_if_not_workbench_image(image)
-    if "-code-server-" not in image_metadata.labels["name"]:
-        pytest.skip(f"Image {image} does not have '-code-server-' in {image_metadata.labels['name']=}'")
+    name = image_metadata.labels["name"]
+    if "-code-server-" not in name and "-codeserver-" not in name:
+        pytest.skip(f"Image {image} does not have '-code-server-' or '-codeserver-' in {name!r}")
 
     return image_metadata
 

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
@@ -82,6 +82,12 @@ print("Scikit-learn smoke test completed successfully.")
 
     @allure.description("Check that mysql client functionality is working with SASL plain auth.")
     def test_mysql_connection(self, tf: TestFrame, datascience_image: Image, subtests):
+        name_label = datascience_image.labels.get("name", "")
+        if "-rstudio-" in name_label:
+            pytest.skip(f"Image {datascience_image.name} does have -rstudio- in {datascience_image.labels['name']=}'")
+
+        MYSQL_CONNECTOR_PYTHON_VERSION = "9.3.0"
+
         network = testcontainers.core.network.Network()
         tf.defer(network.create())
 
@@ -159,17 +165,17 @@ except Exception as e:
             notebook = docker_utils.NotebookContainer(container)
             notebook.require_running(context="after start")
 
+            # ODH labels use "-code-server-"; RHOAI/RHDS Konflux labels use "-codeserver-".
+            is_codeserver = "-code-server-" in name_label or "-codeserver-" in name_label
+
             # RHOAIENG-140: code-server image users are expected to install their own db clients
-            if "-code-server-" in datascience_image.labels["name"]:
-                exit_code, output = notebook.exec(["python", "-m", "pip", "install", "mysql-connector-python==9.3.0"])
+            if is_codeserver:
+                exit_code, output = notebook.exec(
+                    ["python", "-m", "pip", "install", f"mysql-connector-python=={MYSQL_CONNECTOR_PYTHON_VERSION}"]
+                )
                 output_str = output.decode()
                 print(output_str)
-
                 assert exit_code == 0, f"Failed to install mysql-connector-python: {output_str}"
-            elif "-rstudio-" in datascience_image.labels["name"]:
-                pytest.skip(
-                    f"Image {datascience_image.name} does have -rstudio- in {datascience_image.labels['name']=}'"
-                )
 
             with subtests.test("Setting the user..."):
                 exit_code, output = notebook.exec(["python", "-c", setup_mysql_user])


### PR DESCRIPTION
## Summary

Fixes `codeserver-ubi9-python-3.12` amd64/arm64 failures in `test_mysql_connection` ([RHAIENG-6039](https://redhat.atlassian.net/browse/RHAIENG-6039)).

RHDS image labels use `codeserver` (e.g. `rhoai/odh-workbench-codeserver-datascience-cpu-py312-rhel9`), not `code-server`. The test only checked `-code-server-` in the label, so the runtime `mysql-connector-python` install was skipped and `mysql.connector` was not found.

**Changes (from `main`, attribution below):**
- `conftest.py`: accept `-codeserver-` in `skip_if_not_workbench_image` and `codeserver_image`
- `jupyterlab_datascience_test.py`: detect code-server via `-code-server-` or `-codeserver-` in the name label; runtime-install `mysql-connector-python` before the mysql scripts

Does not cherry-pick the full [RHAIENG-2846](https://redhat.atlassian.net/browse/RHAIENG-2846) hermetic codeserver commit — only the test-file hunks.

(cherry picked from commit aebf2c75eb35958a21c8ca53b22d50fbd0249be0)
(cherry picked from commit bbffd5b068346ba77b6584f40e82f56b36403d2c)

## Test plan

- [ ] CI: `codeserver-ubi9-python-3.12` amd64 + arm64 `test_mysql_connection` passes on Build Notebooks (push)

[RHAIENG-6039]: https://redhat.atlassian.net/browse/RHAIENG-6039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-2846]: https://redhat.atlassian.net/browse/RHAIENG-2846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded workbench image detection to recognize additional label naming variants, improving compatibility across supported container images.
  * Updated database connection test coverage to better handle Code Server and RStudio image differences, reducing false skips and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->