### PR TITLE
[rhoai-2.25] Per-platform GHCR image tags for RHDS builds

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -244,7 +244,7 @@ jobs:
           max_ref_len = 128 - len(env.TARGET) - len(short_sha) - len(suffix) - 3
 
           if max_ref_len < 1:
-              print(f"::error::Target name '{env.TARGET}' ({len(env.TARGET)} chars) is too long to accommodate a branch name and commit SHA within the 128-character Docker tag limit.", file=sys.stderr)
+              print(f"::error::Target name '{env.TARGET}' ({len(env.TARGET)} chars) plus suffix '{suffix}' ({len(suffix)} chars) is too long to accommodate a branch name and commit SHA within the 128-character Docker tag limit.", file=sys.stderr)
               sys.exit(1)
 
           image_tag = f"{sanitized_ref[:max_ref_len]}_{short_sha}_{suffix}"

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -200,6 +200,7 @@ jobs:
           TARGET: ${{ inputs.target }}
           REGISTRY: ${{ env.IMAGE_REGISTRY }}
           PLATFORM: ${{ inputs.platform }}
+          PRODUCT: ${{ env.PRODUCT }}
         # language=python
         run: |
           import os, re, sys
@@ -212,6 +213,7 @@ jobs:
               TARGET: str
               REGISTRY: str
               PLATFORM: str
+              PRODUCT: str
 
               @classmethod
               def from_env(cls):
@@ -227,22 +229,32 @@ jobs:
           env = Env.from_env()
 
           sanitized_ref = sanitize(env.REF_NAME)
+          sanitized_platform = sanitize(env.PLATFORM)
 
-          # Total tag length = len(target) + 1(-) + len(ref) + 1(_) + len(sha) <= 128
-          # Therefore, max_ref_len = 128 - len(env.TARGET) - len(env.SHA) - 2
-          max_ref_len = 128 - len(env.TARGET) - len(env.SHA) - 2
+          # Build a suffix from build type and platform so that different
+          # odh/rhoai builds and architectures get distinct tags.
+          build_type = env.PRODUCT
+          suffix = f"{build_type}_{sanitized_platform}"
+
+          # 7-char SHA prefix is enough to identify a commit uniquely
+          short_sha = env.SHA[:7]
+
+          # Total tag = {target}-{ref}_{short_sha}_{suffix}
+          # Separators: 1 '-' + 2 '_' = 3 fixed chars
+          max_ref_len = 128 - len(env.TARGET) - len(short_sha) - len(suffix) - 3
 
           if max_ref_len < 1:
               print(f"::error::Target name '{env.TARGET}' ({len(env.TARGET)} chars) is too long to accommodate a branch name and commit SHA within the 128-character Docker tag limit.", file=sys.stderr)
               sys.exit(1)
 
-          image_tag = f"{sanitized_ref[:max_ref_len]}_{env.SHA}"
+          image_tag = f"{sanitized_ref[:max_ref_len]}_{short_sha}_{suffix}"
           full_tag = f"{env.TARGET}-{image_tag}"
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"IMAGE_TAG={image_tag}\n")
               f.write(f"OUTPUT_IMAGE={env.REGISTRY}:{full_tag}\n")
-              f.write(f"SANITIZED_PLATFORM={sanitize(env.PLATFORM)}\n")
+              f.write(f"SANITIZED_PLATFORM={sanitized_platform}\n")
+              f.write(f"BUILD_TYPE={build_type}\n")
 
       # endregion
 

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -56,7 +56,10 @@ jobs:
 
           registry = os.environ["IMAGE_REGISTRY"]
           ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
-          tag_suffix = "_odh_linux_amd64" if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks" else ""
+          if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks":
+              tag_suffix = "_odh_linux_amd64"
+          else:
+              tag_suffix = "_rhoai_linux_amd64"
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -37,9 +37,7 @@ def test_find_suitable_sha__single():
 
 
 def test_find_suitable_sha__rhoai_branch_with_platform_suffix():
-    skopeo_output = json.dumps(
-        {"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc1234_rhoai_linux_amd64"]}
-    )
+    skopeo_output = json.dumps({"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc1234_rhoai_linux_amd64"]})
     assert (
         find_suitable_sha("rhoai-2.25", "_rhoai_linux_amd64", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
         == "abc1234"

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -36,9 +36,14 @@ def test_find_suitable_sha__single():
     assert find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
 
 
-def test_find_suitable_sha__rhoai_branch_without_suffix():
-    skopeo_output = json.dumps({"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc123def456"]})
-    assert find_suitable_sha("rhoai-2.25", "", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output) == "abc123def456"
+def test_find_suitable_sha__rhoai_branch_with_platform_suffix():
+    skopeo_output = json.dumps(
+        {"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc1234_rhoai_linux_amd64"]}
+    )
+    assert (
+        find_suitable_sha("rhoai-2.25", "_rhoai_linux_amd64", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
+        == "abc1234"
+    )
 
 
 def test_find_suitable_sha__multiple():
@@ -57,6 +62,6 @@ def test_find_suitable_sha__multiple():
 
 if __name__ == "__main__":
     test_find_suitable_sha__single()
-    test_find_suitable_sha__rhoai_branch_without_suffix()
+    test_find_suitable_sha__rhoai_branch_with_platform_suffix()
     test_find_suitable_sha__multiple()
     print("OK")


### PR DESCRIPTION
## Summary

- Port main's image tag suffix `{product}_{platform}` into `build-notebooks-TEMPLATE.yaml` so RHDS pushes tags like `jupyter-minimal-ubi9-python-3.12-rhoai-2.25_{sha7}_rhoai_linux_amd64` instead of a single arch-neutral tag per commit.
- Teach `test-containers.yaml` / `find_images_for_test_matrix.py` to discover `_rhoai_linux_amd64` tags on `red-hat-data-services/notebooks` (mirrors upstream `_odh_linux_amd64`).

## Why

GHCR tags on `rhoai-2.25` were shared across amd64 and arm64 matrix legs — last writer wins, so GHA amd64 test jobs could pull an arm64 codeserver manifest (`Exec format error` / misleading `container state improper`). Distinct per-platform tags fix the arch race.

## Expected CI behavior on this PR

- **Test Infrastructure Self-Test** will fail at `find-images` until a `rhoai-2.25` push build publishes all four matrix images with the new suffix. That is expected for this PR alone.
- After merge + next `Build Notebooks` push on `rhoai-2.25`, self-test should pass and codeserver arch mismatches should stop.

## Test plan

- [x] `python3 ci/find_images_for_test_matrix.py`
- [ ] Merge → wait for `Build Notebooks` push on `rhoai-2.25` with new tags
- [ ] Re-run / confirm `Test Infrastructure Self-Test` green
- [ ] Rebase #2446 (codeserver mysql label) on top once self-test is green

## Follow-up

- #2446 codeserver mysql test label fix (`-codeserver-` vs `-code-server-`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container image tagging to include platform-specific suffixes and shorter SHA-based tags for better consistency.
  * Adjusted test image selection so downstream jobs pull the correct image variant for each environment.
* **Tests**
  * Updated automated coverage to reflect the new tag-suffix behavior and verify the revised image selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->