### PR TITLE
[rhoai-2.25] RHAIENG-287: cherry-pick hadolint fixes + konflux mirrors

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -51,7 +51,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 #            we need to ensure the same cache directory is mounted in
 #            the final stage with the necessary permissions to consume from cache
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -285,7 +285,7 @@ FROM codeserver as tests
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 COPY ${CODESERVER_SOURCE_CODE}/test /tmp/test
 # TODO(jdanek): add --mount=type=bind,target=/opt/app-root/src
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -282,7 +282,7 @@ COPY ${CODESERVER_SOURCE_CODE}/test /tmp/test
 # TODO(jdanek): add --mount=type=bind,target=/opt/app-root/src
 RUN <<'EOF'
 set -Eeuxo pipefail
-python3 /tmp/test/test_startup.py |& tee /tmp/test_log.txt
+python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF
 
 from codeserver

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -12,6 +12,7 @@ FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
 # e.g., registry.access.redhat.com/ubi9/python-312:latest
 FROM ${BASE_IMAGE} AS rpm-base
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -38,6 +39,7 @@ RUN ./get_code_server_rpm.sh && touch /tmp/control
 #######################
 FROM registry.access.redhat.com/ubi9/python-312:latest AS whl-cache
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -288,5 +290,5 @@ set -Eeuxo pipefail
 python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF
 
-from codeserver
+FROM codeserver
 COPY --from=tests /tmp/test_log.txt /tmp/test_log.txt

--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rpm-base         #
 ####################
@@ -17,7 +20,7 @@ ENV HOME=/root
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
@@ -76,7 +79,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -3,12 +3,16 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rpm-base         #
 ####################
 # e.g., registry.access.redhat.com/ubi9/python-312:latest
 FROM ${BASE_IMAGE} AS rpm-base
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -17,7 +21,7 @@ ENV HOME=/root
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 
@@ -35,6 +39,7 @@ RUN ./get_code_server_rpm.sh && touch /tmp/control
 #######################
 FROM registry.access.redhat.com/ubi9/python-312:latest AS whl-cache
 
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -51,7 +56,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 #            we need to ensure the same cache directory is mounted in
 #            the final stage with the necessary permissions to consume from cache
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
@@ -76,7 +81,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd
@@ -276,10 +281,10 @@ FROM codeserver as tests
 ARG CODESERVER_SOURCE_CODE=codeserver/ubi9-python-3.12
 COPY ${CODESERVER_SOURCE_CODE}/test /tmp/test
 # TODO(jdanek): add --mount=type=bind,target=/opt/app-root/src
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-python3 /tmp/test/test_startup.py |& tee /tmp/test_log.txt
+python3 /tmp/test/test_startup.py 2>&1 | tee /tmp/test_log.txt
 EOF
 
-from codeserver
+FROM codeserver
 COPY --from=tests /tmp/test_log.txt /tmp/test_log.txt

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -44,7 +47,7 @@ ARG TARGETARCH
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -195,7 +195,8 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     git checkout ${ONNX_VERSION}
     git submodule update --init --recursive
     pip install -r requirements.txt
-    export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel
 else
     echo "Skipping ONNX build on non-Power"

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -194,7 +194,7 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     cd onnx
     git checkout ${ONNX_VERSION}
     git submodule update --init --recursive
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel
@@ -304,7 +304,7 @@ COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    pip install /onnxwheels/*.whl
+    pip install --no-cache-dir /onnxwheels/*.whl
 else
     echo "Skipping ONNX/OpenBLAS install on non-Power"
 fi

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -222,6 +222,7 @@ else
     echo "Skipping OpenBLAS build on non-Power"
 fi
 EOF
+
 ####################
 # jupyter-minimal #
 ####################

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -23,7 +23,7 @@ RUN arch="${TARGETARCH:-$(uname -m)}" && \
     arch=$(echo "$arch" | cut -d- -f1) && \
     if [ "$arch" = "s390x" ]; then \
         echo "Skipping mongocli build for ${arch}, creating dummy binary"; \
-        mkdir -p /tmp && echo -e '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
+        mkdir -p /tmp && printf '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
         chmod +x /tmp/mongocli; \
     else \
         echo "Building mongocli for ${arch}"; \
@@ -174,7 +174,7 @@ FROM cpu-base AS common-builder
 ARG TARGETARCH
 # hadolint ignore=DL3002
 USER root
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip
@@ -306,7 +306,7 @@ COPY --from=openblas-builder /root/OpenBLAS-${OPENBLAS_VERSION} /openblas
 COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 
 # Power-specific ONNX/OpenBLAS installation
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     pip install --no-cache-dir /onnxwheels/*.whl
@@ -316,7 +316,7 @@ fi
 EOF
 
 USER root
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     rm -rf /onnxwheels
@@ -325,7 +325,7 @@ else
 fi
 EOF
 
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     PREFIX=/usr/local make -C /openblas install

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -213,7 +213,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
+    wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
     unzip OpenBLAS-${OPENBLAS_VERSION}.zip
     cd OpenBLAS-${OPENBLAS_VERSION}
     make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -112,6 +112,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 FROM cpu-base AS pyarrow-builder
 
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER 0
 WORKDIR /tmp/build-wheels
 
@@ -171,6 +172,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 #######################################################
 FROM cpu-base AS common-builder
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER root
 RUN <<'EOF'
 set -Eeuxo pipefail

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -20,7 +23,7 @@ RUN arch="${TARGETARCH:-$(uname -m)}" && \
     arch=$(echo "$arch" | cut -d- -f1) && \
     if [ "$arch" = "s390x" ]; then \
         echo "Skipping mongocli build for ${arch}, creating dummy binary"; \
-        mkdir -p /tmp && echo -e '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
+        mkdir -p /tmp && printf '#!/bin/sh\necho "mongocli not supported on s390x"' > /tmp/mongocli && \
         chmod +x /tmp/mongocli; \
     else \
         echo "Building mongocli for ${arch}"; \
@@ -44,7 +47,7 @@ ARG TARGETARCH
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd
@@ -109,6 +112,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 FROM cpu-base AS pyarrow-builder
 
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER 0
 WORKDIR /tmp/build-wheels
 
@@ -168,8 +172,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 #######################################################
 FROM cpu-base AS common-builder
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER root
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     dnf install -y gcc-toolset-13 cmake ninja-build git wget unzip
@@ -194,8 +199,9 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     cd onnx
     git checkout ${ONNX_VERSION}
     git submodule update --init --recursive
-    pip install -r requirements.txt
-    export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    pip install --no-cache-dir -r requirements.txt
+    CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
+    export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel
 else
     echo "Skipping ONNX build on non-Power"
@@ -213,7 +219,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
+    wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip
     unzip OpenBLAS-${OPENBLAS_VERSION}.zip
     cd OpenBLAS-${OPENBLAS_VERSION}
     make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
@@ -222,6 +228,7 @@ else
     echo "Skipping OpenBLAS build on non-Power"
 fi
 EOF
+
 ####################
 # jupyter-minimal #
 ####################
@@ -297,17 +304,17 @@ COPY --from=openblas-builder /root/OpenBLAS-${OPENBLAS_VERSION} /openblas
 COPY --from=onnx-builder /root/onnx_wheel/ /onnxwheels/
 
 # Power-specific ONNX/OpenBLAS installation
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    pip install /onnxwheels/*.whl
+    pip install --no-cache-dir /onnxwheels/*.whl
 else
     echo "Skipping ONNX/OpenBLAS install on non-Power"
 fi
 EOF
 
 USER root
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     rm -rf /onnxwheels
@@ -316,7 +323,7 @@ else
 fi
 EOF
 
-RUN <<'EOF'
+RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
     PREFIX=/usr/local make -C /openblas install

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -21,6 +21,9 @@ RUN chmod +x install_texlive.sh install_pandoc.sh
 RUN ./install_texlive.sh
 RUN ./install_pandoc.sh
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -34,7 +37,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -29,7 +32,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -29,7 +32,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -29,7 +32,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -29,7 +32,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -31,7 +34,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -23,6 +23,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 FROM ${BASE_IMAGE} AS whl-cache
 
+# hadolint ignore=DL3002
 USER root
 ENV HOME=/root
 WORKDIR /root

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -31,7 +31,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -56,7 +59,7 @@ USER root
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
@@ -20,6 +23,7 @@ RUN cd ./mongodb-cli-mongocli-v${MONGOCLI_VERSION}/ && \
 ####################
 FROM ${BASE_IMAGE} AS whl-cache
 
+# hadolint ignore=DL3002
 USER root
 ENV HOME=/root
 WORKDIR /root
@@ -31,7 +35,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    pip install --no-cache uv && \
+    pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
     source ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
@@ -56,7 +60,7 @@ USER root
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ARG TARGETARCH
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -194,7 +194,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         source /opt/rh/gcc-toolset-13/enable && \
-        wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
+        wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
     else \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -220,7 +220,8 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \
     	pip install -r requirements.txt && \
-    	export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    	CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    	export CMAKE_ARGS && \
     	pip wheel . -w /onnx_wheels; \
     else \
         echo "Not ppc64le, skipping ONNX build" && mkdir -p /onnx_wheels; \
@@ -243,8 +244,10 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive && \
     	cd arrow && rm -rf .git && mkdir dist                                  && \
     	pip3 install -r python/requirements-build.txt                          && \
-    	export ARROW_HOME=$(pwd)/dist                                          && \
-    	export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH                && \
+    	ARROW_HOME=$(pwd)/dist && \
+    	export ARROW_HOME && \
+    	LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH && \
+    	export LD_LIBRARY_PATH && \
     	export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH                && \
     	export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"  && \
     	export ARROW_TEST_DATA="${PWD}/testing/data"                           && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -219,7 +219,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \
-    	pip install -r requirements.txt && \
+    	pip install --no-cache-dir -r requirements.txt && \
     	CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
     	export CMAKE_ARGS && \
     	pip wheel . -w /onnx_wheels; \
@@ -243,7 +243,7 @@ RUN echo "arrow-builder stage TARGETARCH: ${TARGETARCH}"
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive && \
     	cd arrow && rm -rf .git && mkdir dist                                  && \
-    	pip3 install -r python/requirements-build.txt                          && \
+    	pip3 install --no-cache-dir -r python/requirements-build.txt                          && \
     	ARROW_HOME=$(pwd)/dist && \
     	export ARROW_HOME && \
     	LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH && \
@@ -275,7 +275,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         export PYARROW_WITH_PARQUET=1       && \
         export PYARROW_WITH_DATASET=1       && \
         export PYARROW_BUNDLE_ARROW_CPP=1   && \
-        pip3 install wheel                  && \
+        pip3 install --no-cache-dir wheel                  && \
         cd ../../python                     && \
         python setup.py build_ext              \
             --build-type=release               \
@@ -313,7 +313,7 @@ COPY --from=arrow-builder /arrowwheels /tmp/arrowwheels
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	echo "Installing ppc64le ONNX, pyarrow wheels and OpenBLAS..." && \
-    	HOME=/root pip install /tmp/onnx_wheels/*.whl /tmp/arrowwheels/*.whl && \
+    	HOME=/root pip install --no-cache-dir /tmp/onnx_wheels/*.whl /tmp/arrowwheels/*.whl && \
         if [ -d "/openblas" ] && [ "$(ls -A /openblas 2>/dev/null)" ]; then \
     		PREFIX=/usr/local make -C /openblas install; \
         fi && rm -rf /openblas /tmp/onnx_wheels /tmp/arrowwheels; \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -104,6 +104,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 FROM cpu-base AS s390x-builder
 
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER 0
 WORKDIR /tmp/build-wheels
 
@@ -185,6 +186,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ##################################
 
 FROM cpu-base AS openblas-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -209,6 +211,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 ###################################
 
 FROM cpu-base AS onnx-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -235,6 +238,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 ##################################
 
 FROM cpu-base AS arrow-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 ARG TARGETARCH
 
@@ -101,6 +104,7 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/oc
 FROM cpu-base AS s390x-builder
 
 ARG TARGETARCH
+# hadolint ignore=DL3002
 USER 0
 WORKDIR /tmp/build-wheels
 
@@ -182,6 +186,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ##################################
 
 FROM cpu-base AS openblas-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -194,7 +199,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         source /opt/rh/gcc-toolset-13/enable && \
-        wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
+        wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
     else \
@@ -206,6 +211,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 ###################################
 
 FROM cpu-base AS onnx-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -219,8 +225,9 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \
-    	pip install -r requirements.txt && \
-    	export CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    	pip install --no-cache-dir -r requirements.txt && \
+    	CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)" && \
+    	export CMAKE_ARGS && \
     	pip wheel . -w /onnx_wheels; \
     else \
         echo "Not ppc64le, skipping ONNX build" && mkdir -p /onnx_wheels; \
@@ -231,6 +238,7 @@ RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
 ##################################
 
 FROM cpu-base AS arrow-builder
+# hadolint ignore=DL3002
 USER root
 WORKDIR /root
 
@@ -242,11 +250,13 @@ RUN echo "arrow-builder stage TARGETARCH: ${TARGETARCH}"
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive && \
     	cd arrow && rm -rf .git && mkdir dist                                  && \
-    	pip3 install -r python/requirements-build.txt                          && \
-        pip3 install --upgrade pip                                             && \
-        pip3 install --force-reinstall setuptools==80.9.0 wheel                && \
-    	export ARROW_HOME=$(pwd)/dist                                          && \
-    	export LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH                && \
+    	pip3 install --no-cache-dir -r python/requirements-build.txt                          && \
+        pip3 install --no-cache-dir --upgrade pip                                             && \
+        pip3 install --no-cache-dir --force-reinstall setuptools==80.9.0 wheel                && \
+    	ARROW_HOME=$(pwd)/dist && \
+    	export ARROW_HOME && \
+    	LD_LIBRARY_PATH=$(pwd)/dist/lib:$LD_LIBRARY_PATH && \
+    	export LD_LIBRARY_PATH && \
     	export CMAKE_PREFIX_PATH=$ARROW_HOME:$CMAKE_PREFIX_PATH                && \
     	export PARQUET_TEST_DATA="${PWD}/cpp/submodules/parquet-testing/data"  && \
     	export ARROW_TEST_DATA="${PWD}/testing/data"                           && \
@@ -311,7 +321,7 @@ COPY --from=arrow-builder /arrowwheels /tmp/arrowwheels
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
     	echo "Installing ppc64le ONNX, pyarrow wheels and OpenBLAS..." && \
-    	HOME=/root pip install /tmp/onnx_wheels/*.whl /tmp/arrowwheels/*.whl && \
+    	HOME=/root pip install --no-cache-dir /tmp/onnx_wheels/*.whl /tmp/arrowwheels/*.whl && \
         if [ -d "/openblas" ] && [ "$(ls -A /openblas 2>/dev/null)" ]; then \
     		PREFIX=/usr/local make -C /openblas install; \
         fi && rm -rf /openblas /tmp/onnx_wheels /tmp/arrowwheels; \

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cpu-base         #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -18,7 +21,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -3,6 +3,9 @@
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # rocm-base        #
 ####################
@@ -16,7 +19,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -20,7 +23,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -5,6 +5,9 @@ ARG TARGETARCH
 #########################
 ARG BASE_IMAGE
 
+# External image alias for UBI repository configuration
+FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
+
 ####################
 # cuda-base        #
 ####################
@@ -20,7 +23,7 @@ USER 0
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
 # By copying ubi.repo from the public UBI 9 image, we enable package management for upgrades and installations.
-COPY --from=registry.access.redhat.com/ubi9/ubi /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
+COPY --from=ubi-repos /etc/yum.repos.d/ubi.repo /etc/yum.repos.d/ubi.repo
 
 # upgrade first to avoid fixable vulnerabilities begin
 # Problem: The operation would result in removing the following protected packages: systemd


### PR DESCRIPTION
## Summary
Cherry-pick the 8 clean commits from [opendatahub-io/notebooks#2547](https://github.com/opendatahub-io/notebooks/pull/2547) ([RHAIENG-287](https://redhat.atlassian.net/browse/RHAIENG-287) hadolint fixes) onto `rhoai-2.25` with `-x`, and mirror each change onto the matching `Dockerfile.konflux.*` pair.

**8 cherry-picks (`-x`):**
1. newline before stage comment (jupyter/datascience)
2. `wget --progress=dot:giga` (DL3047)
3. `2>&1 |` instead of `|&` (SC3029, codeserver)
4. separate `export` for CMAKE_ARGS (SC2155)
5. `pip install --no-cache-dir` (DL3042)
6. `FROM … AS ubi-repos` stage alias (DL3022)
7. inline `# hadolint ignore=DL3002`
8. `RUN /bin/bash <<'EOF'` / `printf` (SC3037/SC3041)

**Konflux mirror commit:** 17 `Dockerfile.konflux.*` files updated (16 auto-patched from the GHA diff; `runtimes/datascience` manual due to [RHAIENG-5986](https://redhat.atlassian.net/browse/RHAIENG-5986) setuptools lines).

**Skipped from #2547** (conflict on `rhoai-2.25`): HEREDOC SC2016 + final cleanup pass — PR B follow-up.

## Hadolint impact (workbench images, local)
| State | Findings |
|-------|----------|
| `rhoai-2.25` before | 98 |
| After cherry-picks only | 68 |
| After + konflux mirrors | **24** (0 errors) |

Remaining: SC2016 HEREDOC (skipped commits), DL3040 on ROCm `dnf module enable`, SC3046 `source`, one `DL3002` on minimal konflux.

## Relation to #2461
#2461 uses `--failure-threshold error` as a workflow workaround. This PR fixes the underlying Dockerfile warnings instead. Can land independently or together.

## Test plan
- [ ] `code-static-analysis` passes (may still need #2461 or PR B for remaining 24 warnings unless threshold changed)
- [ ] `hadolint --config ci/hadolint-config.yaml` on workbench Dockerfiles shows reduced findings

Made with [Cursor](https://cursor.com)

[RHAIENG-287]: https://redhat.atlassian.net/browse/RHAIENG-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5986]: https://redhat.atlassian.net/browse/RHAIENG-5986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build consistency across multiple image variants by standardizing how repository configuration is sourced.
  * Made several build steps more reliable with stricter shell execution and better error handling.
  * Updated package installation flows to reduce cache-related issues and improve build reproducibility.
  * Improved logging and progress output for some long-running build downloads and test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->