### PR TITLE
[rhoai-2.25] Improve container test startup failure diagnostics

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -29,19 +29,11 @@ class TestBaseImage:
     """Tests that are applicable for all images we have in this repository."""
 
     def _run_test(self, image: str, test_fn: Callable[[testcontainers.core.container.DockerContainer], None]):
-        container = testcontainers.core.container.DockerContainer(image=image, user=23456, group_add=[0])
-        container.with_command(["/bin/sh", "-c", "sleep infinity"])
         try:
-            container.start()
-            test_fn(container)
-            return
+            with docker_utils.running_container(image) as container:
+                test_fn(container)
         except Exception as e:
             pytest.fail(f"Unexpected exception in test: {e}")
-        finally:
-            docker_utils.NotebookContainer(container).stop(timeout=0)
-
-        # If the return doesn't happen in the try block, fail the test
-        pytest.fail("The test did not pass as expected.")
 
     def test_elf_files_can_link_runtime_libs(self, subtests: pytest_subtests.SubTests, image):
         def test_fn(container: testcontainers.core.container.DockerContainer):
@@ -197,10 +189,12 @@ class TestBaseImage:
             else:
                 container.with_volume_mapping(str(tmp_crypto), "/proc/sys", mode="ro,z")
 
-            container.with_command(["/bin/sh", "-c", "sleep infinity"])
+            container.with_command("/bin/sh -c 'sleep infinity'")
 
             try:
                 container.start()
+                docker_utils.require_running(container, context="after start")
+                docker_utils.guard_container_exec(container)
 
                 with subtests.test("/proc/sys/crypto/fips_enabled is 1"):
                     # sysctl here works too, but it may not be present in image

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 class TestBaseImage:
     """Tests that are applicable for all images we have in this repository."""
 
-    def _run_test(self, image: str, test_fn: Callable[[testcontainers.core.container.DockerContainer], None]):
+    def _run_test(self, image: str, test_fn: Callable[[docker_utils.NotebookContainer], None]):
         try:
             with docker_utils.running_container(image) as container:
                 test_fn(container)
@@ -36,7 +36,7 @@ class TestBaseImage:
             pytest.fail(f"Unexpected exception in test: {e}")
 
     def test_elf_files_can_link_runtime_libs(self, subtests: pytest_subtests.SubTests, image):
-        def test_fn(container: testcontainers.core.container.DockerContainer):
+        def test_fn(container: docker_utils.NotebookContainer):
             def check_elf_file():
                 """This python function will be executed on the image itself.
                 That's why it has to have here all imports it needs."""
@@ -123,7 +123,7 @@ class TestBaseImage:
         if utils.is_rstudio_image(image):
             pytest.skip("oc command is not preinstalled in RStudio images.")
 
-        def test_fn(container: testcontainers.core.container.DockerContainer):
+        def test_fn(container: docker_utils.NotebookContainer):
             ecode, output = container.exec(["/bin/sh", "-c", "oc version"])
 
             logging.debug(output.decode())
@@ -135,7 +135,7 @@ class TestBaseImage:
         if utils.is_rstudio_image(image):
             pytest.skip("skopeo command is not preinstalled in RStudio images.")
 
-        def test_fn(container: testcontainers.core.container.DockerContainer):
+        def test_fn(container: docker_utils.NotebookContainer):
             ecode, output = container.exec(["/bin/sh", "-c", "skopeo --version"])
 
             logging.debug(output.decode())
@@ -146,7 +146,7 @@ class TestBaseImage:
     def test_pip_install_cowsay_runs(self, image: str):
         """Checks that the Python virtualenv in the image is writable."""
 
-        def test_fn(container: testcontainers.core.container.DockerContainer):
+        def test_fn(container: docker_utils.NotebookContainer):
             ecode, output = container.exec(["python3", "-m", "pip", "install", "cowsay"])
             logging.debug(output.decode())
             assert ecode == 0
@@ -193,28 +193,28 @@ class TestBaseImage:
 
             try:
                 container.start()
-                docker_utils.require_running(container, context="after start")
-                docker_utils.guard_container_exec(container)
+                notebook = docker_utils.NotebookContainer(container)
+                notebook.require_running(context="after start")
 
                 with subtests.test("/proc/sys/crypto/fips_enabled is 1"):
                     # sysctl here works too, but it may not be present in image
-                    ecode, output = container.exec(["/bin/sh", "-c", "cat /proc/sys/crypto/fips_enabled"])
+                    ecode, output = notebook.exec(["/bin/sh", "-c", "cat /proc/sys/crypto/fips_enabled"])
                     assert ecode == 0, output.decode()
                     assert "1\n" == output.decode(), f"Unexpected crypto/fips_enabled content: {output.decode()}"
 
                 # 0: enabled, 1: partial success, 2: not enabled
                 with subtests.test("/fips-mode-setup --is-enabled reports 1"):
-                    ecode, output = container.exec(["/bin/sh", "-c", "fips-mode-setup --is-enabled"])
+                    ecode, output = notebook.exec(["/bin/sh", "-c", "fips-mode-setup --is-enabled"])
                     assert ecode == 1, output.decode()
 
                 with subtests.test("/fips-mode-setup --check reports partial success"):
-                    ecode, output = container.exec(["/bin/sh", "-c", "fips-mode-setup --check"])
+                    ecode, output = notebook.exec(["/bin/sh", "-c", "fips-mode-setup --check"])
                     assert ecode == 1, output.decode()
                     assert "FIPS mode is enabled.\n" in output.decode(), output.decode()
                     assert "Inconsistent state detected.\n" in output.decode(), output.decode()
 
                 with subtests.test("oc version command runs"):
-                    ecode, output = container.exec(["/bin/sh", "-c", "oc version"])
+                    ecode, output = notebook.exec(["/bin/sh", "-c", "oc version"])
                     assert ecode == 0, output.decode()
             finally:
                 docker_utils.NotebookContainer(container).stop(timeout=0)
@@ -233,7 +233,7 @@ class TestBaseImage:
             # RStudio image doesn't have '/opt/app-root/share' directory
             directories_to_check.append([f"{app_root_path}/share", "775", expected_gid, expected_uid])
 
-        def test_fn(container: testcontainers.core.container.DockerContainer):
+        def test_fn(container: docker_utils.NotebookContainer):
             for item in directories_to_check:
                 with subtests.test(f"Checking permissions of the: {item[0]}"):
                     # ignore `:%u`, it does not matter what the uid is, it's the gid that is nonrandom on openshift

--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -30,7 +30,7 @@ class TestBaseImage:
 
     def _run_test(self, image: str, test_fn: Callable[[testcontainers.core.container.DockerContainer], None]):
         container = testcontainers.core.container.DockerContainer(image=image, user=23456, group_add=[0])
-        container.with_command("/bin/sh -c 'sleep infinity'")
+        container.with_command(["/bin/sh", "-c", "sleep infinity"])
         try:
             container.start()
             test_fn(container)
@@ -197,7 +197,7 @@ class TestBaseImage:
             else:
                 container.with_volume_mapping(str(tmp_crypto), "/proc/sys", mode="ro,z")
 
-            container.with_command("/bin/sh -c 'sleep infinity'")
+            container.with_command(["/bin/sh", "-c", "sleep infinity"])
 
             try:
                 container.start()

--- a/tests/containers/docker_utils.py
+++ b/tests/containers/docker_utils.py
@@ -11,6 +11,7 @@ import time
 from os import PathLike
 from typing import TYPE_CHECKING
 
+import docker.client
 import docker.errors
 import podman
 import pytest
@@ -21,8 +22,6 @@ import tests.containers.pydantic_schemas
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    import docker.client
-    import testcontainers.core.container
     from docker.models.containers import Container
 
 

--- a/tests/containers/docker_utils.py
+++ b/tests/containers/docker_utils.py
@@ -328,7 +328,7 @@ def container_exec_with_stdin(
                 raw_io._sock.shutdown(pysocket.SHUT_WR)
             else:
                 stream.shutdown(pysocket.SHUT_WR)
-    except (OSError, AttributeError):
+    except OSError, AttributeError:
         # This is expected if the remote process closes the connection first.
         pass
 

--- a/tests/containers/docker_utils.py
+++ b/tests/containers/docker_utils.py
@@ -34,6 +34,24 @@ class NotebookContainer:
     def __init__(self, container: testcontainers.core.container.DockerContainer) -> None:
         self.testcontainer = container
 
+    def require_running(self, *, context: str = "after start") -> None:
+        wrapped = self.testcontainer.get_wrapped_container()
+        if wrapped is None:
+            pytest.fail(f"Container not started ({context})")
+        wrapped.reload()
+        if wrapped.status == "running":
+            return
+        pytest.fail(format_container_diagnostics(self.testcontainer, context=context))
+
+    def exec(self, command: str | list[str]):
+        try:
+            return self.testcontainer.exec(command)
+        except docker.errors.APIError as exc:
+            if _is_dead_container_exec_error(exc):
+                context = f"exec({command!r})"
+                pytest.fail(format_container_diagnostics(self.testcontainer, context=context))
+            raise
+
     def stop(self, timeout: int = 10):
         """Stop container with customizable timeout.
 
@@ -96,44 +114,12 @@ def format_container_diagnostics(
     )
 
 
-def require_running(
-    container: testcontainers.core.container.DockerContainer,
-    *,
-    context: str = "after start",
-) -> None:
-    wrapped = container.get_wrapped_container()
-    if wrapped is None:
-        pytest.fail(f"Container not started ({context})")
-    wrapped.reload()
-    if wrapped.status == "running":
-        return
-    pytest.fail(format_container_diagnostics(container, context=context))
-
-
 def _is_dead_container_exec_error(exc: BaseException) -> bool:
     message = str(exc).lower()
     if isinstance(exc, docker.errors.APIError):
         explanation = getattr(exc, "explanation", "") or ""
         message = f"{message} {explanation}".lower()
     return any(phrase in message for phrase in _DEAD_CONTAINER_EXEC_PHRASES)
-
-
-def guard_container_exec(container: testcontainers.core.container.DockerContainer) -> None:
-    if getattr(container, "_docker_utils_exec_guarded", False):
-        return
-    original_exec = container.exec
-
-    def exec_guarded(command: str | list[str]):
-        try:
-            return original_exec(command)
-        except docker.errors.APIError as exc:
-            if _is_dead_container_exec_error(exc):
-                context = f"exec({command!r})"
-                pytest.fail(format_container_diagnostics(container, context=context)) from exc
-            raise
-
-    container.exec = exec_guarded  # type: ignore[method-assign]
-    container._docker_utils_exec_guarded = True
 
 
 @contextlib.contextmanager
@@ -147,13 +133,13 @@ def running_container(
     groups = sorted({0, *(group_add or [])})
     container = testcontainers.core.container.DockerContainer(image=image, user=user, group_add=groups, **kwargs)
     container.with_command("/bin/sh -c 'sleep infinity'")
+    notebook = NotebookContainer(container)
     try:
         container.start()
-        require_running(container, context="after start")
-        guard_container_exec(container)
-        yield container
+        notebook.require_running(context="after start")
+        yield notebook
     finally:
-        NotebookContainer(container).stop(timeout=0)
+        notebook.stop(timeout=0)
 
 
 def container_cp(
@@ -342,7 +328,7 @@ def container_exec_with_stdin(
                 raw_io._sock.shutdown(pysocket.SHUT_WR)
             else:
                 stream.shutdown(pysocket.SHUT_WR)
-    except OSError, AttributeError:
+    except (OSError, AttributeError):
         # This is expected if the remote process closes the connection first.
         pass
 

--- a/tests/containers/docker_utils.py
+++ b/tests/containers/docker_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import io
 import logging
 import os.path
@@ -10,7 +11,10 @@ import time
 from os import PathLike
 from typing import TYPE_CHECKING
 
+import docker.errors
 import podman
+import pytest
+import testcontainers.core.container
 
 import tests.containers.pydantic_schemas
 
@@ -34,7 +38,9 @@ class NotebookContainer:
         """Stop container with customizable timeout.
 
         DockerContainer.stop() has unchangeable 10s timeout between SIGSTOP and SIGKILL."""
-        self.testcontainer.get_wrapped_container().stop(timeout=timeout)
+        wrapped = self.testcontainer.get_wrapped_container()
+        if wrapped is not None:
+            wrapped.stop(timeout=timeout)
         self.testcontainer.stop()
 
     def wait_for_exit(self) -> int:
@@ -44,6 +50,110 @@ class NotebookContainer:
             time.sleep(0.2)
             container.reload()
         return container.attrs["State"]["ExitCode"]
+
+
+_DEAD_CONTAINER_EXEC_PHRASES = (
+    "container state improper",
+    "is not running",
+    "container must be running",
+)
+
+
+def _container_logs_tail(container: Container, *, limit: int = 8000) -> str:
+    try:
+        logs = container.logs(stdout=True, stderr=True, tail=100)
+        if isinstance(logs, bytes):
+            text = logs.decode(errors="replace")
+        else:
+            text = b"".join(logs).decode(errors="replace")
+    except Exception as exc:
+        return f"<failed to read logs: {exc}>"
+    if len(text) > limit:
+        return f"...(truncated)...\n{text[-limit:]}"
+    return text
+
+
+def format_container_diagnostics(
+    container: testcontainers.core.container.DockerContainer,
+    *,
+    context: str,
+) -> str:
+    wrapped = container.get_wrapped_container()
+    if wrapped is None:
+        return f"Container not started ({context})"
+    wrapped.reload()
+    state = wrapped.attrs.get("State", {})
+    return "\n".join(
+        [
+            f"Container not running ({context})",
+            f"  status: {wrapped.status!r}",
+            f"  exit_code: {state.get('ExitCode')!r}",
+            f"  error: {state.get('Error')!r}",
+            f"  oom_killed: {state.get('OOMKilled')!r}",
+            "--- container logs (tail) ---",
+            _container_logs_tail(wrapped),
+        ]
+    )
+
+
+def require_running(
+    container: testcontainers.core.container.DockerContainer,
+    *,
+    context: str = "after start",
+) -> None:
+    wrapped = container.get_wrapped_container()
+    if wrapped is None:
+        pytest.fail(f"Container not started ({context})")
+    wrapped.reload()
+    if wrapped.status == "running":
+        return
+    pytest.fail(format_container_diagnostics(container, context=context))
+
+
+def _is_dead_container_exec_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    if isinstance(exc, docker.errors.APIError):
+        explanation = getattr(exc, "explanation", "") or ""
+        message = f"{message} {explanation}".lower()
+    return any(phrase in message for phrase in _DEAD_CONTAINER_EXEC_PHRASES)
+
+
+def guard_container_exec(container: testcontainers.core.container.DockerContainer) -> None:
+    if getattr(container, "_docker_utils_exec_guarded", False):
+        return
+    original_exec = container.exec
+
+    def exec_guarded(command: str | list[str]):
+        try:
+            return original_exec(command)
+        except docker.errors.APIError as exc:
+            if _is_dead_container_exec_error(exc):
+                context = f"exec({command!r})"
+                pytest.fail(format_container_diagnostics(container, context=context)) from exc
+            raise
+
+    container.exec = exec_guarded  # type: ignore[method-assign]
+    container._docker_utils_exec_guarded = True
+
+
+@contextlib.contextmanager
+def running_container(
+    image: str,
+    *,
+    user: int = 23456,
+    group_add: list[int] | None = None,
+    **kwargs,
+):
+    groups = sorted({0, *(group_add or [])})
+    container = testcontainers.core.container.DockerContainer(image=image, user=user, group_add=groups, **kwargs)
+    container.with_command("/bin/sh -c 'sleep infinity'")
+    try:
+        container.start()
+        require_running(container, context="after start")
+        guard_container_exec(container)
+        yield container
+    finally:
+        NotebookContainer(container).stop(timeout=0)
 
 
 def container_cp(

--- a/tests/containers/runtimes/runtime_test.py
+++ b/tests/containers/runtimes/runtime_test.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import contextlib
-
 import allure
-import pytest
-import testcontainers.core.container
 
 from tests.containers import base_image_test, conftest, docker_utils
 
@@ -28,7 +24,7 @@ class TestRuntimeImage:
                     socket.close(0)  # linger=0
                 context.term()
 
-        with running_image(runtime_image.name) as container:
+        with docker_utils.running_container(runtime_image.name) as container:
             exit_code, output_bytes = container.exec(
                 # NOTE: /usr/bin/python3 would not find zmq, we need python3 in user's venv
                 base_image_test.encode_python_function_execution_command_interpreter("python3", check_zmq)
@@ -38,17 +34,3 @@ class TestRuntimeImage:
         assert b"pyzmq imported and socket created successfully" in output_bytes, (
             f"Expected success message not found in output. Output: {output_bytes}"
         )
-
-
-@contextlib.contextmanager
-def running_image(image: str):
-    """Usage: with running_image("quay.io/...") as container:"""
-    container = testcontainers.core.container.DockerContainer(image=image, user=23456, group_add=[0])
-    container.with_command(["/bin/sh", "-c", "sleep infinity"])
-    try:
-        container.start()
-        yield container
-    except Exception as e:
-        pytest.fail(f"Unexpected exception in test: {e}")
-    finally:
-        docker_utils.NotebookContainer(container).stop(timeout=0)

--- a/tests/containers/runtimes/runtime_test.py
+++ b/tests/containers/runtimes/runtime_test.py
@@ -44,7 +44,7 @@ class TestRuntimeImage:
 def running_image(image: str):
     """Usage: with running_image("quay.io/...") as container:"""
     container = testcontainers.core.container.DockerContainer(image=image, user=23456, group_add=[0])
-    container.with_command("/bin/sh -c 'sleep infinity'")
+    container.with_command(["/bin/sh", "-c", "sleep infinity"])
     try:
         container.start()
         yield container

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
@@ -156,12 +156,12 @@ except Exception as e:
         (container.with_network(network).with_command("/bin/sh -c 'sleep infinity'"))
         try:
             container.start(wait_for_readiness=False)
-            docker_utils.require_running(container, context="after start")
-            docker_utils.guard_container_exec(container)
+            notebook = docker_utils.NotebookContainer(container)
+            notebook.require_running(context="after start")
 
             # RHOAIENG-140: code-server image users are expected to install their own db clients
             if "-code-server-" in datascience_image.labels["name"]:
-                exit_code, output = container.exec(["python", "-m", "pip", "install", "mysql-connector-python==9.3.0"])
+                exit_code, output = notebook.exec(["python", "-m", "pip", "install", "mysql-connector-python==9.3.0"])
                 output_str = output.decode()
                 print(output_str)
 
@@ -172,7 +172,7 @@ except Exception as e:
                 )
 
             with subtests.test("Setting the user..."):
-                exit_code, output = container.exec(["python", "-c", setup_mysql_user])
+                exit_code, output = notebook.exec(["python", "-c", setup_mysql_user])
                 output_str = output.decode()
 
                 print(output_str)
@@ -181,7 +181,7 @@ except Exception as e:
                 assert exit_code == 0
 
             with subtests.test("Checking the output of the clearpassuser script..."):
-                exit_code, output = container.exec(["python", "-c", clearpassuser])
+                exit_code, output = notebook.exec(["python", "-c", clearpassuser])
                 output_str = output.decode()
 
                 print(output_str)

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
@@ -153,7 +153,7 @@ except Exception as e:
 """
 
         container = WorkbenchContainer(image=datascience_image.name, user=4321, group_add=[0])
-        (container.with_network(network).with_command("/bin/sh -c 'sleep infinity'"))
+        (container.with_network(network).with_command(["/bin/sh", "-c", "sleep infinity"]))
         try:
             container.start(wait_for_readiness=False)
 

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
@@ -153,9 +153,11 @@ except Exception as e:
 """
 
         container = WorkbenchContainer(image=datascience_image.name, user=4321, group_add=[0])
-        (container.with_network(network).with_command(["/bin/sh", "-c", "sleep infinity"]))
+        (container.with_network(network).with_command("/bin/sh -c 'sleep infinity'"))
         try:
             container.start(wait_for_readiness=False)
+            docker_utils.require_running(container, context="after start")
+            docker_utils.guard_container_exec(container)
 
             # RHOAIENG-140: code-server image users are expected to install their own db clients
             if "-code-server-" in datascience_image.labels["name"]:


### PR DESCRIPTION
## Summary

- Add `require_running()` after `container.start()` so tests fail immediately with container status, exit code, and log tail when the sleep container dies on startup.
- Wrap `container.exec()` to translate Podman `container state improper` (and similar) into the same diagnostics instead of an opaque API error.
- Centralize the sleep-container pattern in `docker_utils.running_container()` for base-image and runtime tests.
- **No Cmd string changes** — docker-py already splits `"/bin/sh -c 'sleep infinity'"` into exec form.

## Context

CI codeserver failures surfaced as `container state improper` on `container.exec()`. That error means the container was already dead; the underlying causes include platform/arch mismatches on shared GHCR tags (see follow-up) and instant startup exits. This PR makes those failures actionable in pytest output.

## Test plan

- [x] Reproduced dead-container exec error on remote podman host; `require_running()` catches instant exit-127 cases.
- [ ] `Test Infrastructure Self-Test` workflow: failures (if any) should show container status + logs instead of bare `container state improper`
- [ ] Matrix legs (jupyter-minimal, jupyter-datascience, codeserver, runtime-datascience) exercised

## Follow-up

- Per-platform image tag suffix on `rhoai-2.25` (already on `main`) to fix arm64/amd64 tag races on GHCR.
- #2446 (codeserver mysql test label detection) after platform tags are fixed.