### PR TITLE
[rhoai-3.4] fix(tests): allow PyPI index for images in AIPCC migration phase 1.5

### DIFF
--- a/tests/containers/base_image_test.py
+++ b/tests/containers/base_image_test.py
@@ -46,9 +46,13 @@ class TestBaseImage:
             if not env:
                 # No env from skopeo or local inspect; assume non-AIPCC so PyPI checks run.
                 return False
+            # If PIP_INDEX_URL points to PyPI, the image is still in AIPCC migration
+            # phase 1.5 — packages are from PyPI and runtime installs must match.
+            pip_index = env.get("PIP_INDEX_URL")
+            if pip_index is not None and index_config_utils.is_pypi_index_url(pip_index):
+                return False
             if "PIP_CONFIG_FILE" in env or "UV_CONFIG_FILE" in env:
                 return True
-            pip_index = env.get("PIP_INDEX_URL")
             if pip_index is not None:
                 return not index_config_utils.is_pypi_index_url(pip_index)
             return False


### PR DESCRIPTION
## Summary

Fixes the `test_python_package_index` failure on `rocm-jupyter-tensorflow-ubi9-python-3.12` and
`runtimes/rocm-tensorflow` images that are still in AIPCC migration phase 1.5.

**Root cause:** The `_has_uv_lock_d` heuristic in `base_image_test.py` checks image env vars to
determine whether an image is AIPCC-enabled. It sees `PIP_CONFIG_FILE=/opt/app-root/pip.conf`
(injected by the base image's `aipcc.sh`) and immediately classifies the image as AIPCC. However,
the ROCm TensorFlow images also explicitly set `PIP_INDEX_URL=https://pypi.org/simple` (the
"phase 1.5" block from [RHAIENG-2189](https://redhat.atlassian.net/browse/RHAIENG-2189)) because their lockfile still resolves from PyPI. The test
then fails asserting that `PIP_INDEX_URL` must not point to PyPI.

**Fix:** Check `PIP_INDEX_URL` *before* `PIP_CONFIG_FILE`. If the env var explicitly points to
PyPI, the image is in phase 1.5 — its packages are from PyPI and runtime installs must stay
consistent. The function returns `False`, routing to `_check_pypi_env_vars` (which passes).

### Why not cherry-pick from main?

On `main`, this was resolved differently:
1. `f5327ea6c` migrated the lockfile to AIPCC packages
2. `c0bebb2c6` removed the env var overrides
3. `7e1b9d9165` ([RHAIENG-4654](https://redhat.atlassian.net/browse/RHAIENG-4654)) deleted `_has_uv_lock_d` entirely (all images are AIPCC on main)

None of these are safe to cherry-pick to `rhoai-3.4`:
- The Dockerfile fix (`c0bebb2c6`) conflicts and would route runtime installs to AIPCC while
  baked-in packages are from PyPI — creating the exact ABI mismatch the test guards against.
- The test simplification (`7e1b9d9165`) removes the PyPI code path entirely, which is needed
  here since ROCm TensorFlow hasn't been migrated yet.

### Affected images

- `jupyter/rocm/tensorflow/ubi9-python-3.12` (Dockerfile.rocm + Dockerfile.konflux.rocm)
- `runtimes/rocm-tensorflow/ubi9-python-3.12` (Dockerfile.rocm + Dockerfile.konflux.rocm)

### CI failure this unblocks

- https://github.com/red-hat-data-services/notebooks/actions/runs/30238315990/job/89890380160?pr=2599

### Validation run

- https://github.com/red-hat-data-services/notebooks/actions/runs/30256667381

## Test plan

- [ ] `rocm-jupyter-tensorflow-ubi9-python-3.12` build+test passes (env vars validated via PyPI path)
- [ ] Other AIPCC images (cuda-pytorch, cuda-tensorflow, rocm-pytorch) still pass the AIPCC path
- [ ] `make test` passes locally (static tests unaffected)

[RHAIENG-2189]: https://redhat.atlassian.net/browse/RHAIENG-2189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4654]: https://redhat.atlassian.net/browse/RHAIENG-4654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ