### PR TITLE
[rhoai-2.25] fix(jupyter): libxcrypt-compat for pytorch+llmcompressor CUDA

### DIFF
--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -100,7 +100,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -100,7 +100,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile && dnf clean all && rm -rf /var/cache/yum
+RUN dnf install -y jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat && dnf clean all && rm -rf /var/cache/yum
 
 # Copy dynamically-linked mongocli built in earlier build stage
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/


### PR DESCRIPTION
## Summary
- Add `libxcrypt-compat` to `jupyter/pytorch+llmcompressor` CUDA Dockerfiles (`Dockerfile.cuda` and `Dockerfile.konflux.cuda`).
- Aligns with `jupyter/pytorch` CUDA images, which already install this package.

## Problem
CI for `cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12` failed `test_elf_files_can_link_runtime_libs`: bundled MySQL SASL plugins (`mysql/vendor/private/sasl2/libplain.so`) require `libcrypt.so.1`, provided by `libxcrypt-compat` on UBI 9.

Runtime `pytorch+llmcompressor` images already had `libxcrypt-compat` in `cuda-base`; only the **jupyter** stage was missing it.

Related: https://github.com/red-hat-data-services/notebooks/pull/2485#issuecomment-5090872040

## Test plan
- [ ] `make test` (static)
- [ ] Re-run `cuda-jupyter-pytorch-llmcompressor-ubi9-python-3.12` PR matrix job and confirm `test_elf_files_can_link_runtime_libs` passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA-enabled Jupyter environments by adding compatibility support for applications requiring legacy cryptographic libraries.
  * Applied the fix consistently across both supported container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->