### PR TITLE
[rhoai-2.25] fix(build): derive native ONNX/pyarrow versions from pylock.toml

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -46,6 +46,9 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER root
 ARG TARGETARCH
+ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
+COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml /tmp/pylock.toml
+COPY scripts/pylock_version.py /tmp/pylock_version.py
 
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
@@ -142,11 +145,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform "$TARGETARCH")
+    # pylock_version prints raw PEP 440; git tags need apache-arrow- prefix (no +local segment today).
+    ARROW_BRANCH="apache-arrow-${PYARROW_VERSION}"
     # Install build dependencies (shared for pyarrow and onnx)
     dnf install -y cmake make gcc-c++ pybind11-devel wget
     dnf clean all
     # Build and collect pyarrow wheel
-    git clone --depth 1 --branch "apache-arrow-17.0.0" https://github.com/apache/arrow.git
+    git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git
     cd arrow/cpp
     mkdir release && cd release
     # ORC 2.0.1 was removed from downloads.apache.org; archive mirror has the expected tarball hash
@@ -214,17 +220,19 @@ EOF
 #######################################################
 FROM common-builder AS onnx-builder
 ARG TARGETARCH
-ARG ONNX_VERSION=v1.20.1
 WORKDIR /root
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
+    ONNX_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml onnx --platform ppc64le)
+    # pylock_version prints raw PEP 440; ONNX git tags use v prefix (no +local segment today).
+    ONNX_TAG="v${ONNX_VERSION}"
     source /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx
-    git checkout ${ONNX_VERSION}
+    git checkout "${ONNX_TAG}"
     git submodule update --init --recursive
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -46,6 +46,9 @@ WORKDIR /opt/app-root/bin
 # OS Packages needs to be installed as root
 USER root
 ARG TARGETARCH
+ARG DATASCIENCE_SOURCE_CODE=jupyter/datascience/ubi9-python-3.12
+COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml /tmp/pylock.toml
+COPY scripts/pylock_version.py /tmp/pylock_version.py
 
 # Inject the official UBI 9 repository configuration into the AIPCC base image.
 # The Quay-based AIPCC image is "repo-less" by default (https://gitlab.com/redhat/rhel-ai/core/base-images/app#repositories), so dnf cannot upgrade or install packages.
@@ -142,11 +145,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform "$TARGETARCH")
+    ARROW_BRANCH="apache-arrow-${PYARROW_VERSION}"
     # Install build dependencies (shared for pyarrow and onnx)
     dnf install -y cmake make gcc-c++ pybind11-devel wget
     dnf clean all
     # Build and collect pyarrow wheel
-    git clone --depth 1 --branch "apache-arrow-17.0.0" https://github.com/apache/arrow.git
+    git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git
     cd arrow/cpp
     mkdir release && cd release
     # ORC 2.0.1 was removed from downloads.apache.org; archive mirror has the expected tarball hash
@@ -214,17 +219,18 @@ EOF
 #######################################################
 FROM common-builder AS onnx-builder
 ARG TARGETARCH
-ARG ONNX_VERSION=v1.20.1
 WORKDIR /root
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "${TARGETARCH}" = "ppc64le" ]; then
+    ONNX_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml onnx --platform ppc64le)
+    ONNX_TAG="v${ONNX_VERSION}"
     source /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx
-    git checkout ${ONNX_VERSION}
+    git checkout "${ONNX_TAG}"
     git submodule update --init --recursive
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS
     pip wheel . -w /root/onnx_wheel

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -33,6 +33,7 @@ ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
+COPY scripts/pylock_version.py ./pylock_version.py
 
 RUN --mount=type=cache,target=/root/.cache/uv /bin/bash <<'EOF'
 set -Eeuxo pipefail

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -33,6 +33,7 @@ ARG TRUSTYAI_SOURCE_CODE=jupyter/trustyai/ubi9-python-3.12
 COPY ${TRUSTYAI_SOURCE_CODE}/pylock.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/pyproject.toml .
 COPY ${TRUSTYAI_SOURCE_CODE}/devel_env_setup.sh .
+COPY scripts/pylock_version.py ./pylock_version.py
 
 RUN --mount=type=cache,target=/root/.cache/uv /bin/bash <<'EOF'
 set -Eeuxo pipefail

--- a/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
+++ b/jupyter/trustyai/ubi9-python-3.12/devel_env_setup.sh
@@ -7,7 +7,7 @@ set -eoux pipefail
 # OpenBlas is built from source (instead of distro provided) with recommended flags for performance #
 #####################################################################################################
 WHEELS_DIR=/wheelsdir
-mkdir -p ${WHEELS_DIR}
+mkdir -p "${WHEELS_DIR}"
 if [[ $(uname -m) == "ppc64le" ]]; then
     CURDIR=$(pwd)
 
@@ -20,7 +20,7 @@ if [[ $(uname -m) == "ppc64le" ]]; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
     source /opt/rh/gcc-toolset-13/enable
-    source $HOME/.cargo/env
+    source "$HOME/.cargo/env"
     
     uv pip install cmake
 
@@ -30,16 +30,17 @@ if [[ $(uname -m) == "ppc64le" ]]; then
     # Install OpenBlas
     # IMPORTANT: Ensure Openblas is installed in the final image
     cd /root
-    curl -L https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz | tar xz
+    curl -L "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.tar.gz" | tar xz
     # rename directory for mounting (without knowing version numbers) in multistage builds
-    mv OpenBLAS-${OPENBLAS_VERSION}/ OpenBLAS/
+    openblas_src="OpenBLAS-${OPENBLAS_VERSION}"
+    mv "${openblas_src}/" OpenBLAS/
     cd OpenBLAS/
-    make -j${MAX_JOBS} TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
+    make -j"${MAX_JOBS}" TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0
     make install
     cd ..
 
     # set path for openblas
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/OpenBLAS/lib/:/usr/local/lib64:/usr/local/lib
+    export LD_LIBRARY_PATH="/opt/OpenBLAS/lib/:/usr/local/lib64:/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     export PKG_CONFIG_PATH=$(find / -type d -name "pkgconfig" 2>/dev/null | tr '\n' ':')
     export CMAKE_ARGS="-DPython3_EXECUTABLE=python"
     export CMAKE_POLICY_VERSION_MINIMUM=3.5
@@ -47,23 +48,27 @@ if [[ $(uname -m) == "ppc64le" ]]; then
     TMP=$(mktemp -d)
 
     # Torch
-    cd ${CURDIR}
-    TORCH_VERSION=$(grep -A1 '"torch"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
-    cd ${TMP}
-    git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION}
+    cd "${CURDIR}"
+    # torch is pinned under x86_64 markers; we build the same version from source on ppc64le
+    TORCH_VERSION=$(python3 ./pylock_version.py torch --platform x86_64)
+    # Drop PEP 440 local segment (+cu128) for git tag; pre-releases (1.0a1) are unchanged.
+    TORCH_VERSION=${TORCH_VERSION%%+*}
+    TORCH_TAG="v${TORCH_VERSION}"
+    cd "${TMP}"
+    git clone --recursive https://github.com/pytorch/pytorch.git -b "${TORCH_TAG}"
     cd pytorch
     # lintrunner's sdist pyproject.toml is non-compliant with PEP 621; skip it (dev-only dep)
     grep -v '^lintrunner' requirements.txt | uv pip install -r /dev/stdin
     python setup.py develop
     rm -f dist/torch*+git*whl
     MAX_JOBS=${MAX_JOBS:-$(nproc)} \
-        PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 uv build --wheel --out-dir ${WHEELS_DIR}
+        PYTORCH_BUILD_VERSION="${TORCH_VERSION}" PYTORCH_BUILD_NUMBER=1 uv build --wheel --out-dir "${WHEELS_DIR}"
 
-    cd ${CURDIR}
+    cd "${CURDIR}"
     # Pyarrow
-    PYARROW_VERSION=$(grep -A1 '"pyarrow"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
-    cd ${TMP}
-    git clone --recursive https://github.com/apache/arrow.git -b apache-arrow-${PYARROW_VERSION}
+    PYARROW_VERSION=$(python3 ./pylock_version.py pyarrow --platform ppc64le)
+    cd "${TMP}"
+    git clone --recursive https://github.com/apache/arrow.git -b "apache-arrow-${PYARROW_VERSION}"
     cd arrow/cpp
     mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=release \
@@ -74,34 +79,36 @@ if [[ $(uname -m) == "ppc64le" ]]; then
         -DARROW_BUILD_STATIC="OFF" \
         -DARROW_PARQUET=ON \
         .. && \
-    make install -j ${MAX_JOBS:-$(nproc)} && \
+    make install -j "${MAX_JOBS:-$(nproc)}" && \
     cd ../../python/ && \
     uv pip install -v -r requirements-wheel-build.txt && \
     PYARROW_PARALLEL=${PYARROW_PARALLEL:-$(nproc)} \
     python setup.py build_ext \
     --build-type=release --bundle-arrow-cpp \
-    bdist_wheel --dist-dir ${WHEELS_DIR}
+    bdist_wheel --dist-dir "${WHEELS_DIR}"
 
     # Pillow (use auditwheel repaired wheel to avoid pulling runtime libs from EPEL)
-    cd ${CURDIR}
-    PILLOW_VERSION=$(grep -A1 '"pillow"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
-    cd ${TMP}
-    git clone --recursive https://github.com/python-pillow/Pillow.git -b ${PILLOW_VERSION}
+    cd "${CURDIR}"
+    PILLOW_VERSION=$(python3 ./pylock_version.py pillow --platform ppc64le)
+    cd "${TMP}"
+    git clone --recursive https://github.com/python-pillow/Pillow.git -b "${PILLOW_VERSION}"
     cd Pillow
     uv build --wheel --out-dir /pillowwheel
     : ================= Fix Pillow Wheel ====================
     cd /pillowwheel
     uv pip install auditwheel
     auditwheel repair pillow*.whl
-    mv wheelhouse/pillow*.whl ${WHEELS_DIR}
+    mv wheelhouse/pillow*.whl "${WHEELS_DIR}"
 
-    ls -ltr ${WHEELS_DIR}
+    ls -ltr "${WHEELS_DIR}"
 
-    cd ${CURDIR}
-    uv pip install --refresh ${WHEELS_DIR}/*.whl accelerate==$(grep -A1 '"accelerate"' pylock.toml | grep -Eo '\b[0-9\.]+\b')
+    cd "${CURDIR}"
+    # accelerate is pinned under x86_64 markers; install the same version on ppc64le
+    ACCELERATE_VERSION=$(python3 ./pylock_version.py accelerate --platform x86_64)
+    uv pip install --refresh "${WHEELS_DIR}"/*.whl "accelerate==${ACCELERATE_VERSION}"
 
     uv pip list
-    cd ${CURDIR}
+    cd "${CURDIR}"
 else
     # only for mounting on non-ppc64le
     mkdir -p /root/OpenBLAS/

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,8 @@
 addopts = --strict-markers --capture=no --tb=short
 
 # pytest-subtest plugin is built-in since pytest 9.0: https://docs.pytest.org/en/stable/how-to/subtests.html
+# 0 = suppress SUBPASSED noise; raise to 1 (or -o verbosity_subtests=1) when debugging large iterables.
+verbosity_subtests = 0
 required_plugins =
 
 junit_logging = all

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -12,6 +12,9 @@ FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
 FROM ${BASE_IMAGE} AS cpu-base
 
 ARG TARGETARCH
+ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.12
+COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml /tmp/pylock.toml
+COPY scripts/pylock_version.py /tmp/pylock_version.py
 
 WORKDIR /opt/app-root/bin
 
@@ -58,13 +61,17 @@ EOF
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
+if [ "$TARGETARCH" = "ppc64le" ]; then
+    ONNX_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml onnx --platform ppc64le)
+    PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform ppc64le)
+    # NB: unquoted heredoc — escape $ for vars that must expand at login
+    cat > /etc/profile.d/ppc64le.sh <<PROFILE_EOF
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
-export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.1
-export PYARROW_VERSION=17.0.0
-export PATH="$HOME/.cargo/bin:$PATH"
+export ONNX_VERSION=${ONNX_VERSION}
+export PYARROW_VERSION=${PYARROW_VERSION}
+export PATH="\$HOME/.cargo/bin:\$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 PROFILE_EOF
 fi
@@ -130,26 +137,17 @@ ARG TARGETARCH
 USER 0
 WORKDIR /tmp/build-wheels
 
-# Set pyarrow version for s390x
-RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-if [ "$TARGETARCH" = "s390x" ]; then
-    echo 'export PYARROW_VERSION=17.0.0' >> /etc/profile.d/s390x.sh
-fi
-EOF
-
 # Build pyarrow optimized for s390x
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
+    PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform s390x)
     # Install build dependencies
     dnf install -y cmake make gcc-c++ pybind11-devel wget git \
         openssl-devel zlib-devel bzip2-devel lz4-devel \
         ninja-build
     dnf clean all
-    # Source the environment variables
-    source /etc/profile.d/s390x.sh
     # Clone specific version of arrow
     git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git
     cd arrow
@@ -249,18 +247,18 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.1
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ]; then
+    source /etc/profile.d/ppc64le.sh
     source /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
-    cd onnx && git checkout v${ONNX_VERSION}
+    cd onnx && git checkout "v${ONNX_VERSION}"
     git submodule update --init --recursive
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS
     pip wheel . -w /onnx_wheels
@@ -280,13 +278,13 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV PYARROW_VERSION=17.0.0
 
 RUN echo "arrow-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ]; then
+    source /etc/profile.d/ppc64le.sh
     git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive
     cd arrow && rm -rf .git && mkdir dist
     pip3 install --no-cache-dir -r python/requirements-build.txt

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -12,6 +12,9 @@ FROM registry.access.redhat.com/ubi9/ubi AS ubi-repos
 FROM ${BASE_IMAGE} AS cpu-base
 
 ARG TARGETARCH
+ARG DATASCIENCE_SOURCE_CODE=runtimes/datascience/ubi9-python-3.12
+COPY ${DATASCIENCE_SOURCE_CODE}/pylock.toml /tmp/pylock.toml
+COPY scripts/pylock_version.py /tmp/pylock_version.py
 
 WORKDIR /opt/app-root/bin
 
@@ -58,13 +61,17 @@ EOF
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFILE_EOF'
+if [ "$TARGETARCH" = "ppc64le" ]; then
+    ONNX_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml onnx --platform ppc64le)
+    PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform ppc64le)
+    # NB: unquoted heredoc — escape $ for vars that must expand at login
+    cat > /etc/profile.d/ppc64le.sh <<PROFILE_EOF
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
-export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.1
-export PYARROW_VERSION=17.0.0
-export PATH="$HOME/.cargo/bin:$PATH"
+export ONNX_VERSION=${ONNX_VERSION}
+export PYARROW_VERSION=${PYARROW_VERSION}
+export PATH="\$HOME/.cargo/bin:\$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 PROFILE_EOF
 fi
@@ -130,26 +137,17 @@ ARG TARGETARCH
 USER 0
 WORKDIR /tmp/build-wheels
 
-# Set pyarrow version for s390x
-RUN /bin/bash <<'EOF'
-set -Eeuxo pipefail
-if [ "$TARGETARCH" = "s390x" ]; then
-    echo 'export PYARROW_VERSION=17.0.0' >> /etc/profile.d/s390x.sh
-fi
-EOF
-
 # Build pyarrow optimized for s390x
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
+    PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform s390x)
     # Install build dependencies
     dnf install -y cmake make gcc-c++ pybind11-devel wget git \
         openssl-devel zlib-devel bzip2-devel lz4-devel \
         ninja-build
     dnf clean all
-    # Source the environment variables
-    source /etc/profile.d/s390x.sh
     # Clone specific version of arrow
     git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git
     cd arrow
@@ -249,18 +247,18 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.1
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ]; then
+    source /etc/profile.d/ppc64le.sh
     source /opt/rh/gcc-toolset-13/enable
     git clone --recursive https://github.com/onnx/onnx.git
-    cd onnx && git checkout v${ONNX_VERSION}
+    cd onnx && git checkout "v${ONNX_VERSION}"
     git submodule update --init --recursive
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS
     pip wheel . -w /onnx_wheels
@@ -280,13 +278,13 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV PYARROW_VERSION=17.0.0
 
 RUN echo "arrow-builder stage TARGETARCH: ${TARGETARCH}"
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ]; then
+    source /etc/profile.d/ppc64le.sh
     git clone -b apache-arrow-${PYARROW_VERSION} https://github.com/apache/arrow.git --recursive
     cd arrow && rm -rf .git && mkdir dist
     pip3 install --no-cache-dir -r python/requirements-build.txt

--- a/scripts/pylock_version.py
+++ b/scripts/pylock_version.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Read pinned package versions from pylock.toml for native image builds.
+
+Marker evaluation
+-----------------
+:func:`evaluate_marker` parses PEP 508-style markers with :mod:`ast` and evaluates
+them against a restricted whitelist of environment keys (:func:`marker_env`). It
+supports nested ``and`` / ``or`` / ``not``, parentheses, ``in`` / ``not in`` tuple
+literals, and ``==`` / ``!=`` with ``.*`` wildcards via :func:`fnmatch.fnmatchcase`.
+
+Version-specifier operators (``>=``, ``~=``, etc.) and unknown marker variables
+raise :class:`ValueError` instead of silently mis-parsing.
+
+Callers format output in shell: ``v${VERSION}`` or ``apache-arrow-${VERSION}`` for git
+branches. When the lock carries a local segment (e.g. torch ``2.7.1+cu128``), strip
+only the ``+…`` suffix (``${VERSION%%+*}``) before tagging — that removes local
+versions but not pre-releases (``1.0a1`` stays ``1.0a1``). Current native-build
+pins are plain releases, so this is sufficient today.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import platform
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_PYLOCK = Path("pylock.toml")
+_ALLOWED_NAMES = frozenset(
+    {
+        "python_version",
+        "python_full_version",
+        "implementation_name",
+        "platform_python_implementation",
+        "sys_platform",
+        "platform_machine",
+        "platform_system",
+        "os_name",
+    }
+)
+
+
+def default_pylock_path() -> Path:
+    if _DEFAULT_PYLOCK.is_file():
+        return _DEFAULT_PYLOCK
+    raise FileNotFoundError(f"{_DEFAULT_PYLOCK} not found in {Path.cwd()}")
+
+
+def python_minor_from_path(pylock_path: Path) -> str:
+    match = re.search(r"python-(\d+\.\d+)", pylock_path.as_posix())
+    return match.group(1) if match else "3.12"
+
+
+def marker_env(*, python_minor: str, platform_machine: str) -> dict[str, str]:
+    return {
+        "python_full_version": f"{python_minor}.0",
+        "python_version": python_minor,
+        "implementation_name": "cpython",
+        "platform_python_implementation": platform.python_implementation(),
+        "sys_platform": "linux",
+        "platform_machine": platform_machine,
+        "platform_system": "Linux",
+        "os_name": "posix",
+    }
+
+
+def _eval_marker(node: ast.AST, env: dict[str, str]) -> bool | str | tuple[str, ...]:
+    match node:
+        case ast.Expression(body):
+            return _eval_marker(body, env)
+
+        case ast.BoolOp(op=ast.And(), values=values):
+            return all(_eval_marker(value, env) for value in values)
+        case ast.BoolOp(op=ast.Or(), values=values):
+            return any(_eval_marker(value, env) for value in values)
+
+        case ast.UnaryOp(op=ast.Not(), operand=operand):
+            return not _eval_marker(operand, env)
+
+        case ast.Compare(left=left, ops=[op], comparators=[right]):
+            left_value = _eval_marker(left, env)
+            right_value = _eval_marker(right, env)
+
+            match op:
+                case ast.Eq():
+                    if isinstance(right_value, str) and right_value.endswith(".*"):
+                        return fnmatch.fnmatchcase(left_value, right_value)
+                    return left_value == right_value
+                case ast.NotEq():
+                    if isinstance(right_value, str) and right_value.endswith(".*"):
+                        return not fnmatch.fnmatchcase(left_value, right_value)
+                    return left_value != right_value
+                case ast.In():
+                    if not isinstance(right_value, tuple):
+                        raise ValueError("'in' requires a tuple literal")
+                    return left_value in right_value
+                case ast.NotIn():
+                    if not isinstance(right_value, tuple):
+                        raise ValueError("'not in' requires a tuple literal")
+                    return left_value not in right_value
+                case _:
+                    raise ValueError(f"comparison operator not supported: {op}")
+
+        case ast.Name(id=name):
+            if name not in _ALLOWED_NAMES:
+                raise ValueError(f"unknown marker variable: {name}")
+            return env.get(name, "")
+
+        case ast.Constant(value=str(string_value)):
+            return string_value
+
+        case ast.Tuple(elts=elts):
+            return tuple(_eval_marker(elt, env) for elt in elts)
+
+        case _:
+            raise ValueError(f"unsupported syntax: {ast.dump(node)}")
+
+
+def evaluate_marker(marker: str, env: dict[str, str]) -> bool:
+    """Return whether *marker* matches *env*."""
+    try:
+        tree = ast.parse(marker, mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(f"invalid marker syntax: {marker!r}") from exc
+    result = _eval_marker(tree, env)
+    if not isinstance(result, bool):
+        raise ValueError(f"marker must evaluate to bool, got {result!r}: {marker!r}")
+    return result
+
+
+def load_pylock_packages(pylock_text: str, *, python_minor: str, platform_machine: str) -> dict[str, dict[str, Any]]:
+    doc = tomllib.loads(pylock_text)
+    env = marker_env(python_minor=python_minor, platform_machine=platform_machine)
+    packages: dict[str, dict[str, Any]] = {}
+    for entry in doc.get("packages", []):
+        marker = entry.get("marker")
+        if marker and not evaluate_marker(marker, env):
+            continue
+        name = entry["name"]
+        if name in packages:
+            raise ValueError(f"duplicate package in lockfile: {name}")
+        packages[name] = entry
+    return packages
+
+
+def locked_version(
+    pylock_path: Path,
+    package: str,
+    *,
+    python_minor: str | None = None,
+    platform_machine: str = "x86_64",
+) -> str:
+    resolved_python = python_minor or python_minor_from_path(pylock_path)
+    packages = load_pylock_packages(
+        pylock_path.read_text(),
+        python_minor=resolved_python,
+        platform_machine=platform_machine,
+    )
+    if package not in packages:
+        raise LookupError(
+            f"package {package!r} not found in {pylock_path} "
+            f"for platform_machine={platform_machine!r} python={resolved_python!r}"
+        )
+    return packages[package]["version"]
+
+
+def _parse_args(argv: list[str] | None) -> tuple[Path, str, str | None, str | None]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "positional",
+        nargs="+",
+        metavar="ARG",
+        help="PACKAGE, or PYLOCK PACKAGE when pylock.toml is not in the cwd",
+    )
+    parser.add_argument("--platform", help="platform_machine for marker evaluation (default: runtime machine)")
+    parser.add_argument("--python", dest="python_minor", help="Python minor version for marker evaluation")
+    args = parser.parse_args(argv)
+
+    match len(args.positional):
+        case 1:
+            pylock_path = default_pylock_path()
+            package = args.positional[0]
+        case 2:
+            pylock_path = Path(args.positional[0])
+            package = args.positional[1]
+        case _:
+            parser.error("expected PACKAGE or PYLOCK PACKAGE")
+
+    return pylock_path, package, args.python_minor, args.platform
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        pylock_path, package, python_minor, platform_machine = _parse_args(argv)
+        version = locked_version(
+            pylock_path,
+            package,
+            python_minor=python_minor,
+            platform_machine=platform_machine or platform.machine(),
+        )
+    except (FileNotFoundError, LookupError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1868,7 +1868,9 @@ rules:
       Remediation: Always quote variables in file operations:
         rm "$FILE"         # correct
         rm $FILE           # dangerous
-    pattern-regex: '(rm|cp|mv|eval|chmod|chown|kill|pkill)\s+[^|;]*(?<!["''\\])\$(?:\{[A-Za-z_][A-Za-z0-9_]*(?:[:\-\+\?=][^}]*)?\}|[A-Za-z_][A-Za-z0-9_]*)'
+    # Word boundaries avoid matching substrings (e.g. "rm" in "--platform").
+    # [^\n|;&]* keeps the match on one logical command (stops at |, ||, ;, &, &&).
+    pattern-regex: '(?<![\w-])(rm|cp|mv|eval|chmod|chown|kill|pkill)(?![\w-])[ \t]+[^\n|;&]*(?<!["''\\])\$(?:\{[A-Za-z_][A-Za-z0-9_]*(?:[:\-\+\?=][^}]*)?\}|[A-Za-z_][A-Za-z0-9_]*)'
     metadata:
       cwe: "CWE-78"
       category: "security"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,20 @@
 from __future__ import annotations
 
+import importlib.util
 import logging
+from pathlib import Path
+
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+@pytest.fixture(scope="session")
+def pylock_version():
+    spec = importlib.util.spec_from_file_location("pylock_version", _SCRIPTS / "pylock_version.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_native_build_versions.py
+++ b/tests/test_native_build_versions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+NATIVE_IMAGE_DIRS = (
+    ROOT / "jupyter/datascience/ubi9-python-3.12",
+    ROOT / "runtimes/datascience/ubi9-python-3.12",
+)
+
+
+@pytest.mark.parametrize("image_dir", NATIVE_IMAGE_DIRS, ids=lambda p: p.relative_to(ROOT).as_posix())
+def test_dockerfiles_read_native_versions_from_pylock(image_dir: Path) -> None:
+    dockerfiles = sorted(image_dir.glob("Dockerfile*"))
+    assert dockerfiles, f"no Dockerfiles under {image_dir}"
+    forbidden = (
+        re.compile(r"ARG ONNX_VERSION"),
+        re.compile(r"ARG PYARROW_VERSION"),
+        re.compile(r"ONNX_VERSION=1\.20\.1"),
+        re.compile(r"apache-arrow-17\.0\.0"),
+    )
+    for dockerfile in dockerfiles:
+        text = dockerfile.read_text()
+        for pattern in forbidden:
+            assert not pattern.search(text), f"{dockerfile.name} still uses {pattern.pattern}"
+        assert "pylock_version.py" in text, f"{dockerfile.name} should copy pylock_version.py"
+        for package in ("onnx", "pyarrow"):
+            # Same-line resolver only: [ \t]+ (not \s+) so newlines cannot join unrelated tokens.
+            lookup = re.compile(rf"\bpylock_version\.py[ \t]+(?:[^\s\n]+[ \t]+)?{re.escape(package)}\b")
+            assert lookup.search(text), f"{dockerfile.name} should resolve {package} via pylock_version.py"
+
+
+@pytest.mark.parametrize("image_dir", NATIVE_IMAGE_DIRS, ids=lambda p: p.relative_to(ROOT).as_posix())
+def test_pylock_pins_resolve_for_native_arches(image_dir: Path, pylock_version) -> None:
+    pylock = image_dir / "pylock.toml"
+    locked_version = pylock_version.locked_version
+    # Resolve per-arch independently; versions may diverge across arches in future lockfiles.
+    assert locked_version(pylock, "onnx", platform_machine="ppc64le"), "onnx should resolve for ppc64le"
+    assert locked_version(pylock, "pyarrow", platform_machine="ppc64le"), "pyarrow should resolve for ppc64le"
+    assert locked_version(pylock, "pyarrow", platform_machine="s390x"), "pyarrow should resolve for s390x"

--- a/tests/test_native_build_versions.py
+++ b/tests/test_native_build_versions.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+from tests.with_subtests import with_subtests
+
+if TYPE_CHECKING:
+    from pytest import Subtests
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -14,7 +20,7 @@ NATIVE_IMAGE_DIRS = (
 
 
 @pytest.mark.parametrize("image_dir", NATIVE_IMAGE_DIRS, ids=lambda p: p.relative_to(ROOT).as_posix())
-def test_dockerfiles_read_native_versions_from_pylock(image_dir: Path) -> None:
+def test_dockerfiles_read_native_versions_from_pylock(image_dir: Path, subtests: Subtests) -> None:
     dockerfiles = sorted(image_dir.glob("Dockerfile*"))
     assert dockerfiles, f"no Dockerfiles under {image_dir}"
     forbidden = (
@@ -23,22 +29,42 @@ def test_dockerfiles_read_native_versions_from_pylock(image_dir: Path) -> None:
         re.compile(r"ONNX_VERSION=1\.20\.1"),
         re.compile(r"apache-arrow-17\.0\.0"),
     )
-    for dockerfile in dockerfiles:
+
+    @with_subtests(subtests, dockerfiles, msg="dockerfile")
+    def _(dockerfile: Path) -> None:
         text = dockerfile.read_text()
-        for pattern in forbidden:
+
+        @with_subtests(subtests, forbidden, msg="forbidden-pattern")
+        def _(pattern: re.Pattern[str]) -> None:
             assert not pattern.search(text), f"{dockerfile.name} still uses {pattern.pattern}"
+
         assert "pylock_version.py" in text, f"{dockerfile.name} should copy pylock_version.py"
-        for package in ("onnx", "pyarrow"):
+
+        @with_subtests(subtests, ("onnx", "pyarrow"), msg="package")
+        def _(package: str) -> None:
             # Same-line resolver only: [ \t]+ (not \s+) so newlines cannot join unrelated tokens.
             lookup = re.compile(rf"\bpylock_version\.py[ \t]+(?:[^\s\n]+[ \t]+)?{re.escape(package)}\b")
             assert lookup.search(text), f"{dockerfile.name} should resolve {package} via pylock_version.py"
 
 
 @pytest.mark.parametrize("image_dir", NATIVE_IMAGE_DIRS, ids=lambda p: p.relative_to(ROOT).as_posix())
-def test_pylock_pins_resolve_for_native_arches(image_dir: Path, pylock_version) -> None:
+def test_pylock_pins_resolve_for_native_arches(
+    image_dir: Path,
+    pylock_version,
+    subtests: Subtests,
+) -> None:
     pylock = image_dir / "pylock.toml"
     locked_version = pylock_version.locked_version
     # Resolve per-arch independently; versions may diverge across arches in future lockfiles.
-    assert locked_version(pylock, "onnx", platform_machine="ppc64le"), "onnx should resolve for ppc64le"
-    assert locked_version(pylock, "pyarrow", platform_machine="ppc64le"), "pyarrow should resolve for ppc64le"
-    assert locked_version(pylock, "pyarrow", platform_machine="s390x"), "pyarrow should resolve for s390x"
+    cases = (
+        ("onnx", "ppc64le"),
+        ("pyarrow", "ppc64le"),
+        ("pyarrow", "s390x"),
+    )
+
+    @with_subtests(subtests, cases, msg="pylock-pin")
+    def _(case: tuple[str, str]) -> None:
+        package, platform_machine = case
+        assert locked_version(pylock, package, platform_machine=platform_machine), (
+            f"{package} should resolve for {platform_machine}"
+        )

--- a/tests/unit/scripts/test_pylock_version.py
+++ b/tests/unit/scripts/test_pylock_version.py
@@ -90,18 +90,14 @@ def test_marker_env_sets_os_name(pylock_version) -> None:
 
 def test_marker_ast_evaluator_handles_nested_and_in(pylock_version) -> None:
     env = pylock_version.marker_env(python_minor="3.12", platform_machine="ppc64le")
-    marker_or_and = (
-        "(python_version == '3.12' or python_version == '3.11') and sys_platform == 'linux'"
-    )
+    marker_or_and = "(python_version == '3.12' or python_version == '3.11') and sys_platform == 'linux'"
     assert pylock_version.evaluate_marker(marker_or_and, env), f"expected true for {marker_or_and!r}"
     marker_in = "platform_machine in ('ppc64le', 's390x')"
     assert pylock_version.evaluate_marker(marker_in, env), f"expected true for {marker_in!r}"
     marker_not_x86 = "not (platform_machine == 'x86_64')"
     assert pylock_version.evaluate_marker(marker_not_x86, env), f"expected true for {marker_not_x86!r}"
     marker_not_ppc = "not (platform_machine == 'ppc64le')"
-    assert not pylock_version.evaluate_marker(marker_not_ppc, env), (
-        f"expected false for {marker_not_ppc!r}"
-    )
+    assert not pylock_version.evaluate_marker(marker_not_ppc, env), f"expected false for {marker_not_ppc!r}"
 
 
 @pytest.mark.parametrize(
@@ -135,6 +131,4 @@ def test_locked_versions_for_dockerfile_packages(
     assert version in _versions_in_pylock(pylock, package), (
         f"{package}@{platform_machine} resolved {version!r} not present in {pylock}"
     )
-    assert _LOOKS_LIKE_VERSION.match(version), (
-        f"{package}@{platform_machine} resolved invalid version {version!r}"
-    )
+    assert _LOOKS_LIKE_VERSION.match(version), f"{package}@{platform_machine} resolved invalid version {version!r}"

--- a/tests/unit/scripts/test_pylock_version.py
+++ b/tests/unit/scripts/test_pylock_version.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = ROOT / "scripts"
+DATASCIENCE_PYLOCK = ROOT / "jupyter/datascience/ubi9-python-3.12/pylock.toml"
+_LOOKS_LIKE_VERSION = re.compile(r"^\d+(\.\d+)*([A-Za-z0-9.+]+)?$")  # sanity check only, not strict PEP 440
+
+# (pylock, package, platform_machine) tuples mirror pylock_version.py call sites in Dockerfiles.
+_DOCKERFILE_PIN_CASES = (
+    (DATASCIENCE_PYLOCK, "onnx", "ppc64le"),
+    (DATASCIENCE_PYLOCK, "pyarrow", "s390x"),
+    (ROOT / "jupyter/trustyai/ubi9-python-3.12/pylock.toml", "torch", "x86_64"),
+    (ROOT / "jupyter/trustyai/ubi9-python-3.12/pylock.toml", "pyarrow", "ppc64le"),
+    (ROOT / "jupyter/trustyai/ubi9-python-3.12/pylock.toml", "pillow", "ppc64le"),
+    (ROOT / "jupyter/trustyai/ubi9-python-3.12/pylock.toml", "accelerate", "x86_64"),
+    (ROOT / "codeserver/ubi9-python-3.12/pylock.toml", "pillow", "ppc64le"),
+)
+
+
+def _versions_in_pylock(pylock: Path, package: str) -> set[str]:
+    doc = tomllib.loads(pylock.read_text())
+    return {entry["version"] for entry in doc.get("packages", []) if entry["name"] == package}
+
+
+@pytest.fixture
+def datascience_onnx_ppc64le(pylock_version) -> str:
+    return pylock_version.locked_version(DATASCIENCE_PYLOCK, "onnx", platform_machine="ppc64le")
+
+
+@pytest.mark.parametrize(
+    ("argv", "cwd"),
+    [
+        ([str(SCRIPTS / "pylock_version.py"), "onnx", "--platform", "ppc64le"], DATASCIENCE_PYLOCK.parent),
+        (
+            [
+                str(SCRIPTS / "pylock_version.py"),
+                str(DATASCIENCE_PYLOCK),
+                "onnx",
+                "--platform",
+                "ppc64le",
+            ],
+            None,
+        ),
+        (["-S", str(SCRIPTS / "pylock_version.py"), "onnx", "--platform", "ppc64le"], DATASCIENCE_PYLOCK.parent),
+    ],
+    ids=["package-only", "explicit-pylock", "stdlib-only"],
+)
+def test_cli_resolves_onnx_for_ppc64le(argv: list[str], cwd: Path | None, datascience_onnx_ppc64le: str) -> None:
+    result = subprocess.run(
+        [sys.executable, *argv],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    assert result.stdout.strip() == datascience_onnx_ppc64le, (
+        f"unexpected CLI output for {argv!r}: {result.stdout.strip()!r}"
+    )
+
+
+def test_missing_package_raises_lookup_error(pylock_version) -> None:
+    with pytest.raises(LookupError):
+        pylock_version.locked_version(DATASCIENCE_PYLOCK, "not-a-real-package", platform_machine="ppc64le")
+
+
+def test_unsupported_marker_syntax_fails_fast(pylock_version) -> None:
+    env = pylock_version.marker_env(python_minor="3.12", platform_machine="x86_64")
+    with pytest.raises(ValueError, match="comparison operator not supported"):
+        pylock_version.evaluate_marker("python_version >= '3.12'", env)
+    with pytest.raises(ValueError, match="unknown marker variable"):
+        pylock_version.evaluate_marker("os_release == '9'", env)
+    with pytest.raises(ValueError, match="unknown marker variable"):
+        pylock_version.evaluate_marker("extra == 'cuda'", env)
+
+
+def test_marker_env_sets_os_name(pylock_version) -> None:
+    env = pylock_version.marker_env(python_minor="3.12", platform_machine="x86_64")
+    assert pylock_version.evaluate_marker("os_name == 'posix'", env), (
+        "expected os_name == 'posix' to evaluate true for UBI Linux marker_env"
+    )
+
+
+def test_marker_ast_evaluator_handles_nested_and_in(pylock_version) -> None:
+    env = pylock_version.marker_env(python_minor="3.12", platform_machine="ppc64le")
+    marker_or_and = (
+        "(python_version == '3.12' or python_version == '3.11') and sys_platform == 'linux'"
+    )
+    assert pylock_version.evaluate_marker(marker_or_and, env), f"expected true for {marker_or_and!r}"
+    marker_in = "platform_machine in ('ppc64le', 's390x')"
+    assert pylock_version.evaluate_marker(marker_in, env), f"expected true for {marker_in!r}"
+    marker_not_x86 = "not (platform_machine == 'x86_64')"
+    assert pylock_version.evaluate_marker(marker_not_x86, env), f"expected true for {marker_not_x86!r}"
+    marker_not_ppc = "not (platform_machine == 'ppc64le')"
+    assert not pylock_version.evaluate_marker(marker_not_ppc, env), (
+        f"expected false for {marker_not_ppc!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "pylock",
+    [
+        DATASCIENCE_PYLOCK,
+        ROOT / "jupyter/trustyai/ubi9-python-3.12/pylock.toml",
+        ROOT / "codeserver/ubi9-python-3.12/pylock.toml",
+        ROOT / "runtimes/datascience/ubi9-python-3.12/pylock.toml",
+    ],
+)
+def test_native_build_pylocks_have_parseable_markers(pylock_version, pylock: Path) -> None:
+    # Syntax/whitelist guard only: evaluates every marker on x86_64. Per-arch correctness
+    # for native-build packages is covered by test_locked_versions_for_dockerfile_packages.
+    doc = tomllib.loads(pylock.read_text())
+    markers = {entry["marker"] for entry in doc.get("packages", []) if entry.get("marker")}
+    assert markers, f"expected markers in {pylock}"
+    env = pylock_version.marker_env(python_minor="3.12", platform_machine="x86_64")
+    for marker in markers:
+        pylock_version.evaluate_marker(marker, env)
+
+
+@pytest.mark.parametrize(("pylock", "package", "platform_machine"), _DOCKERFILE_PIN_CASES)
+def test_locked_versions_for_dockerfile_packages(
+    pylock_version,
+    pylock: Path,
+    package: str,
+    platform_machine: str,
+) -> None:
+    version = pylock_version.locked_version(pylock, package, platform_machine=platform_machine)
+    assert version in _versions_in_pylock(pylock, package), (
+        f"{package}@{platform_machine} resolved {version!r} not present in {pylock}"
+    )
+    assert _LOOKS_LIKE_VERSION.match(version), (
+        f"{package}@{platform_machine} resolved invalid version {version!r}"
+    )

--- a/tests/unit/test_semgrep_shell_unquoted.py
+++ b/tests/unit/test_semgrep_shell_unquoted.py
@@ -1,0 +1,60 @@
+"""Regression coverage for shell-unquoted-var-in-dangerous-cmd in semgrep.yaml."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SEMGREP_YAML = ROOT / "semgrep.yaml"
+RULE_ID = "shell-unquoted-var-in-dangerous-cmd"
+
+
+def _dangerous_cmd_pattern() -> re.Pattern[str]:
+    doc = yaml.safe_load(SEMGREP_YAML.read_text())
+    for rule in doc["rules"]:
+        if rule.get("id") == RULE_ID:
+            return re.compile(rule["pattern-regex"])
+    raise AssertionError(f"{RULE_ID} not found in {SEMGREP_YAML}")
+
+
+@pytest.fixture(scope="module")
+def pattern() -> re.Pattern[str]:
+    return _dangerous_cmd_pattern()
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "rm $FILE",
+        "rm ${FILE}",
+        "cp $SRC $DST",
+        "rm $FILE && echo ok",
+        "rm $FILE || echo ok",
+        "echo ok && rm $FILE",
+        "echo ok || rm $OTHER",
+    ],
+)
+def test_flags_unquoted_var_in_dangerous_cmd(pattern: re.Pattern[str], line: str) -> None:
+    assert pattern.search(line), f"expected match for {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        'rm "$FILE"',
+        "rm '$FILE'",
+        "python pylock_version.py --platform x86_64",
+        # Quoted rm must not match $OTHER after shell command separators.
+        'rm "$FILE" && echo $OTHER',
+        'rm "$FILE" || echo $OTHER',
+        'rm "$FILE"; echo $OTHER',
+        'rm "$FILE" | echo $OTHER',
+        'rm "$FILE" & echo $OTHER',
+    ],
+)
+def test_ignores_safe_or_other_command_vars(pattern: re.Pattern[str], line: str) -> None:
+    assert not pattern.search(line), f"unexpected match for {line!r}"

--- a/tests/unit/test_subtests.py
+++ b/tests/unit/test_subtests.py
@@ -1,0 +1,66 @@
+"""Coverage for tests.with_subtests.with_subtests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.with_subtests import with_subtests
+
+if TYPE_CHECKING:
+    import pytest
+    from pytest import Subtests
+
+pytest_plugins = ("pytester",)
+
+
+def test_with_subtests_quiet_runs_all_items(subtests: Subtests) -> None:
+    seen: list[int] = []
+
+    @with_subtests(subtests, range(3), quiet=True)
+    def _(u: int) -> None:
+        seen.append(u)
+        assert u < 3
+
+    assert seen == [0, 1, 2]
+
+
+def test_with_subtests_noisy_runs_all_items(subtests: Subtests) -> None:
+    seen: list[int] = []
+
+    @with_subtests(subtests, range(3), quiet=False)
+    def _(u: int) -> None:
+        seen.append(u)
+        assert u < 3
+
+    assert seen == [0, 1, 2]
+
+
+def test_with_subtests_quiet_pytest_fail_continues(pytester: pytest.Pytester) -> None:
+    """pytest.fail.Exception is not Exception; quiet mode must still wrap and continue."""
+    pytester.makepyfile(
+        # language=Python
+        """
+        import pytest
+        from tests.with_subtests import with_subtests
+
+        def test_inner(subtests):
+            seen = []
+
+            @with_subtests(subtests, (0, 1, 2), quiet=True)
+            def _(u):
+                seen.append(u)
+                if u == 0:
+                    pytest.fail("intentional quiet-mode fail")
+
+            assert seen == [0, 1, 2]
+        """
+    )
+    result = pytester.runpytest("-p", "no:cacheprovider")
+    # Subtest failure + parent "contains failed subtests" → two failed outcomes.
+    # Later items still ran: seen assert passed (no AssertionError about seen).
+    result.assert_outcomes(failed=2)
+    out = result.stdout.str()
+    assert "Failed: intentional quiet-mode fail" in out
+    assert "SUBFAILED(item=0)" in out
+    assert "assert seen ==" not in out
+    assert "assert [0] ==" not in out

--- a/tests/with_subtests.py
+++ b/tests/with_subtests.py
@@ -1,0 +1,51 @@
+"""Decorator-style iterable subtests for static/manifest checks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from pytest import Subtests
+
+
+def with_subtests[T, U](
+    subtests: Subtests,
+    iterable: Iterable[T],
+    msg: str | None = None,
+    quiet: bool = False,
+    **fixed_kw: object,
+) -> Callable[[Callable[[T], U]], None]:
+    """Decorator that immediately runs the decorated body as a subtest per item.
+
+    Multi-statement functions can be used for iterable-driven subtests without a
+    manual ``for`` / ``with subtests.test`` pair. Pass ``quiet=True`` to avoid
+    opening a subtest context for passing items (less SUBPASSED noise).
+
+    >>> @with_subtests(subtests, range(3))
+    >>> def _(i: int):
+    >>>     assert i < 3
+    """
+
+    def run(f: Callable[[T], U]) -> None:
+        __tracebackhide__ = True
+
+        for item in iterable:
+            if not quiet:
+                with subtests.test(msg=msg, item=item, **fixed_kw):
+                    f(item)
+            else:
+                # Quiet: only open a subtest context when the body fails, so
+                # successful items do not emit SUBPASSED noise.
+                # pytest.fail.Exception is OutcomeException (BaseException), not Exception.
+                try:
+                    f(item)
+                except Exception, pytest.fail.Exception:
+                    with subtests.test(msg=msg, item=item, **fixed_kw):
+                        # Re-raise inside subtest so pytest captures and continues.
+                        raise
+
+    return run


### PR DESCRIPTION
## Description

Replace hardcoded `ARG ONNX_VERSION` / `ARG PYARROW_VERSION` with a stdlib-only `scripts/pylock_version.py` helper that reads pinned versions from each workbench `pylock.toml` using PEP 508-style platform markers.

**Scope (images touched):**
- `jupyter/datascience`, `runtimes/datascience` — ppc64le ONNX + pyarrow native builds; s390x pyarrow
- `jupyter/trustyai` — `devel_env_setup.sh` ppc64le wheel builds (torch/pyarrow/pillow/accelerate)

**`scripts/pylock_version.py`:**
- Stdlib-only (`tomllib` + `ast` marker evaluator); runs in UBI `python-312` before `uv` is installed
- Prints raw PEP 440 versions; shell applies prefixes (`v${ONNX_VERSION}`, `apache-arrow-${PYARROW_VERSION}`, `${TORCH_VERSION%%+*}` for git tags)
- Marker evaluation via `ast.parse` — supports nested `and`/`or`/`not`, `in` tuples, `.*` wildcards; rejects unsupported operators loudly

**Also in this PR:**
- ONNX **1.22.0** (from pylock) removed upstream `requirements.txt` — ppc64le `onnx-builder` uses `requirements-min.txt`
- Trustyai `devel_env_setup.sh` shell quoting + unset-safe `LD_LIBRARY_PATH` under `set -u`
- Semgrep `shell-unquoted-var-in-dangerous-cmd` hardened (word boundaries; stop at `|`, `||`, `;`, `&`, `&&`)
- `tests/with_subtests.py` decorator for iterable-driven subtests (quieter alternative to manual `for`/`with subtests.test`) — tracks [opendatahub-io/notebooks#4140](https://github.com/opendatahub-io/notebooks/issues/4140)

**Commits (5):**
1. `feat(scripts): add stdlib pylock_version helper`
2. `fix(build): derive native ONNX/pyarrow versions from pylock.toml`
3. `fix(trustyai): resolve pins via pylock and quote shell vars`
4. `fix(semgrep): harden shell-unquoted-var-in-dangerous-cmd`
5. `test: add with_subtests helper for iterable static checks`

## How Has This Been Tested?

- [x] `uv run pytest` on `tests/unit/scripts/test_pylock_version.py`, `tests/test_native_build_versions.py`, `tests/unit/test_subtests.py`, `tests/unit/test_semgrep_shell_unquoted.py`
- [x] `python3.12 -S scripts/pylock_version.py` smoke test on host and in `registry.access.redhat.com/ubi9/python-312:latest`
- [x] `uv run prek --all-files` (ruff green; pre-existing pyright noise on unrelated `runtime_test.py`)
- [ ] Konflux: jupyter/runtime datascience ppc64le after merge (openblas follow-up is #2534)

Self checklist:
- [x] Targeted unit tests run before review
- [x] Konflux-specific changes are in `Dockerfile.konflux.*` under `rhds/notebooks` as required for rhoai-2.25

## Merge criteria

- [x] Focused thematic commits (not one mega-squash)
- [x] Testing instructions in PR body
- [ ] Review / lgtm / approve

## Out of scope / follow-ups

- [#2534](https://github.com/red-hat-data-services/notebooks/pull/2534) — `openblas-devel` in `onnx-builder` for ppc64le numpy sdist (stacked after this merges)
- Broader adoption of `with_subtests` across the suite — [ODH #4140](https://github.com/opendatahub-io/notebooks/issues/4140)
- whl-cache dedup (trustyai double `uv pip install`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Native CPU and runtime images now derive ONNX and PyArrow versions from the lockfile, producing matching architecture-specific tags (including ppc64le and s390x).
  * TrustyAI wheel caching now includes the version-resolution helper for consistent builds.
  * ONNX native builds now install from a minimal dependency set.
* **Build/Configuration**
  * Added lock-aware `pylock_version` tooling and use it during Docker builds and development setup (with a configurable `DATASCIENCE_SOURCE_CODE` build argument).
* **Tests**
  * Added coverage validating Dockerfiles and marker-based version resolution follow the lockfile, plus new unit tests for the helper, Semgrep rule, and subtest behavior.
* **Chores**
  * Reduced noisy pytest subtest output and tightened the Semgrep shell-variable detection rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->