### PR TITLE
RHAIENG-287: fix remaining hadolint findings on rhoai-2.25

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -58,7 +58,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -58,7 +58,7 @@ COPY ${CODESERVER_SOURCE_CODE}/devel_env_setup.sh ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -69,27 +69,33 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y $PACKAGES && \
     dnf clean all && rm -rf /var/cache/yum
 
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo && \
-    export HOME=/root && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh && \
-    chmod +x rustup-init.sh && \
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path && \
-    rm -f rustup-init.sh && \
-    chown -R 1001:0 /opt/.cargo && \
+    mkdir -p /opt/.cargo
+    export HOME=/root
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+    chmod +x rustup-init.sh
+    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    rm -f rustup-init.sh
+    chown -R 1001:0 /opt/.cargo
     # Set environment variables
-    echo 'export PATH=/opt/.cargo/bin:$PATH' >> /etc/profile.d/cargo.sh && \
-    echo 'export CARGO_HOME=/opt/.cargo' >> /etc/profile.d/cargo.sh && \
-    echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/cargo.sh; \
+    cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
+export PATH=/opt/.cargo/bin:$PATH
+export CARGO_HOME=/opt/.cargo
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+CARGO_EOF
 fi
+EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
-    alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    python --version && python3 --version; \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
+    alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    python --version && python3 --version
 fi
+EOF
 
 # Other apps and tools installed as default user
 USER 1001
@@ -194,7 +200,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    source /opt/rh/gcc-toolset-13/enable
+    . /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx
     git checkout ${ONNX_VERSION}

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -69,27 +69,33 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y $PACKAGES && \
     dnf clean all && rm -rf /var/cache/yum
 
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo && \
-    export HOME=/root && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh && \
-    chmod +x rustup-init.sh && \
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path && \
-    rm -f rustup-init.sh && \
-    chown -R 1001:0 /opt/.cargo && \
+    mkdir -p /opt/.cargo
+    export HOME=/root
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+    chmod +x rustup-init.sh
+    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    rm -f rustup-init.sh
+    chown -R 1001:0 /opt/.cargo
     # Set environment variables
-    echo 'export PATH=/opt/.cargo/bin:$PATH' >> /etc/profile.d/cargo.sh && \
-    echo 'export CARGO_HOME=/opt/.cargo' >> /etc/profile.d/cargo.sh && \
-    echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/cargo.sh; \
+    cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
+export PATH=/opt/.cargo/bin:$PATH
+export CARGO_HOME=/opt/.cargo
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+CARGO_EOF
 fi
+EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
-    alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    python --version && python3 --version; \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
+    alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    python --version && python3 --version
 fi
+EOF
 
 # Other apps and tools installed as default user
 USER 1001
@@ -194,7 +200,7 @@ WORKDIR /root
 RUN <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
-    source /opt/rh/gcc-toolset-13/enable
+    . /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx
     git checkout ${ONNX_VERSION}

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -11,6 +11,7 @@ FROM registry.access.redhat.com/ubi9/python-312:latest AS pdf-builder
 WORKDIR /opt/app-root/bin
 
 # OS Packages needs to be installed as root
+# hadolint ignore=DL3002
 USER 0
 
 # Copy scripts

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -94,7 +94,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -104,7 +104,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -154,7 +154,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -164,7 +164,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -164,7 +164,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -174,7 +174,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -37,7 +37,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -37,7 +37,7 @@ COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
 RUN --mount=type=cache,target=/root/.cache/uv \
     pip install --no-cache-dir uv && \
     # the devel script is ppc64le specific - sets up build-time dependencies
-    source ./devel_env_setup.sh && \
+    . ./devel_env_setup.sh && \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     # RHAIENG-5986: cap setuptools version in isolated sdist builds (pkg_resources removed in 82+)
     printf '%s\n' 'setuptools>=80.9.0,<82' > build_constraints.txt && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -50,38 +50,47 @@ RUN --mount=type=cache,target=/var/cache/dnf \
         dnf clean all && rm -rf /var/cache/yum; \
     fi
 
-RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        echo 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export OPENBLAS_VERSION=0.3.30' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export ONNX_VERSION=1.20.1' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export PYARROW_VERSION=17.0.0' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/ppc64le.sh; \
-    fi
+RUN <<EOF
+if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
+export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH
+export OPENBLAS_VERSION=0.3.30
+export ONNX_VERSION=1.20.1
+export PYARROW_VERSION=17.0.0
+export PATH="$HOME/.cargo/bin:$PATH"
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+PROFILE_EOF
+fi
+EOF
 
 # For s390x only, set ENV vars and install Rust
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo && \
-    export HOME=/root && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh && \
-    chmod +x rustup-init.sh && \
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path && \
-    rm -f rustup-init.sh && \
-    chown -R 1001:0 /opt/.cargo && \
+    mkdir -p /opt/.cargo
+    export HOME=/root
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+    chmod +x rustup-init.sh
+    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    rm -f rustup-init.sh
+    chown -R 1001:0 /opt/.cargo
     # Set environment variables
-    echo 'export PATH=/opt/.cargo/bin:$PATH' >> /etc/profile.d/cargo.sh && \
-    echo 'export CARGO_HOME=/opt/.cargo' >> /etc/profile.d/cargo.sh && \
-    echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/cargo.sh; \
+    cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
+export PATH=/opt/.cargo/bin:$PATH
+export CARGO_HOME=/opt/.cargo
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+CARGO_EOF
 fi
+EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
-    alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    python --version && python3 --version; \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
+    alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    python --version && python3 --version
 fi
+EOF
 
 # Other apps and tools installed as default user
 USER 1001
@@ -123,7 +132,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             ninja-build && \
         dnf clean all && \
         # Source the environment variables
-        source /etc/profile.d/s390x.sh && \
+        . /etc/profile.d/s390x.sh && \
         # Clone specific version of arrow
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git && \
         cd arrow && \
@@ -198,7 +207,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        source /opt/rh/gcc-toolset-13/enable && \
+        . /opt/rh/gcc-toolset-13/enable && \
         wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
@@ -221,7 +230,7 @@ ENV ONNX_VERSION=1.20.1
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-    	source /opt/rh/gcc-toolset-13/enable && \
+    	. /opt/rh/gcc-toolset-13/enable && \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -50,38 +50,47 @@ RUN --mount=type=cache,target=/var/cache/dnf \
         dnf clean all && rm -rf /var/cache/yum; \
     fi
 
-RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        echo 'export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export OPENBLAS_VERSION=0.3.30' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export ONNX_VERSION=1.20.1' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export PYARROW_VERSION=17.0.0' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> /etc/profile.d/ppc64le.sh && \
-        echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/ppc64le.sh; \
-    fi
+RUN <<EOF
+if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
+export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:$LD_LIBRARY_PATH
+export OPENBLAS_VERSION=0.3.30
+export ONNX_VERSION=1.20.1
+export PYARROW_VERSION=17.0.0
+export PATH="$HOME/.cargo/bin:$PATH"
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+PROFILE_EOF
+fi
+EOF
 
 # For s390x only, set ENV vars and install Rust
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo && \
-    export HOME=/root && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh && \
-    chmod +x rustup-init.sh && \
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path && \
-    rm -f rustup-init.sh && \
-    chown -R 1001:0 /opt/.cargo && \
+    mkdir -p /opt/.cargo
+    export HOME=/root
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+    chmod +x rustup-init.sh
+    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    rm -f rustup-init.sh
+    chown -R 1001:0 /opt/.cargo
     # Set environment variables
-    echo 'export PATH=/opt/.cargo/bin:$PATH' >> /etc/profile.d/cargo.sh && \
-    echo 'export CARGO_HOME=/opt/.cargo' >> /etc/profile.d/cargo.sh && \
-    echo 'export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1' >> /etc/profile.d/cargo.sh; \
+    cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
+export PATH=/opt/.cargo/bin:$PATH
+export CARGO_HOME=/opt/.cargo
+export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+CARGO_EOF
 fi
+EOF
 
 # Set python alternatives only for s390x (not needed for other arches)
-RUN if [ "$TARGETARCH" = "s390x" ]; then \
-    alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
-    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
-    python --version && python3 --version; \
+RUN <<EOF
+if [ "$TARGETARCH" = "s390x" ]; then
+    alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    python --version && python3 --version
 fi
+EOF
 
 # Other apps and tools installed as default user
 USER 1001
@@ -123,7 +132,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             ninja-build && \
         dnf clean all && \
         # Source the environment variables
-        source /etc/profile.d/s390x.sh && \
+        . /etc/profile.d/s390x.sh && \
         # Clone specific version of arrow
         git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git && \
         cd arrow && \
@@ -198,7 +207,7 @@ RUN echo "openblas-builder stage TARGETARCH: ${TARGETARCH}"
 
 # Download and build OpenBLAS
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-        source /opt/rh/gcc-toolset-13/enable && \
+        . /opt/rh/gcc-toolset-13/enable && \
         wget --progress=dot:giga https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip && \
         unzip OpenBLAS-${OPENBLAS_VERSION}.zip && cd OpenBLAS-${OPENBLAS_VERSION}                                            && \
         make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0; \
@@ -221,7 +230,7 @@ ENV ONNX_VERSION=1.20.1
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN if [ "$TARGETARCH" = "ppc64le" ]; then \
-    	source /opt/rh/gcc-toolset-13/enable && \
+    	. /opt/rh/gcc-toolset-13/enable && \
     	git clone --recursive https://github.com/onnx/onnx.git && \
     	cd onnx && git checkout v${ONNX_VERSION} && \
     	git submodule update --init --recursive && \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -80,7 +80,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -90,7 +90,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -80,7 +80,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -90,7 +90,7 @@ ENV ROCM_PATH=/opt/rocm
 # Workaround for 2.25.2 issue https://issues.redhat.com/browse/RHAIENG-1638 missing rocm package in older AIPCC builds
 # https://issues.redhat.com/browse/AIPCC-5882
 USER 0
-RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs
+RUN dnf --setopt=reposdir=/etc/rhaipcc/repos.d --enablerepo="external-amd-rocm-*" install -y rocm-device-libs && dnf clean all
 USER 1001
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
## Summary

Follow-up to #2462 — clears the **25 remaining** hadolint warnings on workbench Dockerfiles (now **0 findings** locally).

- **SC2016** (6): HEREDOC profile scripts in jupyter/runtime datascience (`91bfe36eb` pattern, keeps `ONNX_VERSION=1.20.1`)
- **SC3046** (8): `source` → `.` in codeserver, trustyai, datascience, runtime datascience
- **DL3040** (10): `&& dnf clean all` after ROCm `rocm-device-libs` installs
- **DL3002** (1): `# hadolint ignore=DL3002` on minimal `pdf-builder` intermediate stage

All applicable fixes mirrored to `Dockerfile.konflux.*` pairs.

## Hadolint impact

| State | Findings |
|-------|----------|
| After #2462 | 25 (0 errors) |
| After this PR | **0** |

## Relation to #2461

With hadolint clean, `code-static-analysis` should pass without the `--failure-threshold error` workaround in #2461.

## Test plan

- [ ] `hadolint --config ci/hadolint-config.yaml` on workbench Dockerfiles → 0 output
- [ ] `code-static-analysis` green on PR

Made with [Cursor](https://cursor.com)