### PR TITLE
[TEST] RHAIENG-5608: Add patch to fix vsce-sign package for CodeServer on PPC64LE builds

### DIFF
--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -65,6 +65,35 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 	source ${NVM_DIR}/nvm.sh
 	while IFS= read -r src_patch; do echo "patches/$src_patch"; patch -p1 < "patches/$src_patch"; done < patches/series
 	nvm use ${NODE_VERSION}
+
+	# ppc64le/s390x: disable @vscode/vsce-sign's postinstall (same fix as prefetch-input/patches/apply-patch.sh on main).
+	# Online build: fetch tarball via npm pack and point the lockfile at the patched file (no cachi2 cache).
+	if [[ "$ARCH" == "ppc64le" || "$ARCH" == "s390x" ]]; then
+		vsceSignVersion=$(jq -r '.packages["node_modules/@vscode/vsce-sign"].version' lib/vscode/build/package-lock.json)
+		if [[ -z "${vsceSignVersion}" || "${vsceSignVersion}" == "null" ]]; then
+			echo "ERROR: failed to read @vscode/vsce-sign version from lib/vscode/build/package-lock.json" >&2
+			exit 1
+		fi
+		patchdir=$(mktemp -d)
+		npm pack "@vscode/vsce-sign@${vsceSignVersion}" --pack-destination="$patchdir"
+		VSCE_TGZ="$patchdir/vscode-vsce-sign-${vsceSignVersion}.tgz"
+		echo "Patching vsce-sign: removing postinstall for ${ARCH} (${VSCE_TGZ})"
+		tmpdir=$(mktemp -d)
+		tar xzf "${VSCE_TGZ}" -C "$tmpdir"
+		jq 'del(.scripts.postinstall)' "$tmpdir/package/package.json" \
+			> /tmp/pkg-tmp.json && mv /tmp/pkg-tmp.json "$tmpdir/package/package.json"
+		tar czf "${VSCE_TGZ}" -C "$tmpdir" package
+		rm -rf "$tmpdir"
+		# Tell npm not to run vsce-sign's postinstall (hasInstallScript=false) and
+		# strip integrity so npm accepts the modified tarball.
+		jq --arg resolved "file:${VSCE_TGZ}" '
+			(.packages["node_modules/@vscode/vsce-sign"].hasInstallScript = false) |
+			(.packages["node_modules/@vscode/vsce-sign"].resolved = $resolved) |
+			del(.packages["node_modules/@vscode/vsce-sign"].integrity)
+		' lib/vscode/build/package-lock.json > /tmp/lock-tmp.json \
+			&& mv /tmp/lock-tmp.json lib/vscode/build/package-lock.json
+	fi
+
 	npm install
 	npm run build
 	VERSION=${CODESERVER_VERSION/v/} npm run build:vscode

--- a/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
+++ b/codeserver/ubi9-python-3.12/get_code_server_rpm.sh
@@ -80,18 +80,20 @@ if [[ "$ARCH" == "amd64" || "$ARCH" == "arm64" ||"$ARCH" == "ppc64le" ]]; then
 		echo "Patching vsce-sign: removing postinstall for ${ARCH} (${VSCE_TGZ})"
 		tmpdir=$(mktemp -d)
 		tar xzf "${VSCE_TGZ}" -C "$tmpdir"
+		pkg_tmp=$(mktemp)
 		jq 'del(.scripts.postinstall)' "$tmpdir/package/package.json" \
-			> /tmp/pkg-tmp.json && mv /tmp/pkg-tmp.json "$tmpdir/package/package.json"
+			> "$pkg_tmp" && mv "$pkg_tmp" "$tmpdir/package/package.json"
 		tar czf "${VSCE_TGZ}" -C "$tmpdir" package
 		rm -rf "$tmpdir"
 		# Tell npm not to run vsce-sign's postinstall (hasInstallScript=false) and
 		# strip integrity so npm accepts the modified tarball.
+		lock_tmp=$(mktemp)
 		jq --arg resolved "file:${VSCE_TGZ}" '
 			(.packages["node_modules/@vscode/vsce-sign"].hasInstallScript = false) |
 			(.packages["node_modules/@vscode/vsce-sign"].resolved = $resolved) |
 			del(.packages["node_modules/@vscode/vsce-sign"].integrity)
-		' lib/vscode/build/package-lock.json > /tmp/lock-tmp.json \
-			&& mv /tmp/lock-tmp.json lib/vscode/build/package-lock.json
+		' lib/vscode/build/package-lock.json > "$lock_tmp" \
+			&& mv "$lock_tmp" lib/vscode/build/package-lock.json
 	fi
 
 	npm install


### PR DESCRIPTION
A test PR for a rebased changes from the #2403 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability on certain architectures by applying an architecture-specific packaging workaround.
  * Reduced installation and release failures by adjusting a dependency so its install-time script is not executed during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->