### PR TITLE
[rhoai-2.25] RHAIENG-6036: skip PDF export on s390x and ppc64le via container_arch

### DIFF
--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -59,7 +59,13 @@ def pytest_addoption(parser: Parser) -> None:
 # https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_generate_tests
 def pytest_generate_tests(metafunc: Metafunc) -> None:
     if image.__name__ in metafunc.fixturenames:
-        metafunc.parametrize(image.__name__, metafunc.config.getoption("--image"))
+        # scope="session" is required here to match the fixture's declared scope.
+        # Without it, metafunc.parametrize defaults to function scope and silently
+        # overrides the fixture scope (https://github.com/pytest-dev/pytest/issues/634),
+        # causing ScopeMismatch for any session-scoped fixture that depends on `image`.
+        image_option = metafunc.config.getoption("--image")
+        assert image_option is not None
+        metafunc.parametrize(image.__name__, image_option, scope="session")
 
 
 def get_image_metadata(image: str) -> Image:

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -125,6 +125,24 @@ def image(request):
     yield request.param
 
 
+@pytest.fixture(scope="session")
+def container_arch(image: str) -> str:
+    """Detect the CPU architecture of the container image. Runs once per session."""
+    container = testcontainers.core.container.DockerContainer(image=image, user=0)
+    container.with_command("/bin/sh -c 'sleep infinity'")
+    known_architectures = {"x86_64", "aarch64", "s390x", "ppc64le"}
+    try:
+        container.start()
+        exit_code, output = container.exec(["uname", "-m"])
+        assert exit_code == 0, f"uname -m failed: {output}"
+        arch = output.decode().strip()
+        if arch not in known_architectures:
+            raise ValueError(f"Unexpected architecture {arch!r}, expected one of {known_architectures}")
+        return arch
+    finally:
+        docker_utils.NotebookContainer(container).stop(timeout=0)
+
+
 @pytest.fixture(scope="function")
 def runtime_image(image: str):
     image_metadata = get_image_metadata(image)

--- a/tests/containers/conftest.py
+++ b/tests/containers/conftest.py
@@ -64,7 +64,7 @@ def pytest_generate_tests(metafunc: Metafunc) -> None:
         # overrides the fixture scope (https://github.com/pytest-dev/pytest/issues/634),
         # causing ScopeMismatch for any session-scoped fixture that depends on `image`.
         image_option = metafunc.config.getoption("--image")
-        assert image_option is not None
+        assert image_option is not None, "--image option must be provided"
         metafunc.parametrize(image.__name__, image_option, scope="session")
 
 

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -56,16 +56,10 @@ class TestJupyterLabImage:
 
     @allure.issue("RHOAIENG-16568")
     @allure.description("Check that PDF export is working correctly")
-    def test_pdf_export(self, jupyterlab_image: conftest.Image) -> None:
+    def test_pdf_export(self, jupyterlab_image: conftest.Image, container_arch: str) -> None:
+        if container_arch in ("s390x", "ppc64le"):
+            pytest.skip(f"PDF export not supported on {container_arch} architecture")
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
-        # Skip if we're running on s390x architecture
-        container.start(wait_for_readiness=False)
-        try:
-            exit_code, arch_output = container.exec(["uname", "-m"])
-            if exit_code == 0 and arch_output.decode().strip() == "s390x":
-                pytest.skip("PDF export functionality is not supported on s390x architecture")
-        finally:
-            docker_utils.NotebookContainer(container).stop(timeout=0)
         test_file_name = "test.ipybn"
         test_file_content = """{
                 "cells": [


### PR DESCRIPTION
## Summary

- Add a `container_arch` session fixture (backported from ODH `main` [#3472](https://github.com/opendatahub-io/notebooks/pull/3472)) that runs `uname -m` once per image under test.
- Refactor `test_pdf_export` to skip on `s390x` and `ppc64le` using that fixture, matching `main`.
- Remove the inline start/stop/uname dance that started a throwaway container before the real test container.

A full `cherry-pick -x` of #3472 does **not** apply cleanly on `rhoai-2.25` (12 files, `BestEffortCleanup`, fixture scoping changes, etc.). This PR carries only the PDF-export/arch-detection slice.

The skip reason is **platform support**, not “unreliable in CI”.

## Test plan

- [ ] `pytest-tests` / pre-commit green
- [ ] `jupyter-minimal-ubi9-python-3.12` ppc64le + s390x matrix jobs skip `test_pdf_export` instead of failing
- [ ] amd64 `test_pdf_export` still runs

## Follow-up

Drop the duplicate PDF-export hunk from #2488 once this merges.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform container testing by detecting supported CPU architectures consistently.
  * PDF export checks now account for architectures where the feature is unavailable, reducing false failures during validation.
  * Enhanced test cleanup ensures temporary containers are stopped reliably after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->