### PR TITLE
[rhoai-2.25] RHAIENG-6036: fix trustyai k8s papermill probe timing

### DIFF
--- a/jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -36,8 +36,8 @@ spec:
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
           readinessProbe:
@@ -45,8 +45,8 @@ spec:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 15
+            periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
           resources:


### PR DESCRIPTION
## Summary

Align TrustyAI StatefulSet health probes with pytorch (`15/10`) so Elyra/Jupyter can finish starting before liveness kills the pod.

**Problem:** On Build Notebooks k8s papermill (`make_test.py`), the trustyai pod CrashLoopBackOffs: liveness `initialDelaySeconds: 5` probes port 8888 before Jupyter listens (~12s+ with Elyra). Papermill then fails with `container not found ("notebook")`.

Evidence: [#2499 CI run 29087867712](https://github.com/red-hat-data-services/notebooks/actions/runs/29087867712/job/86345881943) — testcontainers **16 passed**; k8s phase failed on probe kills (events captured in `make_test.py` finally dumps).

**Fix:** `jupyter/trustyai/ubi9-python-3.12/kustomize/base/statefulset.yaml` only:
- liveness: `initialDelaySeconds` 5→15, `periodSeconds` 5→10
- readiness: `initialDelaySeconds` 10→15, `periodSeconds` 5→10

Matches `jupyter/pytorch/ubi9-python-3.12/kustomize/base/statefulset.yaml` on `main`. **Not** a `cherry-pick -x` from main trustyai (trustyai statefulset on main still has 5/10).

## Out of scope (already fixed elsewhere)

| Symptom | Fix | Status |
|---------|-----|--------|
| `/opt/app-root/share` 755:0 + spinner | [#2451](https://github.com/red-hat-data-services/notebooks/pull/2451) | [RHAIENG-6041](https://redhat.atlassian.net/browse/RHAIENG-6041) — testcontainers green on tip |
| Papermill CSV 404 | [#2499](https://github.com/red-hat-data-services/notebooks/pull/2499) | Merged |
| Codeserver mysql test | [#2446](https://github.com/red-hat-data-services/notebooks/pull/2446) | [RHAIENG-6039](https://redhat.atlassian.net/browse/RHAIENG-6039) — testcontainers green on tip |
| Codeserver check-payload FIPS | [#2500](https://github.com/red-hat-data-services/notebooks/pull/2500) | Separate PR |

## Test plan

- [ ] `jupyter-trustyai-ubi9-python-3.12` amd64 Build Notebooks: k8s papermill (`make_test.py`) passes
- [ ] Testcontainers phase remains green (unchanged by this PR)

## Local repro

k3s on `100.105.65.25`: Quay trustyai image + #2499 branch — papermill passes with probe 15s patch (`/tmp/test-trustyai-quay-k8s.log`).

[RHAIENG-6041]: https://redhat.atlassian.net/browse/RHAIENG-6041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service health-check timing by increasing liveness and readiness probe initial delays and intervals to better accommodate startup.
  * Preserved existing health-check endpoints, probe methods/targets, and success/failure thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->