### PR TITLE
[rhoai-2.25] RHAIENG-2345: install Jupyter PDF deps from RPMs

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -279,7 +279,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -277,7 +277,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -72,7 +72,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -74,7 +74,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -93,7 +93,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -74,7 +74,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -62,7 +62,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -72,7 +72,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -79,7 +79,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -79,7 +79,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -79,7 +79,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -79,7 +79,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -77,7 +77,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -77,7 +77,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -75,7 +75,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -75,7 +75,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -79,7 +79,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -79,7 +79,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -107,7 +107,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -107,7 +107,6 @@ USER 0
 
 # Dependencies for PDF export begin
 RUN ./utils/install_pdf_deps.sh
-ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
 # Dependencies for PDF export end
 
 USER 1001

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -1,21 +1,12 @@
 #!/bin/bash
 
-# Install dependencies required for Notebooks PDF exports
+# Install OS dependencies required for JupyterLab PDF export.
+# Uses RHEL/UBI AppStream texlive RPMs plus EPEL for texlive-tcolorbox and pandoc.
+# Requires AppStream (subscription or c9s); plain unsubscribed UBI lacks these packages
+# (see https://github.com/red-hat-data-services/notebooks/issues/2310).
+# Backport of main's RPM approach (RHAIENG-2186 / RHAIENG-2345); replaces Utah/CTAN curl.
 
-set -euxo pipefail
-
-# Mapping of `uname -m` values to equivalent GOARCH values
-declare -A UNAME_TO_GOARCH
-UNAME_TO_GOARCH["x86_64"]="amd64"
-UNAME_TO_GOARCH["aarch64"]="arm64"
-UNAME_TO_GOARCH["ppc64le"]="ppc64le"
-UNAME_TO_GOARCH["s390x"]="s390x"
-
-ARCH="${UNAME_TO_GOARCH[$(uname -m)]}"
-if [[ -z "${ARCH:-}" ]]; then
-    echo "Unsupported architecture: $(uname -m)" >&2
-    exit 1
-fi
+set -Eeuxo pipefail
 
 # Skip PDF export installation for s390x and ppc64le architectures
 if [[ "$(uname -m)" == "s390x" || "$(uname -m)" == "ppc64le" ]]; then
@@ -23,21 +14,58 @@ if [[ "$(uname -m)" == "s390x" || "$(uname -m)" == "ppc64le" ]]; then
     exit 0
 fi
 
-# tex live installation
-# Pin to the TeX Live 2025 historic archive so the installer version and
-# package repository version always match (mirror.ctan.org now serves 2026).
-TEXLIVE_HISTORIC="https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2025/tlnet-final"
-echo "Installing TexLive to allow PDf export from Notebooks"
-curl -fL "${TEXLIVE_HISTORIC}/install-tl-unx.tar.gz" -o install-tl-unx.tar.gz
-zcat < install-tl-unx.tar.gz | tar xf -
-cd install-tl-2*
-perl ./install-tl --no-interaction --scheme=scheme-small --texdir=/usr/local/texlive --repository="${TEXLIVE_HISTORIC}"
-ln -s /usr/local/texlive/bin/"$(uname -m)-linux" /usr/local/texlive/bin/linux
-cd /usr/local/texlive/bin/linux
-./tlmgr --repository="${TEXLIVE_HISTORIC}" install tcolorbox pdfcol adjustbox titling enumitem soul ucs collection-fontsrecommended
+# https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
+# texlive-tcolorbox is not in AppStream; install from EPEL (do not curl a pinned Fedora RPM URL).
+PACKAGES=(
+texlive-adjustbox
+texlive-bibtex
+texlive-charter
+texlive-ec
+texlive-euro
+texlive-eurosym
+texlive-fpl
+texlive-jknapltx
+texlive-knuth-local
+texlive-lm-math
+texlive-marvosym
+texlive-mathpazo
+texlive-mflogo-font
+texlive-parskip
+texlive-plain
+texlive-pxfonts
+texlive-rsfs
+texlive-tcolorbox
+texlive-times
+texlive-titling
+texlive-txfonts
+texlive-ulem
+texlive-upquote
+texlive-utopia
+texlive-wasy
+texlive-wasy-type1
+texlive-wasysym
+texlive-xetex
+# dependencies of texlive-tcolorbox
+texlive-environ
+texlive-trimspaces
+)
 
-# pandoc installation
-curl -fL "https://github.com/jgm/pandoc/releases/download/3.7.0.2/pandoc-3.7.0.2-linux-${ARCH}.tar.gz"  -o /tmp/pandoc.tar.gz
-mkdir -p /usr/local/pandoc
-tar xvzf /tmp/pandoc.tar.gz --strip-components 1 -C /usr/local/pandoc/
-rm -f /tmp/pandoc.tar.gz
+# EPEL provides texlive-tcolorbox and pandoc (dynamic binary; check-payload friendly).
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+if ! dnf install -y "${PACKAGES[@]}" pandoc; then
+    echo "ERROR: Failed to install texlive/pandoc RPMs." >&2
+    echo "AppStream texlive packages require a subscribed RHEL/UBI build or c9s AppStream." >&2
+    echo "Unsubscribed UBI-only template builds are tracked in" >&2
+    echo "https://github.com/red-hat-data-services/notebooks/issues/2310" >&2
+    exit 1
+fi
+
+dnf clean all
+
+pdflatex --version
+pandoc --version
+texhash
+kpsewhich tcolorbox.sty
+command -v pandoc
+command -v pdflatex

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -121,7 +121,6 @@ def main():
         """),
         "Dependencies for PDF export": textwrap.dedent(r"""
             RUN ./utils/install_pdf_deps.sh
-            ENV PATH="/usr/local/texlive/bin/linux:/usr/local/pandoc/bin:$PATH"
         """),
         "Download Elyra Bootstrapper": textwrap.dedent(r"""
             RUN curl -fL https://raw.githubusercontent.com/opendatahub-io/elyra/refs/tags/v4.3.1/elyra/kfp/bootstrapper.py \

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_test.py
@@ -60,7 +60,7 @@ class TestJupyterLabImage:
         if container_arch in ("s390x", "ppc64le"):
             pytest.skip(f"PDF export not supported on {container_arch} architecture")
         container = WorkbenchContainer(image=jupyterlab_image.name, user=4321, group_add=[0])
-        test_file_name = "test.ipybn"
+        test_file_name = "test.ipynb"
         test_file_content = """{
                 "cells": [
                     {


### PR DESCRIPTION
## Description

Replace flaky Utah/CTAN TexLive + GitHub pandoc fetches in `jupyter/utils/install_pdf_deps.sh` with `dnf` RPMs (AppStream texlive + EPEL `texlive-tcolorbox` / `pandoc`).

Tracks **[RHAIENG-2345](https://redhat.atlassian.net/browse/RHAIENG-2345)**. Backports the RPM approach already on main ([RHAIENG-2186](https://redhat.atlassian.net/browse/RHAIENG-2186) / ODH [#3846](https://github.com/opendatahub-io/notebooks/pull/3846)), adapted for 2.25 subscribed UBI builds.

### Why
- Konflux/GHA flakes: `curl` to `ftp.math.utah.edu` (`curl: (28)` / `(60)`)
- Static GitHub pandoc trips post-#2513 **check-payload** (`executable is not dynamically linked`)
- Slack Mar 2026 consensus (vsok, dlutz): stop curling pinned Fedora RPM URLs; use `dnf install` instead ([RHAIENG-4114](https://redhat.atlassian.net/browse/RHAIENG-4114))

### Changes
- Rewrite `install_pdf_deps.sh`: AppStream `texlive-*` list + enable EPEL for `texlive-tcolorbox` and `pandoc`
- Drop `/usr/local/texlive` / `/usr/local/pandoc` PATH overrides (RPM bins are on `/usr/bin`)
- Clear error pointing at [#2310](https://github.com/red-hat-data-services/notebooks/issues/2310) when AppStream packages are missing

### Out of scope / notes
- **Does not fix [#2310](https://github.com/red-hat-data-services/notebooks/issues/2310)** (unsubscribed UBI template builds lack AppStream). Expect Test Build Notebooks Template (`subscription: false`) to still fail; subscribed Konflux/RHDS Build Notebooks should work.
- Does not stack with [#2534](https://github.com/red-hat-data-services/notebooks/pull/2534) (openblas).
- Supersedes TexLive curl retries in [#1883](https://github.com/red-hat-data-services/notebooks/pull/1883) for this path; #1883 remains useful for unrelated `dnf` flakes — cc @daniellutz.
- No `pandoc-rhai` / pylock churn (follow-up: [RHAIENG-5765](https://redhat.atlassian.net/browse/RHAIENG-5765)).
- EPEL pandoc is **2.14.x** (vs previous GitHub 3.7); if nbconvert PDF smoke fails, we can interim retry-curl GitHub pandoc.

### Related
- Main: ODH [#2746](https://github.com/opendatahub-io/notebooks/pull/2746), [#3846](https://github.com/opendatahub-io/notebooks/pull/3846)
- RHDS Utah pin bandage: [#1982](https://github.com/red-hat-data-services/notebooks/pull/1982)
- ppc64le helpers `install_texlive.sh` / `install_pandoc.sh` left alone (skipped arches / pdf-builder)

## How Has This Been Tested?

* https://github.com/red-hat-data-services/notebooks/actions/runs/29916877152

- [x] `bash -n jupyter/utils/install_pdf_deps.sh`
- [x] Confirmed EPEL9 packages exist: `texlive-tcolorbox` 20200406-38.el9, `pandoc` 2.14.0.3-17.el9; `epel-release-latest-9` reachable
- [ ] CI: Konflux `/build-konflux` — minimal cuda/cpu amd64 past `install_pdf_deps` (no utah.edu)
- [ ] CI: GHA Build Notebooks (subscribed) — datascience/minimal amd64; check-payload no longer fails on static pandoc
- [ ] PDF export / nbconvert smoke on built image
- [ ] Confirm ppc64le/s390x still skip cleanly

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

[RHAIENG-2345]: https://redhat.atlassian.net/browse/RHAIENG-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-2186]: https://redhat.atlassian.net/browse/RHAIENG-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4114]: https://redhat.atlassian.net/browse/RHAIENG-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-5765]: https://redhat.atlassian.net/browse/RHAIENG-5765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF export dependency setup across Jupyter images by installing TeX Live and Pandoc through supported system packages.
  * Removed hardcoded tool-path configuration, improving consistency across CPU, CUDA, and ROCm variants.
  * Added installation validation and clearer error handling for unavailable package sources.
  * Preserved architecture-specific behavior for platforms that do not support PDF export dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->