### PR TITLE
[rhoai-2.25] RHAIENG-6067: fix image tag ref prefix in build template

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -193,17 +193,56 @@ jobs:
 
       - name: Calculate image name and tag
         id: calculated_vars
+        shell: python
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          TARGET: ${{ inputs.target }}
+          REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          PLATFORM: ${{ inputs.platform }}
+        # language=python
         run: |
+          import os, re, sys
+          from dataclasses import dataclass
+
+          @dataclass
+          class Env:
+              REF_NAME: str
+              SHA: str
+              TARGET: str
+              REGISTRY: str
+              PLATFORM: str
+
+              @classmethod
+              def from_env(cls):
+                  return cls(**{k: os.environ[k] for k in cls.__annotations__})
+
           # Need for sanitization explained in https://github.com/opendatahub-io/notebooks/issues/631
-          # For length, Docker image tags have 128-character limit, and we form them as <inputs.target>-<ref_name>_<sha>
-          # therefore since sha is 40 characters, and our target names are <40 chars, we should cut ref_name at 40
-          SANITIZED_REF_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/_/g') | cut -c 1-40
-          IMAGE_TAG="${SANITIZED_REF_NAME}_${{ github.sha }}"
+          # Docker image tags have a 128-character limit.
+          # We calculate the max allowed length for ref_name dynamically to ensure compliance.
+          INVALID_TAG_CHARS_RE = re.compile(r'[^a-zA-Z0-9._-]')
+          def sanitize(s: str) -> str:
+              return INVALID_TAG_CHARS_RE.sub('_', s)
 
-          echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "OUTPUT_IMAGE=${{ env.IMAGE_REGISTRY}}:${{ inputs.target }}-${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          env = Env.from_env()
 
-          echo "SANITIZED_PLATFORM=$(echo "${{ inputs.platform }}" | sed 's/[^a-zA-Z0-9._-]/_/g')" >> "$GITHUB_OUTPUT"
+          sanitized_ref = sanitize(env.REF_NAME)
+
+          # Total tag length = len(target) + 1(-) + len(ref) + 1(_) + len(sha) <= 128
+          # Therefore, max_ref_len = 128 - len(env.TARGET) - len(env.SHA) - 2
+          max_ref_len = 128 - len(env.TARGET) - len(env.SHA) - 2
+
+          if max_ref_len < 1:
+              print(f"::error::Target name '{env.TARGET}' ({len(env.TARGET)} chars) is too long to accommodate a branch name and commit SHA within the 128-character Docker tag limit.", file=sys.stderr)
+              sys.exit(1)
+
+          image_tag = f"{sanitized_ref[:max_ref_len]}_{env.SHA}"
+          full_tag = f"{env.TARGET}-{image_tag}"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"IMAGE_TAG={image_tag}\n")
+              f.write(f"OUTPUT_IMAGE={env.REGISTRY}:{full_tag}\n")
+              f.write(f"SANITIZED_PLATFORM={sanitize(env.PLATFORM)}\n")
 
       # endregion
 


### PR DESCRIPTION
## Summary

Fixes broken image tagging on `rhoai-2.25` GHA push builds ([RHAIENG-6067](https://redhat.atlassian.net/browse/RHAIENG-6067)).

The shell step piped `cut` outside the command substitution:

```bash
SANITIZED_REF_NAME=$(echo "${{ github.ref_name }}" | sed '...') | cut -c 1-40
```

That left `SANITIZED_REF_NAME` empty, so pushed tags were `{target}-_{sha}` instead of `{target}-{ref}_{sha}`.

**main is already fixed** — it uses a Python tag calculator from #3093 (`b979893c4`), later extended with product/platform suffix in RHAIENG-5164.

This PR cherry-picks `b979893c4` onto `rhoai-2.25` with `-x`.

## Test plan

* https://github.com/red-hat-data-services/notebooks/actions/runs/28856441048/job/85584114787

- [ ] Push build tags images as `jupyter-minimal-ubi9-python-3.12-rhoai-2.25_<sha>` (not `-_<sha>`)
- [ ] PR #2447 self-test workflow finds images after a green push build with all four matrix targets

Made with [Cursor](https://cursor.com)

[RHAIENG-6067]: https://redhat.atlassian.net/browse/RHAIENG-6067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ