### PR TITLE
[rhoai-2.25] fix(ci): select odh vs rhoai in TEMPLATE self-test by repository

### DIFF
--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -32,9 +32,10 @@ jobs:
       python: "3.12"
       github: ${{ toJson(github) }}
       platform: linux/amd64
-      # jupyter-minimal install_pdf_deps.sh needs RHEL AppStream texlive RPMs
-      # (RHAIENG-2345 / #2310). Same-repo PRs inherit subscription secrets;
-      # fork PRs that touch these paths will fail without them (see CONTRIBUTING.md).
-      subscription: ${{ true }}
-      product: rhoai
+      # ODH midstream vs RHDS downstream: avoid exercising stale odh lockfiles on RHDS.
+      product: ${{ github.repository == 'red-hat-data-services/notebooks' && 'rhoai' || 'odh' }}
+      # jupyter-minimal PDF deps need RHEL AppStream on RHDS (RHAIENG-2345 / #2310).
+      # Same-repo PRs inherit subscription secrets; fork PRs fail without them
+      # (see CONTRIBUTING.md).
+      subscription: ${{ github.repository == 'red-hat-data-services/notebooks' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Make the TEMPLATE self-test pick product by repository: `odh` on `opendatahub-io/notebooks`, `rhoai` (+ subscription) on `red-hat-data-services/notebooks`.
- Stops RHDS from exercising midstream (`prefetch-input/odh`) lockfiles that can go stale (e.g. CentOS Stream RPM 404s during hermeto prefetch).

## Test plan
- [ ] TEMPLATE self-test runs as **rhoai** with subscription on RHDS
- [ ] Prefetch uses `prefetch-input/rhds`
- [ ] No unrelated workflow changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the notebook template workflow to automatically detect the repository context and apply the appropriate product and subscription settings.
  * Improved behavior for pull requests from forks and the primary repository.
  * Added updated guidance for repository lockfiles and AppStream dependencies to support more consistent build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->