### PR TITLE
RHAIENG-4246: chore(.tekton/): enable arm64 for PyTorch CUDA images

### DIFF
--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+    - linux-d160-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -61,7 +62,7 @@ spec:
     - path: runtimes/pytorch/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-extra-fast/amd64
+    - linux-d160-m2xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -61,7 +62,7 @@ spec:
     - path: runtimes/pytorch+llmcompressor/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+    - linux-d160-m8xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -63,7 +64,7 @@ spec:
     - path: jupyter/pytorch/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -48,6 +48,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m8xlarge/amd64
+    - linux-d160-m8xlarge/arm64
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
@@ -63,7 +64,7 @@ spec:
     - path: jupyter/pytorch+llmcompressor/ubi9-python-3.12
       type: pip
       binary:
-        arch: "x86_64"
+        arch: "x86_64,aarch64"
       requirements_files: [requirements.cuda.txt]
   pipelineRef:
     resolver: git


### PR DESCRIPTION
/agy review

## Summary
- Enable arm64 Konflux builds for the four PyTorch CUDA family PR PipelineRuns (workbench + runtime, with/without LLM Compressor) — the only non-ROCm notebook images still missing arm64 on RHDS `main`.
- Match existing TensorFlow / minimal CUDA patterns: workbench `linux-d160-m8xlarge/arm64`, runtime `linux-d160-m2xlarge/arm64`, hermetic pip `binary.arch: "x86_64,aarch64"`.
- Supersedes spike [#1975](https://github.com/red-hat-data-services/notebooks/pull/1975) (Mar 2026 Internal builds already Succeeded for PyTorch CUDA on arm). Durable source of truth: companion [konflux-central#2942](https://github.com/red-hat-data-services/konflux-central/pull/2942).

Jira: [RHAIENG-4246](https://redhat.atlassian.net/browse/RHAIENG-4246)

## Test plan
- [ ] `/build-konflux` (or kfbuild labels) on this PR; treat only **Konflux Production Internal** (stone-prod-p02) as signal
- [ ] Confirm arm64 `build-images` Succeeded for all four components
- [ ] Prefer merging konflux-central first so sync does not overwrite this change

[RHAIENG-4246]: https://redhat.atlassian.net/browse/RHAIENG-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ARM64 build support alongside existing AMD64 targets for selected CUDA PyTorch pipeline and workbench images.
  - Enabled multi-architecture binary selection for both `x86_64` and `aarch64`.
  - Updated PipelineRun configurations to build and prefetch artifacts across multiple CPU architectures (including PyTorch and PyTorch+LLM compressor workbench images).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->