### PR TITLE
[rhoai-2.25] RHAIENG-6036: waive codeserver sandbox-runtime seccomp in check-payload

### DIFF
--- a/scripts/check-payload/config.toml
+++ b/scripts/check-payload/config.toml
@@ -290,6 +290,11 @@ files = [
     "/usr/local/pandoc/bin/pandoc",
     # when code-server is not installed from rpm, the exclusion below won't apply
     "/usr/lib/code-server/lib/vscode/node_modules/@vscode/ripgrep/bin/rg",
+    # @anthropic-ai/sandbox-runtime ships static seccomp helper binaries (not crypto-related)
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/arm64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/x64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/arm64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64/apply-seccomp",
 ]
 dirs = [
     # VS Code 1.112+ @anthropic-ai/sandbox-runtime seccomp BPF loaders (no crypto)
@@ -302,6 +307,10 @@ error = "ErrNotDynLinked"
 files = [
     # executable is not dynamically linked
     "/usr/lib/code-server/lib/vscode/node_modules/@vscode/ripgrep/bin/rg",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/arm64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/x64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/arm64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64/apply-seccomp",
 ]
 dirs = [
     # VS Code 1.112+ @anthropic-ai/sandbox-runtime seccomp BPF loaders (no crypto)


### PR DESCRIPTION
## Summary

Split from #2487/#2488: add check-payload FIPS waivers for `@anthropic-ai/sandbox-runtime` `apply-seccomp` static binaries on codeserver images.

## Test plan

- [ ] `codeserver-ubi9-python-3.12` check-payload green on Build Notebooks matrix

## Related

- #2487 — codeserver mysql skip + trustyai Dockerfile/probes
- #2488 — OCP HTTP wait only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package validation to correctly recognize additional static sandbox helper binaries.
  * Prevented false-positive cryptographic compliance warnings when validating packages that include these binaries.
  * Ensured validation results more accurately reflect the contents of code-server RPM packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->