### PR TITLE
Add component-specific on-comment to pull-request pipelines (rhoai-2.25)

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-datascience)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-minimal-cpu)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-llmcompressor)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-rocm)"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-datascience)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cpu)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-llmcompressor)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-trustyai)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:
     appstudio.openshift.io/application: automation


### PR DESCRIPTION
## Summary
- Update/add `pipelinesascode.tekton.dev/on-comment` in 16 pull-request `.tekton` files
- Align comment-based rebuild triggers with konflux-central push pipeline patterns now removed from push.yaml
- Enables component-specific rebuild commands (e.g. `/build-datascience`, `/build-runtime-pytorch-cuda`) on PRs

## Files changed
- `odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-datascience)"`
- `odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-minimal-cpu)"`
- `odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-pytorch-cuda)"`
- `odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-pytorch-llmcompressor)"`
- `odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-pytorch-rocm)"`
- `odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-tensorflow-cuda)"`
- `odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-runtime-tensorflow-rocm)"`
- `odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-datascience)"`
- `odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-minimal-cpu)"`
- `odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-minimal-cuda)"`
- `odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-minimal-rocm)"`
- `odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-pytorch-cuda)"`
- `odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-pytorch-llmcompressor)"`
- `odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-pytorch-rocm)"`
- `odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-tensorflow-cuda)"`
- `odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml` (updated) -> `"^/(build-konflux|build-trustyai)"`

## Test plan
- [ ] Open a test PR and verify `/build-konflux` still triggers builds
- [ ] Verify component-specific commands (e.g. `/build-datascience`) trigger the correct pipeline
- [ ] Merge companion konflux-central PR removing on-comment from push.yaml
