### PR TITLE
RHAIENG-5795: chore(deps): fix CVE-2026-48526 - bump PyJWT to 2.13.0

### DIFF
--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -23,5 +23,5 @@ starlette>=1.0.1
 # RHAIENG-3754: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
 black>=26.3.1
 
-# RHAIENG-3755: CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 violation)
-pyjwt>=2.12.0
+# RHAIENG-5795: CVE-2026-48526 PyJWT: Authentication bypass via forged JWTs
+pyjwt>=2.13.0


### PR DESCRIPTION
## Summary

Fixes CVE-2026-48526 by upgrading PyJWT from 2.12.0 to 2.13.0 on **rhoai-3.3** branch.

## CVE Details

**CVE-2026-48526**: Authentication bypass due to forged JSON Web Tokens
- PyJWT accepts public-key JWK as HMAC secret, enabling forged HS256 tokens
- CVSS: 7.4 (HIGH)
- Fixed in: **PyJWT 2.13.0**

## Changes

- Updated `dependencies/cve-constraints.txt`: `pyjwt>=2.13.0`
- Regenerated all lockfiles via `make refresh-lock-files`

## Testing

- [ ] Lockfiles regenerated successfully
- [ ] PyJWT resolved to 2.13.0 in all affected images

## References

- Jira: [RHAIENG-5795](https://redhat.atlassian.net/browse/RHAIENG-5795)
- Advisory: [GHSA-xgmm-8j9v-c9wx](https://github.com/advisories/GHSA-xgmm-8j9v-c9wx)

🤖 Generated with Claude Code

[RHAIENG-5795]: https://redhat.atlassian.net/browse/RHAIENG-5795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum PyJWT version to address a known security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->