### PR TITLE
[rhoai-2.25] Fix remaining hadolint DL3040/SC3046/DL3002

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -58,7 +58,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -194,7 +194,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    source /opt/rh/gcc-toolset-13/enable
+    . /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx
     git checkout ${ONNX_VERSION}

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -194,7 +194,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    source /opt/rh/gcc-toolset-13/enable
+    . /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx
     git checkout ${ONNX_VERSION}

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -10,7 +10,8 @@ FROM registry.access.redhat.com/ubi9/python-312:latest AS pdf-builder
 
 WORKDIR /opt/app-root/bin
 
-# OS Packages needs to be installed as root
+# OS Packages needs to be installed as root (intermediate pdf-builder stage).
+# hadolint ignore=DL3002
 USER 0
 
 # Copy scripts

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -94,7 +94,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -104,7 +104,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -154,7 +154,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -164,7 +164,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -164,7 +164,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -174,7 +174,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -37,7 +37,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -37,7 +37,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             ninja-build && \
         dnf clean all && \
         # Source the environment variables
-        source /etc/profile.d/s390x.sh && \
+        . /etc/profile.d/s390x.sh && \
         # Clone specific version of arrow
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git && \
         cd arrow && \
@@ -198,7 +198,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        source /opt/rh/gcc-toolset-13/enable && \
+        . /opt/rh/gcc-toolset-13/enable && \
         wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
@@ -221,7 +221,7 @@ ENV ONNX_VERSION=1.20.1
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-    	source /opt/rh/gcc-toolset-13/enable && \
+    	. /opt/rh/gcc-toolset-13/enable && \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -123,7 +123,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             ninja-build && \
         dnf clean all && \
         # Source the environment variables
-        source /etc/profile.d/s390x.sh && \
+        . /etc/profile.d/s390x.sh && \
         # Clone specific version of arrow
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git && \
         cd arrow && \
@@ -198,7 +198,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        source /opt/rh/gcc-toolset-13/enable && \
+        . /opt/rh/gcc-toolset-13/enable && \
         wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
@@ -221,7 +221,7 @@ ENV ONNX_VERSION=1.20.1
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-    	source /opt/rh/gcc-toolset-13/enable && \
+    	. /opt/rh/gcc-toolset-13/enable && \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -80,7 +80,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -90,7 +90,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -80,7 +80,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -90,7 +90,8 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs \
+    && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
## Summary
Follow-up to #2462. Fix the remaining easy hadolint findings with real Dockerfile changes (not config ignores).

- **DL3040** (10): append `&& dnf clean all` after ROCm `rocm-device-libs` installs
- **SC3046** (8): replace bash `source` with POSIX `.`
- **DL3002** (1): `# hadolint ignore=DL3002` on intermediate `pdf-builder` `USER 0` in `jupyter/minimal/.../Dockerfile.konflux.cpu` (same pattern as main)

**Base:** `fix/rhoai-2.25-hadolint-cherry-pick` (#2462). Merge #2462 first, or retarget this PR to `rhoai-2.25` after #2462 lands.

## Hadolint impact (workbench images)
| State | Findings |
|-------|----------|
| After #2462 | 25 |
| After this PR | **6** (all SC2016 — HEREDOC profile-script rewrite, separate PR B) |

## Test plan
- [ ] `hadolint --config ci/hadolint-config.yaml` on workbench Dockerfiles shows only SC2016
- [ ] `code-static-analysis` still needs SC2016 fix or #2461 threshold until PR B