### PR TITLE
[rhoai-2.25] RHAIENG-6036: restore check-payload workbench FIPS waivers

### DIFF
--- a/scripts/check-payload/config.toml
+++ b/scripts/check-payload/config.toml
@@ -203,6 +203,53 @@ files = ["/usr/bin/launcher-v2"]
 # Temporary supprsssions for workbenches
 # https://github.com/openshift/check-payload/blob/main/internal/types/errors.go
 # See docs/fips.md for full context on FIPS compliance status.
+#
+# Restored after #2513 dropped these 2.25-needed waivers (main no longer ships
+# static GitHub pandoc / py-spy the same way). Keep codeserver sandbox dirs
+# from #2513.
+
+[[rpm.rstudio-server.ignore]]
+error = "ErrNotDynLinked"
+files = [
+    # executable is not dynamically linked
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/pandoc",
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/typst",
+]
+
+[[rpm.rstudio-server.ignore]]
+error = "ErrNotDynLinked"
+files = [
+    # executable is not dynamically linked
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild",
+]
+
+[[rpm.rstudio-server.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+    # go binary is not CGO_ENABLED
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild",
+]
+
+[[rpm.rstudio-server.ignore]]
+error = "ErrGoNoCgoInit"
+files = [
+    # x_cgo_init or _cgo_topofstack not found
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild",
+]
+
+[[rpm.rstudio-server.ignore]]
+error = "ErrLibcryptoMissing"
+files = [
+    # openssl: did not find libcrypto library within binary
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild",
+]
+
+[[rpm.rstudio-server.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+    # go binary does not contain required symbol(s)
+    "/usr/lib/rstudio-server/bin/quarto/bin/tools/x86_64/esbuild",
+]
 
 # valgrind is waived since it doesn't do anything with crypto in a
 # security context
@@ -222,13 +269,25 @@ files = [
     "/usr/libexec/valgrind/none-amd64-linux",
 ]
 
-# py-spy is excluded from images via exclude-dependencies (RHAIENG-58916).
-# pandoc-rhai 3.9.0.2 is dynamically linked (RHAIENG-5765) — no waiver needed.
+# py-spy is still shipped on rhoai-2.25 (not yet exclude-dependencies); waived —
+# it does not do crypto in a security context.
+# GitHub tarball pandoc under /usr/local/pandoc is static (until RPM/EPEL path
+# lands via RHAIENG-2345 / #2550).
 
-# when scanning with `scan local --path`
+# when scanning with `scan image --spec`
+[[payload.python-311-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+    # executable is not dynamically linked
+    "/opt/app-root/bin/py-spy",
+]
+# when scanning with `scan local --path`, the above does not apply
 [[ignore]]
 error = "ErrNotDynLinked"
 files = [
+    # executable is not dynamically linked
+    "/opt/app-root/bin/py-spy",
+    "/usr/local/pandoc/bin/pandoc",
     # when code-server is not installed from rpm, the exclusion below won't apply
     "/usr/lib/code-server/lib/vscode/node_modules/@vscode/ripgrep/bin/rg",
 ]


### PR DESCRIPTION
## Description

Restore the pre-[#2513](https://github.com/red-hat-data-services/notebooks/pull/2513) `check-payload` excludes for workbench images so Build Notebooks / PR matrix stops failing FIPS on static binaries that 2.25 still ships.

### What #2513 removed (incorrect for 2.25)

Main-oriented comments claimed py-spy is gone (`exclude-dependencies`) and pandoc is dynamic (`pandoc-rhai`). On `rhoai-2.25`:

- **py-spy** is still in datascience/pytorch/tensorflow/… `pylock.toml` → `/opt/app-root/bin/py-spy` fails `ErrNotDynLinked`
- **GitHub pandoc** still installed under `/usr/local/pandoc/bin/pandoc` (until [#2550](https://github.com/red-hat-data-services/notebooks/pull/2550) RPM path)
- **rstudio-server** quarto tools (pandoc/typst/esbuild) still need the same rpm ignores

### Restored

- `[[rpm.rstudio-server.ignore]]` blocks (pandoc, typst, esbuild)
- `[[payload.python-311-container.ignore]]` + `[[ignore]]` for `/opt/app-root/bin/py-spy`
- `[[ignore]]` for `/usr/local/pandoc/bin/pandoc`

### Kept from #2513

- codeserver `@anthropic-ai/sandbox-runtime` seccomp **dir** ignores (covers [#2500](https://github.com/red-hat-data-services/notebooks/pull/2500)’s intent; that PR can close as superseded once this lands)
- AI Pipelines argoexec/launcher overrides
- valgrind, ripgrep

Independent of [#2550](https://github.com/red-hat-data-services/notebooks/pull/2550) (PDF RPM) and [#2534](https://github.com/red-hat-data-services/notebooks/pull/2534) (openblas).

## How Has This Been Tested?

* https://github.com/red-hat-data-services/notebooks/actions/runs/29916258707

- [x] Diff vs pre-#2513 config: restored workbench ignores match prior paths
- [ ] CI: Build Notebooks matrix — jupyter-minimal / datascience amd64 check-payload green (no `pandoc` / `py-spy` `ErrNotDynLinked`)
- [ ] codeserver still green with sandbox-runtime dir ignores

Self checklist:
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package validation for Quarto tools, including Pandoc, Typst, and esbuild.
  - Updated handling for Python tooling, including py-spy and Pandoc, reducing false validation failures during package checks.
  - Improved support for binaries with dynamic-linking, Go, CGO, cryptography, and symbol-related characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->