### PR TITLE
[rhoai-2.25] RHAIENG-2345: subscribe Build Notebooks push (non-codeserver)

### DIFF
--- a/.github/workflows/build-notebooks-push.yaml
+++ b/.github/workflows/build-notebooks-push.yaml
@@ -60,6 +60,9 @@ jobs:
       python: "${{ matrix.python }}"
       github: "${{ toJSON(github) }}"
       platform: "${{ matrix.platform }}"
-      subscription: "${{ matrix.subscription }}"
+      # Matrix gen only sets subscription for *rhel* targets. RHOAI ubi9 images still
+      # need AppStream (e.g. texlive RPMs in install_pdf_deps.sh). Match build-notebooks-pr.yaml:
+      # force subscription for everything except hermetic codeserver (public UBI locks).
+      subscription: ${{ !contains(matrix.target, 'codeserver') }}
       product: rhoai
     secrets: inherit

--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -32,8 +32,9 @@ jobs:
       python: "3.12"
       github: ${{ toJson(github) }}
       platform: linux/amd64
-      # Match downstream/main: self-test uses a public-base image and must not
-      # require subscription secrets (unavailable on fork PRs).
-      subscription: ${{ false }}
+      # jupyter-minimal install_pdf_deps.sh needs RHEL AppStream texlive RPMs
+      # (RHAIENG-2345 / #2310). Same-repo PRs inherit subscription secrets;
+      # fork PRs that touch these paths will fail without them (see CONTRIBUTING.md).
+      subscription: ${{ true }}
       product: rhoai
     secrets: inherit


### PR DESCRIPTION
## Description

After [#2550](https://github.com/red-hat-data-services/notebooks/pull/2550) switched PDF deps to AppStream/EPEL RPMs, two CI paths still built **unsubscribed** and fail `dnf install texlive-*`:

### 1. Build Notebooks (push)
[`gen_gha_matrix_jobs.py`](ci/cached-builds/gen_gha_matrix_jobs.py) sets `"subscription": "rhel" in target`, and push passed that through → jobs named `…, false)` (e.g. [run 29916877152](https://github.com/red-hat-data-services/notebooks/actions/runs/29916877152/job/88912802574)).

**Fix:** match [`build-notebooks-pr.yaml`](.github/workflows/build-notebooks-pr.yaml): `subscription: ${{ !contains(matrix.target, 'codeserver') }}`.

### 2. Test Build Notebooks Template (PR check)
Hardcoded `subscription: false` → same AppStream miss. Breaks any PR that triggers the template self-test (paths under `.github/workflows/`, Makefile, etc.), e.g. [#2540](https://github.com/red-hat-data-services/notebooks/pull/2540) / [job 88918051263](https://github.com/red-hat-data-services/notebooks/actions/runs/29918547713/job/88918051263?pr=2540) (`subscription: false`, `No match for argument: texlive-adjustbox`).

**Fix:** `subscription: ${{ true }}` ([#2310](https://github.com/red-hat-data-services/notebooks/issues/2310)).

Codeserver stays unsubscribed (hermetic public UBI locks). Same-repo secrets required; fork PRs that touch these paths will fail without them (see CONTRIBUTING.md).

## How Has This Been Tested?

* https://github.com/red-hat-data-services/notebooks/actions/runs/29919884418

- [x] Diff: push override identical to PR workflow expression
- [ ] Test Build Notebooks Template on this PR: `subscription: true`, past `install_pdf_deps`
- [ ] After merge: Build Notebooks (push) on `rhoai-2.25` shows `…, true)` for non-codeserver

Self checklist:
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work