### PR TITLE
[2.25] RHAIENG-6036: document same-repo PR workflow for RHDS

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -222,8 +222,9 @@ When contributing to this project:
 4. **Update documentation**
 
 **RHDS (`red-hat-data-services/notebooks`):** Open PRs from branches pushed to
-`red-hat-data-services/notebooks`, not from forks. Fork PRs skip subscription and
-AIPCC registry builds. See [CONTRIBUTING.md](CONTRIBUTING.md#contributing-from-branches-vs-forks).
+`red-hat-data-services/notebooks`, not from forks. Fork PRs still schedule
+subscription and AIPCC registry builds, but those jobs fail without repo secrets.
+See [CONTRIBUTING.md](CONTRIBUTING.md#contributing-from-branches-vs-forks).
 
 For detailed contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/Agents.md
+++ b/Agents.md
@@ -216,10 +216,14 @@ make undeploy9-${NOTEBOOK_NAME} # Cleanup
 
 When contributing to this project:
 
-1. **Fork and branch** from main
+1. **Fork and branch** from main (ODH) or push a same-repo branch (RHDS/RHOAI)
 2. **Write clear commit messages**
 3. **Add tests** for new functionality
 4. **Update documentation**
+
+**RHDS (`red-hat-data-services/notebooks`):** Open PRs from branches pushed to
+`red-hat-data-services/notebooks`, not from forks. Fork PRs skip subscription and
+AIPCC registry builds. See [CONTRIBUTING.md](CONTRIBUTING.md#contributing-from-branches-vs-forks).
 
 For detailed contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,11 @@ git push origin HEAD:<your-initials>/branch-name
 This gives CI full access to build secrets (RHEL subscription, AIPCC registry) and
 uses the org's paid runners with higher concurrency limits.
 
-**Fork PRs:** If you open a PR from a fork, CI will run non-secret checks (code
-quality, ODH image builds) but subscription builds (RHEL, AIPCC) will be skipped.
-A bot will comment with instructions for re-creating the PR from a same-repo branch.
+**Fork PRs:** If you open a PR from a fork, CI still schedules the full build matrix
+(including RHEL and AIPCC subscription targets), but those jobs fail because fork
+workflows cannot access the required secrets. Non-subscription checks (for example
+code quality) may still run. A bot will comment with instructions for re-creating
+the PR from a same-repo branch.
 
 For pull requests against **`red-hat-data-services/notebooks`**, push branches to
 that repository (for example `git push rhds HEAD:fix/my-branch`) and open the PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,26 @@ Pull requests are the best way to propose changes to the notebooks repository:
 - Make sure your code lints.
 - Issue that pull request!
 
+### Contributing from branches vs forks
+
+**Recommended:** If you have write access to the repo, push your branch directly
+and create the PR from there:
+
+```bash
+git push origin HEAD:<your-initials>/branch-name
+```
+
+This gives CI full access to build secrets (RHEL subscription, AIPCC registry) and
+uses the org's paid runners with higher concurrency limits.
+
+**Fork PRs:** If you open a PR from a fork, CI will run non-secret checks (code
+quality, ODH image builds) but subscription builds (RHEL, AIPCC) will be skipped.
+A bot will comment with instructions for re-creating the PR from a same-repo branch.
+
+For pull requests against **`red-hat-data-services/notebooks`**, push branches to
+that repository (for example `git push rhds HEAD:fix/my-branch`) and open the PR
+from a same-repo branch — not from a personal fork.
+
 ### Some basic instructions to create a new notebook
 
 - Decide from which notebook you want to derive the new notebook


### PR DESCRIPTION
## Description

Document same-repo vs fork PR workflow for RHDS contributors:
- Add "Contributing from branches vs forks" to CONTRIBUTING.md (from main)
- Note that PRs against `red-hat-data-services/notebooks` must use branches on rhds, not forks
- Mirror RHDS guidance in Agents.md
- Clarify that fork PRs schedule subscription builds but those jobs fail without secrets (per `build-notebooks-pr.yaml`)

## How Has This Been Tested?

Docs review only; no CI impact expected.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — N/A (docs only)
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work