### PR TITLE
[rhoai-2.25] fix(ppc64le): openblas-devel for ONNX numpy builds

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -232,6 +232,9 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     cd onnx
     git checkout "${ONNX_TAG}"
     git submodule update --init --recursive
+    # numpy from requirements-min.txt builds from sdist on ppc64le (no PyPI wheel); needs BLAS.
+    dnf install -y openblas-devel
+    dnf clean all
     pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -230,6 +230,9 @@ if [ "${TARGETARCH}" = "ppc64le" ]; then
     cd onnx
     git checkout "${ONNX_TAG}"
     git submodule update --init --recursive
+    # numpy from requirements-min.txt builds from sdist on ppc64le (no PyPI wheel); needs BLAS.
+    dnf install -y openblas-devel
+    dnf clean all
     pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -258,6 +258,9 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx && git checkout "v${ONNX_VERSION}"
     git submodule update --init --recursive
+    # numpy from requirements-min.txt builds from sdist on ppc64le (no PyPI wheel); needs BLAS.
+    dnf install -y openblas-devel
+    dnf clean all
     pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -258,6 +258,9 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
     git clone --recursive https://github.com/onnx/onnx.git
     cd onnx && git checkout "v${ONNX_VERSION}"
     git submodule update --init --recursive
+    # numpy from requirements-min.txt builds from sdist on ppc64le (no PyPI wheel); needs BLAS.
+    dnf install -y openblas-devel
+    dnf clean all
     pip install --no-cache-dir -r requirements-min.txt
     CMAKE_ARGS="-DPython3_EXECUTABLE=$(which python3.12)"
     export CMAKE_ARGS


### PR DESCRIPTION
## Description

Konflux ppc64le builds of jupyter/runtime datascience fail in `onnx-builder` when installing ONNX `requirements-min.txt`: `numpy==1.26.0` has **no ppc64le wheel** on PyPI, so pip builds from sdist and needs BLAS. `openblas-builder` artifacts are only copied into the final image, not into `onnx-builder`.

This PR installs `openblas-devel` via dnf in `onnx-builder` before `pip install -r requirements-min.txt` (verified available on UBI 9.6 ppc64le from `ubi-9-codeready-builder-rpms`).

Depends on / follows [#2519](https://github.com/red-hat-data-services/notebooks/pull/2519) (merged) — pylock-driven ONNX 1.22 + `requirements-min.txt`. Rebased onto `rhoai-2.25` after that merge.

Touches:
- `jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu`
- `jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu`
- `runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu`
- `runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu`

## How Has This Been Tested?

- Confirmed on SSH host (`podman --platform linux/ppc64le`): `dnf install -y openblas-devel` succeeds on UBI 9.6; `pip install numpy==1.26.0` then builds a `linux_ppc64le` wheel successfully (~15m under qemu).
- Confirmed PyPI has **no** `numpy==1.26.0` ppc64le wheels.
- Await Konflux ppc64le jupyter-datascience + runtime-datascience.

Self checklist:
- [x] Targeted validation before review
- [x] Konflux-specific changes in `Dockerfile.konflux.*` for rhoai-2.25

## Test plan

- [ ] Konflux: jupyter-datascience ppc64le `onnx-builder` passes numpy install
- [ ] Konflux: runtime-datascience ppc64le `onnx-builder` passes numpy install
- [ ] amd64 legs still green (openblas-devel only installed on ppc64le path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Power (ppc64le) ONNX/NumPy build outcomes by adding the required OpenBLAS development libraries so prerequisite components can build correctly when prebuilt NumPy wheels aren’t available.
* **Chores**
  * Reduced image build clutter by cleaning package-manager metadata before installing Python dependencies.
  * Added clarifying build notes for Power (ppc64le) to document why BLAS support is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->