### PR TITLE
[rhoai-3.4] fix(ci): use on-demand fetch for pylock downgrade baseline

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -45,8 +45,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
-          # Full history so tests/test_pylock_downgrade.py can `git show origin/main:…/pylock.toml`.
-          fetch-depth: 0
 
       - name: Setup uv and Python
         uses: ./.github/actions/setup-uv
@@ -57,6 +55,19 @@ jobs:
       - name: Install deps
         id: install-deps
         run: uv sync --locked
+
+      - name: Fetch downgrade check base ref
+        if: ${{ steps.install-deps.conclusion == 'success' && !cancelled() }}
+        run: |
+          NULL_SHA="0000000000000000000000000000000000000000"
+          BASE_SHA="${PULL_REQUEST_BASE_SHA:-$PUSH_BEFORE_SHA}"
+          if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "$NULL_SHA" ] \
+             && ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --depth=1 origin "$BASE_SHA"
+          fi
+        env:
+          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
 
       - name: Static tests (pytest + Dockerfile alignment)
         run: make test


### PR DESCRIPTION
## Summary
- Remove `fetch-depth: 0` from `pytest-tests` (shallow checkout by default).
- Add a targeted `git fetch --depth=1` for the pylock downgrade baseline (`pull_request.base.sha` or `github.event.before`).
- Skip fetch when `github.event.before` is the all-zeros null SHA on the first push of a new branch.

Implements the release-branch side of [opendatahub-io/notebooks#4051](https://github.com/opendatahub-io/notebooks/issues/4051) for `rhoai-3.4`.

## Test plan
- [ ] Confirm `pytest-tests` passes on a PR against `rhoai-3.4`
- [ ] Confirm first push of a new branch no longer needs full history checkout
- [ ] Confirm `test_pylock_downgrade` still compares against the PR base / previous push tip

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated test workflow reliability by fetching only the required commit history for pull request and push comparisons.
  * Reduced unnecessary repository checkout data during quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->