### PR TITLE
[rhoai-2.25] fix(ci): require RHOAI Quay bot secrets in params-env

### DIFF
--- a/.github/workflows/params-env.yaml
+++ b/.github/workflows/params-env.yaml
@@ -40,8 +40,11 @@ jobs:
           cp ci/secrets/pull-secret.json "$HOME/.config/containers/auth.json"
 
       - name: Configure Quay.io pull auth for RHOAI namespace
-        if: env.RHOAI_QUAY_BOT_USERNAME != ''
         run: |
+          if [ -z "${RHOAI_QUAY_BOT_USERNAME}" ] || [ -z "${RHOAI_QUAY_BOT_PASSWORD}" ]; then
+            echo "::error title=Missing RHOAI Quay bot secrets::RHOAI_QUAY_BOT_USERNAME and RHOAI_QUAY_BOT_PASSWORD are required for params-env validation. Fork PRs are inherently less secure (GitHub withholds repository secrets) and are unsupported — push a same-repo branch instead. See CONTRIBUTING.md#contributing-from-branches-vs-forks."
+            exit 1
+          fi
           printf '%s' "${RHOAI_QUAY_BOT_PASSWORD}" | skopeo login --username "${RHOAI_QUAY_BOT_USERNAME}" --password-stdin quay.io
         env:
           RHOAI_QUAY_BOT_USERNAME: ${{ secrets.RHOAI_QUAY_BOT_USERNAME }}


### PR DESCRIPTION
## Description

Make Quay.io RHOAI bot login **required** in `params-env` validation.

- Drop the broken optional `if: env.RHOAI_QUAY_BOT_USERNAME != ''` guard (step-level `env` is not visible to `if`, and unset ≠ `''` so the step always ran).
- If `RHOAI_QUAY_BOT_USERNAME` / `PASSWORD` are missing, fail with a loud `::error::` that fork PRs are unsupported (GitHub withholds repository secrets) and same-repo branches are required — aligned with [CONTRIBUTING.md](https://github.com/red-hat-data-services/notebooks/blob/rhoai-2.25/CONTRIBUTING.md#contributing-from-branches-vs-forks) and Build Notebooks fork messaging.

Independent of [#2556](https://github.com/red-hat-data-services/notebooks/pull/2556).

## How Has This Been Tested?

- Logic review against GHA `env`/`if` semantics and existing fork guidance.
- Full end-to-end login depends on repo secrets on a same-repo push/PR.

Self checklist (all need to be checked):
- [x] N/A for workflow-only change (`make test` does not exercise this GHA)
- [x] RHDS-only CI workflow fix on `rhoai-2.25` (not an ODH sync path change)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Test plan

- [ ] Same-repo push/PR with secrets configured: Quay login succeeds (or fails clearly on bad credentials, not the empty-secret path)
- [ ] Confirm missing-secret path emits the `::error title=Missing RHOAI Quay bot secrets::` annotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation for Quay.io pull authentication by checking that both the bot username and password are set at runtime.
  * Added clearer, actionable error messaging when required credentials are missing, including guidance for forked workflows.
  * Ensures the authentication step fails fast instead of proceeding with incomplete settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->