### PR TITLE
[rhoai-2.25] RHAIENG-6066: add test-containers self-test workflow

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -1,0 +1,135 @@
+---
+name: Test Infrastructure Self-Test
+
+"on":
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tests/containers/**'
+      - 'tests/conftest.py'
+      - 'pytest.ini'
+      - '.github/workflows/test-containers.yaml'
+  push:
+    branches: [main, stable, 'rhoai-*']
+    paths:
+      - 'tests/containers/**'
+      - 'tests/conftest.py'
+      - 'pytest.ini'
+      - '.github/workflows/test-containers.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  TESTCONTAINERS_RYUK_DISABLED: "true"
+  IMAGE_REGISTRY: "ghcr.io/opendatahub-io/notebooks/workbench-images"
+
+jobs:
+  find-images:
+    name: Find test images
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+    steps:
+      - name: Find images for test matrix
+        id: find
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          GH_TOKEN: ${{ github.token }}
+        shell: python
+        # language=python
+        run: |
+          import json, os, subprocess, sys
+
+          registry = os.environ["IMAGE_REGISTRY"]
+          suffix = "_odh_linux_amd64"
+          required = [
+              "jupyter-minimal-ubi9-python-3.12",
+              "jupyter-datascience-ubi9-python-3.12",
+              "runtime-datascience-ubi9-python-3.12",
+          ]
+
+          result = subprocess.run(
+              ["skopeo", "list-tags", "--creds", f"token:{os.environ['GH_TOKEN']}", f"docker://{registry}"],
+              capture_output=True, text=True, timeout=180,
+          )
+          if result.returncode != 0:
+              print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
+              sys.exit(1)
+
+          tags = set(json.loads(result.stdout)["Tags"])
+
+          sha_sets = []
+          for img in required:
+              prefix = f"{img}-main_"
+              shas = {t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)}
+              print(f"  {img}: {len(shas)} builds")
+              sha_sets.append(shas)
+
+          common = set.intersection(*sha_sets)
+          if not common:
+              print(f"::error::No SHA has all required images: {required}", file=sys.stderr)
+              sys.exit(1)
+
+          sha = common.pop()
+          matrix = {"include": [
+              {"image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
+          ]}
+          print(f"Using SHA {sha} ({len(common)+1} candidates)")
+          print(json.dumps(matrix, indent=2))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={json.dumps(matrix)}\n")
+
+  container-tests:
+    name: "${{ matrix.image }}"
+    needs: find-images
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup uv and Python
+        uses: ./.github/actions/setup-uv
+
+      - name: Install deps
+        run: uv sync --locked
+
+      - name: Start Podman socket
+        run: |
+          podman --version
+          systemctl --user enable --now podman.socket
+          echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and run tests
+        env:
+          TEST_IMAGE: ${{ matrix.image }}
+        run: |
+          set -Eeuxo pipefail
+          podman pull "${TEST_IMAGE}"
+          uv run pytest tests/containers \
+            -m 'not openshift and not cuda and not rocm and not manifest_validation' \
+            --image="${TEST_IMAGE}" \
+            -v
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -37,6 +37,12 @@ jobs:
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
       - name: Find images for test matrix
         id: find
         env:
@@ -46,6 +52,9 @@ jobs:
         # language=python
         run: |
           import json, os, subprocess, sys
+          sys.path.insert(0, "ci")
+
+          from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
           suffix = "_odh_linux_amd64"
@@ -63,25 +72,11 @@ jobs:
               print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
               sys.exit(1)
 
-          tags = set(json.loads(result.stdout)["Tags"])
-
-          sha_sets = []
-          for img in required:
-              prefix = f"{img}-main_"
-              shas = {t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)}
-              print(f"  {img}: {len(shas)} builds")
-              sha_sets.append(shas)
-
-          common = set.intersection(*sha_sets)
-          if not common:
-              print(f"::error::No SHA has all required images: {required}", file=sys.stderr)
-              sys.exit(1)
-
-          sha = common.pop()
+          sha = find_suitable_sha(suffix, required, result.stdout)
           matrix = {"include": [
               {"image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
           ]}
-          print(f"Using SHA {sha} ({len(common)+1} candidates)")
+          print(f"Using SHA {sha}")
           print(json.dumps(matrix, indent=2))
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -55,14 +55,8 @@ jobs:
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          repository = os.environ.get("GITHUB_REPOSITORY", "")
-          if repository == "red-hat-data-services/notebooks":
-              # RHDS push tags are currently {target}-_{sha} (empty ref prefix; see build-notebooks-TEMPLATE).
-              ref_prefix = ""
-              tag_suffix = ""
-          else:
-              ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
-              tag_suffix = "_odh_linux_amd64"
+          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
+          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -91,6 +91,8 @@ jobs:
       matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -9,6 +9,7 @@ name: Test Infrastructure Self-Test
       - 'tests/conftest.py'
       - 'pytest.ini'
       - '.github/workflows/test-containers.yaml'
+      - 'ci/find_images_for_test_matrix.py'
   push:
     branches: [main, stable, 'rhoai-*']
     paths:
@@ -16,6 +17,7 @@ name: Test Infrastructure Self-Test
       - 'tests/conftest.py'
       - 'pytest.ini'
       - '.github/workflows/test-containers.yaml'
+      - 'ci/find_images_for_test_matrix.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,7 +29,7 @@ permissions:
 
 env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
-  IMAGE_REGISTRY: "ghcr.io/opendatahub-io/notebooks/workbench-images"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
 
 jobs:
   find-images:
@@ -48,17 +50,20 @@ jobs:
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
         shell: python
         # language=python
         run: |
-          import json, os, subprocess, sys
+          import json, os, re, subprocess, sys
           sys.path.insert(0, "ci")
 
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          suffix = "_odh_linux_amd64"
+          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
+          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
           required = [
+              "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",
               "jupyter-datascience-ubi9-python-3.12",
               "runtime-datascience-ubi9-python-3.12",
@@ -72,18 +77,18 @@ jobs:
               print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
               sys.exit(1)
 
-          sha = find_suitable_sha(suffix, required, result.stdout)
+          sha = find_suitable_sha(ref_prefix, tag_suffix, required, result.stdout)
           matrix = {"include": [
-              {"image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
+              {"name": img, "image": f"{registry}:{img}-{ref_prefix}_{sha}{tag_suffix}"} for img in required
           ]}
-          print(f"Using SHA {sha}")
+          print(f"Using ref {ref_prefix!r}, SHA {sha}")
           print(json.dumps(matrix, indent=2))
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"matrix={json.dumps(matrix)}\n")
 
   container-tests:
-    name: "${{ matrix.image }}"
+    name: "${{ matrix.name }}"
     needs: find-images
     runs-on: ubuntu-24.04
     strategy:
@@ -92,14 +97,24 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup uv and Python
-        uses: ./.github/actions/setup-uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+        with:
+          version-file: pyproject.toml
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.14"
 
       - name: Install deps
         run: uv sync --locked
 
       - name: Start Podman socket
         run: |
+          set -Eeuxo pipefail
           podman --version
           systemctl --user enable --now podman.socket
           echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> "$GITHUB_ENV"
@@ -118,7 +133,7 @@ jobs:
           set -Eeuxo pipefail
           podman pull "${TEST_IMAGE}"
           uv run pytest tests/containers \
-            -m 'not openshift and not cuda and not rocm and not manifest_validation' \
+            -m 'not openshift and not cuda and not rocm' \
             --image="${TEST_IMAGE}" \
             -v
 

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -55,8 +55,14 @@ jobs:
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
-          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
+          repository = os.environ.get("GITHUB_REPOSITORY", "")
+          if repository == "red-hat-data-services/notebooks":
+              # RHDS push tags are currently {target}-_{sha} (empty ref prefix; see build-notebooks-TEMPLATE).
+              ref_prefix = ""
+              tag_suffix = ""
+          else:
+              ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
+              tag_suffix = "_odh_linux_amd64"
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -4,7 +4,7 @@ name: Test Infrastructure Self-Test
 "on":
   workflow_dispatch:
   pull_request:
-    paths:
+    paths: &test-containers-paths
       - 'tests/containers/**'
       - 'tests/conftest.py'
       - 'pytest.ini'
@@ -12,12 +12,7 @@ name: Test Infrastructure Self-Test
       - 'ci/find_images_for_test_matrix.py'
   push:
     branches: [main, stable, 'rhoai-*']
-    paths:
-      - 'tests/containers/**'
-      - 'tests/conftest.py'
-      - 'pytest.ini'
-      - '.github/workflows/test-containers.yaml'
-      - 'ci/find_images_for_test_matrix.py'
+    paths: *test-containers-paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -33,19 +33,12 @@ def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], sko
 
 def test_find_suitable_sha__single():
     skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_odh_linux_amd64"]})
-    assert (
-        find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
-    )
+    assert find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
 
 
 def test_find_suitable_sha__rhoai_branch_without_suffix():
-    skopeo_output = json.dumps(
-        {"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc123def456"]}
-    )
-    assert (
-        find_suitable_sha("rhoai-2.25", "", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
-        == "abc123def456"
-    )
+    skopeo_output = json.dumps({"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc123def456"]})
+    assert find_suitable_sha("rhoai-2.25", "", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output) == "abc123def456"
 
 
 def test_find_suitable_sha__multiple():

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -3,7 +3,12 @@ import sys
 
 
 def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], skopeo_output: str) -> str:
-    """Skopeo lists tags oldest to newest."""
+    """Skopeo lists tags oldest to newest.
+
+    Image tags are formed as ``{target}-{ref_prefix}_{sha}{tag_suffix}``.
+    On RHDS rhoai-2.25 push builds the ref prefix is currently empty, yielding
+    tags like ``jupyter-minimal-ubi9-python-3.12-_<sha>``.
+    """
     tags = list(json.loads(skopeo_output)["Tags"])
 
     sha_list: list[list[str]] = []
@@ -45,6 +50,22 @@ def test_find_suitable_sha__rhoai_branch_without_suffix():
     )
 
 
+def test_find_suitable_sha__rhds_empty_ref_prefix():
+    sha = "568c8cfa48c44e90b30ce8e37c671d15b03950de"
+    skopeo_output = json.dumps(
+        {
+            "Tags": [
+                f"jupyter-minimal-ubi9-python-3.12-_{sha}",
+                f"jupyter-datascience-ubi9-python-3.12-_{sha}",
+            ]
+        }
+    )
+    assert (
+        find_suitable_sha("", "", ["jupyter-minimal-ubi9-python-3.12", "jupyter-datascience-ubi9-python-3.12"], skopeo_output)
+        == sha
+    )
+
+
 def test_find_suitable_sha__multiple():
     skopeo_output = json.dumps(
         {
@@ -62,5 +83,6 @@ def test_find_suitable_sha__multiple():
 if __name__ == "__main__":
     test_find_suitable_sha__single()
     test_find_suitable_sha__rhoai_branch_without_suffix()
+    test_find_suitable_sha__rhds_empty_ref_prefix()
     test_find_suitable_sha__multiple()
     print("OK")

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -1,0 +1,55 @@
+import json
+import sys
+
+
+def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> str:
+    """Skopeo lists tags oldest to newest."""
+    tags = list(json.loads(skopeo_output)["Tags"])
+
+    sha_list: list[list[str]] = []
+    for img in required:
+        prefix = f"{img}-main_"
+        shas = [
+            t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)
+        ]
+        print(f"  {img}: {len(shas)} builds")
+        sha_list.append(shas)
+
+    common = set.intersection(*map(set, sha_list))
+    if not common:
+        print(f"::error::No SHA has all required images: {required}", file=sys.stderr)
+        sys.exit(1)
+
+    for sha in reversed(sha_list[0]):
+        if sha in common:
+            return sha
+    raise RuntimeError("unreachable")
+
+
+def test_find_suitable_sha__single():
+    suffix = "_suffix"
+    required = ["codeserver-ubi9-python-3.12"]
+    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_suffix"]})
+    assert find_suitable_sha(suffix, required, skopeo_output) == "abdcef"
+
+
+def test_find_suitable_sha__multiple():
+    suffix = "_suffix"
+    required = ["img-a", "img-b"]
+    skopeo_output = json.dumps(
+        {
+            "Tags": [
+                "img-a-main_old111_suffix",
+                "img-b-main_old111_suffix",
+                "img-a-main_new222_suffix",
+                "img-b-main_new222_suffix",
+            ]
+        }
+    )
+    assert find_suitable_sha(suffix, required, skopeo_output) == "new222"
+
+
+if __name__ == "__main__":
+    test_find_suitable_sha__single()
+    test_find_suitable_sha__multiple()
+    print("OK")

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -2,15 +2,17 @@ import json
 import sys
 
 
-def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> str:
+def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], skopeo_output: str) -> str:
     """Skopeo lists tags oldest to newest."""
     tags = list(json.loads(skopeo_output)["Tags"])
 
     sha_list: list[list[str]] = []
     for img in required:
-        prefix = f"{img}-main_"
+        prefix = f"{img}-{ref_prefix}_"
         shas = [
-            t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)
+            t.removeprefix(prefix).removesuffix(tag_suffix)
+            for t in tags
+            if t.startswith(prefix) and t.endswith(tag_suffix) and len(t) > len(prefix) + len(tag_suffix)
         ]
         print(f"  {img}: {len(shas)} builds")
         sha_list.append(shas)
@@ -27,15 +29,23 @@ def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> s
 
 
 def test_find_suitable_sha__single():
-    suffix = "_suffix"
-    required = ["codeserver-ubi9-python-3.12"]
-    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_suffix"]})
-    assert find_suitable_sha(suffix, required, skopeo_output) == "abdcef"
+    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_odh_linux_amd64"]})
+    assert (
+        find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
+    )
+
+
+def test_find_suitable_sha__rhoai_branch_without_suffix():
+    skopeo_output = json.dumps(
+        {"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc123def456"]}
+    )
+    assert (
+        find_suitable_sha("rhoai-2.25", "", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
+        == "abc123def456"
+    )
 
 
 def test_find_suitable_sha__multiple():
-    suffix = "_suffix"
-    required = ["img-a", "img-b"]
     skopeo_output = json.dumps(
         {
             "Tags": [
@@ -46,10 +56,11 @@ def test_find_suitable_sha__multiple():
             ]
         }
     )
-    assert find_suitable_sha(suffix, required, skopeo_output) == "new222"
+    assert find_suitable_sha("main", "_suffix", ["img-a", "img-b"], skopeo_output) == "new222"
 
 
 if __name__ == "__main__":
     test_find_suitable_sha__single()
+    test_find_suitable_sha__rhoai_branch_without_suffix()
     test_find_suitable_sha__multiple()
     print("OK")

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -6,8 +6,6 @@ def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], sko
     """Skopeo lists tags oldest to newest.
 
     Image tags are formed as ``{target}-{ref_prefix}_{sha}{tag_suffix}``.
-    On RHDS rhoai-2.25 push builds the ref prefix is currently empty, yielding
-    tags like ``jupyter-minimal-ubi9-python-3.12-_<sha>``.
     """
     tags = list(json.loads(skopeo_output)["Tags"])
 
@@ -50,22 +48,6 @@ def test_find_suitable_sha__rhoai_branch_without_suffix():
     )
 
 
-def test_find_suitable_sha__rhds_empty_ref_prefix():
-    sha = "568c8cfa48c44e90b30ce8e37c671d15b03950de"
-    skopeo_output = json.dumps(
-        {
-            "Tags": [
-                f"jupyter-minimal-ubi9-python-3.12-_{sha}",
-                f"jupyter-datascience-ubi9-python-3.12-_{sha}",
-            ]
-        }
-    )
-    assert (
-        find_suitable_sha("", "", ["jupyter-minimal-ubi9-python-3.12", "jupyter-datascience-ubi9-python-3.12"], skopeo_output)
-        == sha
-    )
-
-
 def test_find_suitable_sha__multiple():
     skopeo_output = json.dumps(
         {
@@ -83,6 +65,5 @@ def test_find_suitable_sha__multiple():
 if __name__ == "__main__":
     test_find_suitable_sha__single()
     test_find_suitable_sha__rhoai_branch_without_suffix()
-    test_find_suitable_sha__rhds_empty_ref_prefix()
     test_find_suitable_sha__multiple()
     print("OK")

--- a/tests/containers/workbenches/workbench_image_test.py
+++ b/tests/containers/workbenches/workbench_image_test.py
@@ -228,6 +228,10 @@ def grab_and_check_logs(subtests: pytest_subtests.SubTests, container: Workbench
         "WARNING: The Jupyter server is listening on all IP addresses and not using encryption. This is not recommended.",
     ]
 
+    if container.get_wrapped_container() is None:
+        logging.warning("Skipping log check: container was never started")
+        return
+
     # Let's wait a couple of seconds to give a chance to log eventual extra startup messages just to be sure we don't
     # miss anything important in this test.
     time.sleep(3)


### PR DESCRIPTION
## Summary

Ports the **Test Infrastructure Self-Test** workflow from `main` to `rhoai-2.25` ([RHAIENG-6066](https://redhat.atlassian.net/browse/RHAIENG-6066)).

When a PR only changes container test code (`tests/containers/**`, `pytest.ini`, etc.), this workflow runs pytest against **previously built** GHCR images instead of waiting for a full image rebuild matrix:

- `codeserver-ubi9-python-3.12`
- `jupyter-minimal-ubi9-python-3.12`
- `jupyter-datascience-ubi9-python-3.12`
- `runtime-datascience-ubi9-python-3.12`

Cherry-picked from `main` with `-x`:

- `dbb99bf5a` — initial workflow + `grab_and_check_logs` guard when container never started
- `96a8be207` — `ci/find_images_for_test_matrix.py` (deterministic latest common SHA)

**rhoai-2.25 adaptations** (commit `849d2a059`):

- `IMAGE_REGISTRY` uses `ghcr.io/${{ github.repository }}/workbench-images`
- Ref prefix from target branch (`rhoai-2.25`), no `_odh_linux_amd64` suffix on RHDS
- uv/podman setup aligned with existing `build-notebooks-TEMPLATE.yaml` (no `setup-uv` composite action)

## Test plan

- [ ] Open a test-only PR (e.g. touch `tests/containers/`) and confirm **Test Infrastructure Self-Test** runs
- [ ] Matrix finds a common SHA across all four images on `ghcr.io/red-hat-data-services/notebooks/workbench-images`
- [ ] Container tests pass for each matrix job (amd64 images from `rhoai-2.25` push builds)

Made with [Cursor](https://cursor.com)

[RHAIENG-6066]: https://redhat.atlassian.net/browse/RHAIENG-6066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated container self-tests for pull requests and selected branch pushes, with parallel test matrix support and published test results.

* **Bug Fixes**
  * Improved container image selection so tests run against the latest matching image set.
  * Prevented log-check failures when a container never starts, avoiding unnecessary test errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->