### PR TITLE
fix: increase prepare-sboms memory and reduce pipeline timeout for llmcompressor-cuda

### DIFF
--- a/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
+++ b/.tekton/odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5-push.yaml
@@ -22,8 +22,8 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipeline: "12h0m0s"
-    tasks: "8h0m0s"
+    pipeline: "3h0m0s"
+    tasks: "2h0m0s"
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -83,9 +83,9 @@ spec:
     - name: prepare-sboms
       computeResources:
         requests:
-          memory: 8Gi
+          memory: 12Gi
         limits:
-          memory: 8Gi
+          memory: 12Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-5
   workspaces:


### PR DESCRIPTION
## Problem

The llmcompressor-cuda build has failed 6 consecutive times. The build
step completes successfully in ~36 min, but `prepare-sboms` (mobster)
is OOM-killed (exit code 137) after only 17 seconds — the 8Gi memory
limit is insufficient for this large CUDA image's SBOM processing.

Additionally, the pipeline timeout is set to 12h/8h which is excessive
for a single-arch amd64 build that takes ~36 min. When prepare-sboms
fails, the pipeline hangs for hours before reporting the failure.

## Changes

- Increase `prepare-sboms` step memory from 8Gi to 12Gi
- Reduce pipeline timeout from 12h to 3h and task timeout from 8h to 2h

## Testing

Use `/build-konflux` to validate the memory increase is sufficient.
If 12Gi is still not enough, will increase to 16Gi.

## Evidence

- Exit code 137 = SIGKILL from cgroup OOM
- mobster starts at 13:15:00, killed at 13:15:17 — only 17s before OOM
- Build step itself completes fine in ~36 min (exit 0)
- 6 consecutive failures, all same pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for SBOM preparation to support resource-intensive builds.
  * Reduced overall pipeline and task timeouts to enable faster failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->