### PR TITLE
[RHAIENG-6070] fix(codeserver): use regex location with correct proxy_pass for Gateway API support

### DIFF
--- a/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template
+++ b/codeserver/ubi9-python-3.12/nginx/serverconf/proxy.conf.template
@@ -62,7 +62,7 @@ location ~ ^/[^/]+/[^/]+/[^/]+/?$ {
 location ~ /codeserver/ {
     rewrite ^.*/codeserver/(.*)$ /$1 break;
     # Standard code-server/NGINX configuration
-    proxy_pass http://workbench_server/;
+    proxy_pass http://workbench_server;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
Related to: https://redhat.atlassian.net/browse/RHAIENG-6070

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted request routing for the codeserver path so proxying to the workbench server behaves more consistently.
  * Improved how incoming URLs are forwarded, helping avoid unexpected path handling issues when accessing the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->