### PR TITLE
[rhoai-2.25] RHAIENG-6197: enable Arrow S3/Substrait in runtime datascience pyarrow builds

### DIFF
--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -176,6 +176,9 @@ if [ "$TARGETARCH" = "s390x" ]; then
     # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
     # fails a checksum mismatch.
     export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
+    # RHAIENG-1643: AWS LC (ARROW_S3) does not support big-endian s390x
+    ARROW_S3_FLAG=""
+    if [ "$TARGETARCH" != "s390x" ]; then ARROW_S3_FLAG="-DARROW_S3=ON"; fi
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
           -DARROW_PYTHON=ON \
@@ -191,6 +194,8 @@ if [ "$TARGETARCH" = "s390x" ]; then
           -DARROW_S3=OFF \
           -DARROW_WITH_BZ2=ON \
           -DARROW_WITH_ZLIB=ON \
+          ${ARROW_S3_FLAG} \
+          -DARROW_SUBSTRAIT=ON \
           -DARROW_BUILD_TESTS=OFF \
           -DARROW_BUILD_BENCHMARKS=OFF \
           -DARROW_USE_CCACHE=OFF \
@@ -335,6 +340,8 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
         -DARROW_CSV=ON \
         -DARROW_PYTHON=ON \
         -DARROW_PARQUET=ON \
+        -DARROW_S3=ON \
+        -DARROW_SUBSTRAIT=ON \
         -DARROW_BUILD_SHARED=ON \
         -DARROW_BUILD_TESTS=OFF
     cd cpp/build


### PR DESCRIPTION
Complements #2503 for [RHAIENG-6197](https://redhat.atlassian.net/browse/RHAIENG-6197).

## Summary

Enables Arrow S3 + Substrait in **pipeline runtime datascience** source-built PyArrow (ppc64le/s390x cmake blocks).

Rebased onto current `rhoai-2.25`. **Codeserver** no longer uses `devel_env_setup.sh` on this branch (pyarrow comes from prebuilt RHAI wheels); that file was dropped during rebase.

## CMake flags

| Arch | ARROW_S3 | ARROW_SUBSTRAIT |
|------|----------|-----------------|
| **ppc64le** | ON | ON |
| **s390x** | OFF ([RHAIENG-1643](https://redhat.atlassian.net/browse/RHAIENG-1643): AWS LC / big-endian) | ON |

## Files changed

- `runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu`
- `runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu`

## Test plan

- [ ] `/build-konflux` for `runtime-datascience` on `ppc64le` and `s390x`
- [ ] **ppc64le:** `python -c "from pyarrow._s3fs import S3FileSystem"` and `feast version`
- [ ] **s390x:** build succeeds; Substrait enabled (`_s3fs` still absent on Z)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved architecture-specific build support for s390x and ppc64le environments.
  * Adjusted Arrow features to ensure compatible S3 and Substrait functionality across supported architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHAIENG-6197]: https://redhat.atlassian.net/browse/RHAIENG-6197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-1643]: https://redhat.atlassian.net/browse/RHAIENG-1643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ