### PR TITLE
[rhoai-2.25] decouple post-build test steps in build-notebooks TEMPLATE

### DIFF
--- a/.github/actions/capture-kernel-logs/action.yml
+++ b/.github/actions/capture-kernel-logs/action.yml
@@ -1,0 +1,41 @@
+---
+name: 'Capture kernel logs'
+description: 'Capture dmesg and journalctl kernel logs on failure and upload as artifacts'
+inputs:
+  log-prefix:
+    description: 'Prefix for log filenames (e.g. job name or matrix key)'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Capture kernel logs
+
+      shell: bash
+      env:
+        LOG_PREFIX: ${{ inputs.log-prefix }}
+      run: |
+        set -Eeuxo pipefail
+        log_dir="${RUNNER_TEMP}/kernel-logs"
+        mkdir -p "${log_dir}"
+        sudo dmesg > "${log_dir}/${LOG_PREFIX}_dmesg.log"
+        sudo journalctl --no-pager -k > "${log_dir}/${LOG_PREFIX}_journalctl-k.log"
+
+    - name: Upload dmesg log
+
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: kernel-logs-${{ inputs.log-prefix }}
+        path: "${{ runner.temp }}/kernel-logs/${{ inputs.log-prefix }}_dmesg.log"
+        archive: false
+        retention-days: 14
+        if-no-files-found: error
+
+    - name: Upload journalctl kernel log
+
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: kernel-logs-${{ inputs.log-prefix }}
+        path: "${{ runner.temp }}/kernel-logs/${{ inputs.log-prefix }}_journalctl-k.log"
+        archive: false
+        retention-days: 14
+        if-no-files-found: error

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -585,10 +585,9 @@ jobs:
       - run: sudo compsize -x "${HOME}/.local/share/containers"
         if: "${{ !cancelled() && steps.install-compsize.outcome == 'success' }}"
 
-      # print system logs, useful when hunting for OOM kills
-
-      - run: sudo dmesg
+      # Capture kernel logs on failure (OOM debugging); upload as uncompressed artifacts instead of flooding job logs
+      - name: Capture kernel logs on failure
         if: "${{ failure() }}"
-
-      - run: journalctl --no-pager -k
-        if: "${{ failure() }}"
+        uses: ./.github/actions/capture-kernel-logs
+        with:
+          log-prefix: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}"

--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -341,6 +341,8 @@ jobs:
         run: uv sync --locked
 
       - name: Run Testcontainers container tests (in PyTest)
+        id: pytest-testcontainers
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         run: |
           set -Eeuxo pipefail
           uv run pytest --capture=fd tests/containers -m 'not openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
@@ -356,9 +358,11 @@ jobs:
 
       - name: "Check if we have tests or not"
         id: have-tests
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         run: "ci/cached-builds/has_tests.py --target ${{ inputs.target }}"
 
       - name: "Change pull policy to IfNotPresent"
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         run: |
           set -Eeuxo pipefail
 
@@ -370,7 +374,7 @@ jobs:
       # Deploying notebook from runtimes/rocm/tensorflow/ubi9-python-3.11/kustomize/base directory...
       # sed: can't read runtimes/rocm/tensorflow/ubi9-python-3.11/kustomize/base/kustomization.yaml: No such file or directory
       - name: "Fixup paths that prevent us from running rocm tests"
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') && steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
 
@@ -379,13 +383,15 @@ jobs:
           ln -s ../rocm-pytorch runtimes/rocm/pytorch
 
       - name: Provision K8s cluster
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
+        id: provision-k8s
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') && steps.have-tests.outputs.tests == 'true' }}
         uses: ./.github/actions/provision-k8s
 
       - name: "Run image tests"
+        id: makefile-tests
         # skip on s390x because we are unable to install requirements-elyra.txt that's installed by runtime image tests
         # https://raw.githubusercontent.com/opendatahub-io/elyra/refs/heads/main/etc/generic/requirements-elyra.txt
-        if: ${{ steps.have-tests.outputs.tests == 'true' && !contains(fromJSON('["linux/s390x"]'), inputs.platform) }}
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') && steps.provision-k8s.outcome == 'success' && !contains(fromJSON('["linux/s390x"]'), inputs.platform) }}
         run: python3 ci/cached-builds/make_test.py --target ${{ inputs.target }}
         env:
           IMAGE_TAG: "${{ steps.calculated_vars.outputs.IMAGE_TAG }}"
@@ -395,7 +401,8 @@ jobs:
       # endregion
 
       - name: Run OpenShift container tests (in PyTest)
-        if: ${{ steps.have-tests.outputs.tests == 'true' }}
+        id: pytest-openshift
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') && steps.provision-k8s.outcome == 'success' && steps.have-tests.outputs.tests == 'true' }}
         run: |
           set -Eeuxo pipefail
           uv run pytest --capture=fd tests/containers -m 'openshift and not cuda and not rocm' --image="${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}"
@@ -410,7 +417,7 @@ jobs:
 
       - name: "pull_request|schedule: resolve target if Trivy scan should run"
         id: resolve-target
-        if: ${{ fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'schedule' }}
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') && (fromJson(inputs.github).event_name == 'pull_request' || fromJson(inputs.github).event_name == 'schedule') }}
         env:
           EVENT_NAME: ${{ fromJson(inputs.github).event_name }}
           HAS_TRIVY_LABEL: ${{ contains(fromJson(inputs.github).event.pull_request.labels.*.name, 'trivy-scan') }}
@@ -454,7 +461,7 @@ jobs:
           fi
 
       - name: Run Trivy vulnerability scanner
-        if: ${{ steps.resolve-target.outputs.target }}
+        if: ${{ !cancelled() && steps.resolve-target.outputs.target }}
         uses: ./.github/actions/trivy-scan-action
         with:
           scan-type: ${{ steps.resolve-target.outputs.type }}
@@ -468,12 +475,14 @@ jobs:
       # region check-payload for FIPS compliance
 
       - id: check-payload-vars
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         run: |
           echo "GOPATH=${{ github.workspace }}/go-check-payload" >> "$GITHUB_OUTPUT"
         working-directory: scripts/check-payload
 
       # for https://github.com/openshift/check-payload to cache the built binary
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         with:
           go-version-file: scripts/check-payload/go.mod
           cache-dependency-path: |
@@ -484,6 +493,7 @@ jobs:
 
       # F0512 15:43:03.219076 21568 main.go:294] Error: exec: "oc": executable file not found in $PATH
       - name: Install oc client
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         run: |
           # Install the oc client
           curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/stable/openshift-client-linux.tar.gz -o /tmp/openshift-client-linux.tar.gz
@@ -502,6 +512,8 @@ jobs:
       # and use --preserve-env=PATH to avoid
       #  F0512 16:31:58.425584    9911 main.go:294] Error: exec: "podman": executable file not found in $PATH
       - name: Check image with check-payload for FIPS compliance
+        id: fips-check
+        if: ${{ !cancelled() && (steps.push-make-target.outcome == 'success' || steps.pr-make-target.outcome == 'success') }}
         run: |
           set -Eeuxo pipefail
           # resolve podman under current user, not under sudo/root

--- a/.github/workflows/test-capture-kernel-logs.yaml
+++ b/.github/workflows/test-capture-kernel-logs.yaml
@@ -1,0 +1,33 @@
+---
+name: Test Capture Kernel Logs Action
+
+"on":
+  push:
+    branches: [main, stable, 'rhoai-*']
+    paths: &capture-kernel-logs-paths
+      - '.github/actions/capture-kernel-logs/**'
+      - '.github/workflows/test-capture-kernel-logs.yaml'
+  pull_request:
+    paths: *capture-kernel-logs-paths
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  test-capture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Capture kernel logs
+        # condition this if: ${{ failure() }}
+        uses: ./.github/actions/capture-kernel-logs
+        with:
+          log-prefix: test-capture


### PR DESCRIPTION
## Summary

Backport independent test-step conditions from [opendatahub-io/notebooks#2901](https://github.com/opendatahub-io/notebooks/pull/2901) to `build-notebooks-TEMPLATE.yaml` on `rhoai-2.25`.

When k8s papermill tests fail (e.g. `jupyter-trustyai` pod crash-loop in [RHAIENG-6076](https://redhat.atlassian.net/browse/RHAIENG-6076)), downstream steps are no longer skipped as a side effect of an earlier failure. Each step now has an explicit `if: ${{ !cancelled() && … }}` guard:

- **Testcontainers pytest** — runs after successful image build
- **K8s provision + makefile tests** — gated on build success; makefile tests additionally require `provision-k8s` success
- **OpenShift pytest, Trivy, check-payload** — run after successful build; **not** blocked by `makefile-tests` failure

Adapted for RHDS workflow layout (`push-make-target` / `pr-make-target` instead of single `make-target`).

## Motivation

PR #2451 / [RHAIENG-6041](https://redhat.atlassian.net/browse/RHAIENG-6041) container tests pass for TrustyAI, but the job is marked failed because k8s papermill fails and prevents unrelated checks (Trivy, FIPS check-payload) from running. This makes CI signal harder to interpret.

## Test plan

- [ ] Build Notebooks PR workflow: verify a target with k8s tests (e.g. `jupyter-trustyai-ubi9-python-3.12`) still runs Trivy / check-payload after papermill failure
- [ ] Verify a green target (e.g. `jupyter-minimal-ubi9-python-3.12`) is unaffected

Related: [RHAIENG-6076](https://redhat.atlassian.net/browse/RHAIENG-6076), [RHAIENG-5133](https://redhat.atlassian.net/browse/RHAIENG-5133)

Made with [Cursor](https://cursor.com)

[RHAIENG-6076]: https://redhat.atlassian.net/browse/RHAIENG-6076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6041]: https://redhat.atlassian.net/browse/RHAIENG-6041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6076]: https://redhat.atlassian.net/browse/RHAIENG-6076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI stability by preventing later checks from running after earlier steps fail or the workflow is canceled.
  * Made image, container, Kubernetes, security scan, and compliance test steps run only when required prerequisites are met.
  * Reduced false failures by tightening when specialized test and scan jobs are triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->