### PR TITLE
[rhoai-3.4] fix(ci): select odh vs rhoai in TEMPLATE self-test by repository

### DIFF
--- a/.github/workflows/test-build-notebooks-template.yaml
+++ b/.github/workflows/test-build-notebooks-template.yaml
@@ -38,5 +38,9 @@ jobs:
       python: "3.12"
       github: ${{ toJson(github) }}
       platform: linux/amd64
-      subscription: false
+      # ODH midstream vs RHDS downstream: avoid exercising stale odh lockfiles on RHDS.
+      # On this branch, konflux=true selects the rhoai (Dockerfile.konflux.*) path.
+      konflux: ${{ github.repository == 'red-hat-data-services/notebooks' }}
+      # jupyter-minimal PDF deps need RHEL AppStream on RHDS (RHAIENG-2345 / #2310).
+      subscription: ${{ github.repository == 'red-hat-data-services/notebooks' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Make the TEMPLATE self-test pick product by repository: `odh` on `opendatahub-io/notebooks`, `rhoai` via `konflux` + subscription on `red-hat-data-services/notebooks`.
- Stops RHDS from exercising midstream (`prefetch-input/odh`) lockfiles that can go stale (e.g. CentOS Stream RPM 404s during hermeto prefetch).

## Test plan
- [ ] TEMPLATE self-test runs as **rhoai** (`konflux=true`, subscription) on RHDS
- [ ] Prefetch uses `prefetch-input/rhds`
- [ ] No unrelated workflow changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated notebook build workflows to automatically select the appropriate subscription and build path based on the repository context.
  * Added clearer guidance for differences between midstream and downstream builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->