### PR TITLE
[rhoai-2.25] RHAIENG-6041: fix TrustyAI post-install RUN block (RHAIENG-1503)

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -199,8 +199,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 USER 1001
 
-RUN # setup path for runtime configuration \
-    mkdir /opt/app-root/runtimes && \
+# setup path for runtime configuration
+RUN mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -195,8 +195,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 USER 1001
 
-RUN # setup path for runtime configuration \
-    mkdir /opt/app-root/runtimes && \
+# setup path for runtime configuration
+RUN mkdir /opt/app-root/runtimes && \
     # Remove default Elyra runtime-images \
     rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json && \
     # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y \


### PR DESCRIPTION
## Summary

Fix `jupyter-trustyai-ubi9-python-3.12` container test failures on `rhoai-2.25` by restoring the TrustyAI post-install `RUN` block that was silently skipped during image build.

When `RUN` starts with `#`, the shell treats the entire continued command as a comment. None of the setup steps ran: `apply.sh` (spinner HTML), `fix-permissions`, `jupyter labextension disable`, etc.

Backport of the fix from [RHAIENG-1503](https://issues.redhat.com/browse/RHAIENG-1503) / [opendatahub-io/notebooks#3778](https://github.com/opendatahub-io/notebooks/pull/3778) (merged on main May 2026).

## Problem

GHA `jupyter-trustyai` job ([run 28674804643](https://github.com/red-hat-data-services/notebooks/actions/runs/28674804643)):

- `test_file_permissions` — `/opt/app-root/share` is `755:0`, expected `775:0`
- `test_spinner_html_loaded` — missing `class="pf-v6-c-spinner"` in served HTML

Root cause in both Dockerfiles:

```dockerfile
RUN # setup path for runtime configuration \
    mkdir /opt/app-root/runtimes && \
```

## Fix

Move the comment above `RUN` ([RHAIENG-1503](https://redhat.atlassian.net/browse/RHAIENG-1503) option 1):

```dockerfile
# setup path for runtime configuration
RUN mkdir /opt/app-root/runtimes && \
```

Files:
- `jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu`
- `jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu`

## Test plan

- [ ] Build Notebooks workflow: `jupyter-trustyai-ubi9-python-3.12` matrix job green
- [ ] `test_spinner_html_loaded` passes
- [ ] `test_file_permissions` passes on `/opt/app-root/share`

Fixes [RHAIENG-6041](https://issues.redhat.com/browse/RHAIENG-6041).


Made with [Cursor](https://cursor.com)

[RHAIENG-1503]: https://redhat.atlassian.net/browse/RHAIENG-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6041]: https://redhat.atlassian.net/browse/RHAIENG-6041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted Dockerfile formatting for the runtime directory setup step.
  * Moved comments onto their own lines for cleaner, more readable build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->