### PR TITLE
[rhoai-2.25][RHAIENG-6197] fix(datascience): restore Feast on ppc64le/s390x by enabling Arrow S3/Substrait in PyArrow build

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -184,6 +184,8 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
           -DARROW_WITH_LZ4=OFF \
           -DARROW_WITH_ZSTD=OFF \
           -DARROW_WITH_SNAPPY=OFF \
+          -DARROW_S3=ON \
+          -DARROW_SUBSTRAIT=ON \
           -DARROW_BUILD_TESTS=OFF \
           -DARROW_BUILD_BENCHMARKS=OFF \
           ..

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -171,6 +171,9 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
     # fails a checksum mismatch.
     export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
+    # RHAIENG-1643: AWS LC (ARROW_S3) does not support big-endian s390x
+    ARROW_S3_FLAG=""
+    if [ "$TARGETARCH" != "s390x" ]; then ARROW_S3_FLAG="-DARROW_S3=ON"; fi
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/usr/local \
           -DARROW_PYTHON=ON \
@@ -184,7 +187,7 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
           -DARROW_WITH_LZ4=OFF \
           -DARROW_WITH_ZSTD=OFF \
           -DARROW_WITH_SNAPPY=OFF \
-          -DARROW_S3=ON \
+          ${ARROW_S3_FLAG} \
           -DARROW_SUBSTRAIT=ON \
           -DARROW_BUILD_TESTS=OFF \
           -DARROW_BUILD_BENCHMARKS=OFF \


### PR DESCRIPTION
Fixes [RHAIENG-6197](https://redhat.atlassian.net/browse/RHAIENG-6197).

## Problem

On RHOAI 2.25 Data Science images (`quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9:rhoai-2.25`), Feast is installed but broken on **ppc64le** and **s390x**:

```
ModuleNotFoundError: No module named 'pyarrow._s3fs'
```

Root cause: on Power/Z, PyArrow is source-built in `Dockerfile.konflux.cpu` without S3/Substrait enabled. On amd64/arm64, prebuilt wheels already include those modules.

## Fix

Cherry-pick for `rhoai-2.25` of the Konflux-side PyArrow build fix originally merged to `main` in #1630 (upstream: opendatahub-io/notebooks#2570), plus the **[RHAIENG-1643](https://redhat.atlassian.net/browse/RHAIENG-1643)** s390x guard from #1666.

In the `pyarrow-builder` stage (`ppc64le` + `s390x`):

- **ppc64le:** `-DARROW_S3=ON` and `-DARROW_SUBSTRAIT=ON`
- **s390x:** `-DARROW_SUBSTRAIT=ON` only — `ARROW_S3` is skipped because AWS LC fails on big-endian (`CMake Error: Big Endian is not supported`)

## s390x limitation

Feast `_s3fs` / full S3 offline-store paths **cannot** be enabled on s390x with pyarrow 17 + AWS LC. This PR restores Substrait on Z and full Feast/pyarrow._s3fs support on **ppc64le**. Documented per Puneet's review and [RHAIENG-1643](https://redhat.atlassian.net/browse/RHAIENG-1643).

## Scope

Only `jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu`.

## Test plan

- [ ] `/build-konflux` for datascience on `ppc64le` and `s390x`
- [ ] **ppc64le:** `python -c "from pyarrow._s3fs import S3FileSystem"` and `feast version`
- [ ] **s390x:** build succeeds; `feast version` (Substrait enabled; `_s3fs` still absent)

[RHAIENG-6197]: https://redhat.atlassian.net/browse/RHAIENG-6197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-1643]: https://redhat.atlassian.net/browse/RHAIENG-1643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-1643]: https://redhat.atlassian.net/browse/RHAIENG-1643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build compatibility for the Python data science environment across supported CPU architectures.
  - Enabled Substrait support to improve interoperability with data processing tools and workflows.
  - Added S3 functionality on compatible architectures while preserving reliable builds on s390x.
  - Improved consistency when configuring data processing and storage integrations across platform variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->