### PR TITLE
Add RHEL subscription activation key to rhoai-3.3 notebook pipelines

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-3-push.yaml
@@ -54,6 +54,8 @@ spec:
     - linux/s390x
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-3-push.yaml
@@ -53,6 +53,8 @@ spec:
     - linux-m2xlarge/arm64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -52,6 +52,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-3-push.yaml
@@ -51,6 +51,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -50,6 +50,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -52,6 +52,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-3-push.yaml
@@ -50,6 +50,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-3-push.yaml
@@ -52,6 +52,8 @@ spec:
     - linux-d160-m2xlarge/arm64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -51,6 +51,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-3-push.yaml
@@ -50,6 +50,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -58,6 +58,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-v3-3-push.yaml
@@ -56,6 +56,8 @@ spec:
     - linux/s390x
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml
@@ -58,6 +58,8 @@ spec:
     - linux/s390x
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-3-push.yaml
@@ -56,6 +56,8 @@ spec:
     - linux-m2xlarge/arm64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-3-push.yaml
@@ -52,6 +52,8 @@ spec:
     - linux-m2xlarge/arm64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -52,6 +52,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-3-push.yaml
@@ -50,6 +50,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -52,6 +52,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-3-push.yaml
@@ -55,6 +55,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -76,6 +76,8 @@ spec:
         limits:
           cpu: '16'
           memory: 32Gi
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -52,6 +52,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-3-push.yaml
@@ -54,6 +54,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -53,6 +53,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-3-push.yaml
@@ -56,6 +56,8 @@ spec:
     - linux-d160-m4xlarge/arm64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
@@ -51,6 +51,8 @@ spec:
     value: "false"
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-3-push.yaml
@@ -54,6 +54,8 @@ spec:
     - linux/x86_64
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -57,6 +57,8 @@ spec:
   timeouts:
     pipeline: 8h
     tasks: 4h
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-3-push.yaml
@@ -61,6 +61,8 @@ spec:
     - linux/s390x
   - name: fips-check-blocking
     value: "false"
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Add `rhel-subscription-activation-key` parameter to all rhoai-3.3 notebook Konflux push and pull-request `.tekton` pipelines (34 files)
- Uses the same secret as rhoai-3.5: `rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6`
- Aligns rhoai-3.3 with rhoai-3.5 subscription access for notebook builds

## Test plan
- [ ] Verify Konflux PR pipelines pick up the new parameter on a test PR (`/build-konflux`)
- [ ] Confirm push pipelines on `rhoai-3.3` branch can access RHEL subscription credentials during build
- [ ] Merge companion PR in `konflux-central` (pipelineruns/notebooks/.tekton)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Build workflows now provide the required RHEL subscription activation key across runtime and workbench images.
  * Applies to both pull-request validation and push-triggered builds.
  * Supports CPU, CUDA, ROCm, and specialized machine-learning configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->