### PR TITLE
RHAIENG-5794: chore(deps): fix CVE-2026-48526 - bump PyJWT to 2.13.0

### DIFF
--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -20,9 +20,9 @@ onnxconverter-common~=1.16.0
 tornado>=6.5.5
 # RHAIENG-5355: CVE-2026-48710 Starlette: Security restriction bypass via malformed HTTP Host header
 starlette>=1.0.1
-# RHAIENG-3795: CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 violation)
-# Reference: https://access.redhat.com/security/cve/CVE-2026-32597
-pyjwt>=2.12.0
+# RHAIENG-5794: CVE-2026-48526 PyJWT: Authentication bypass via forged JWTs
+# Reference: https://github.com/advisories/GHSA-xgmm-8j9v-c9wx
+pyjwt>=2.13.0
 # RHAIENG-3841: CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion
 # Reference: https://access.redhat.com/security/cve/CVE-2026-30922
 pyasn1>=0.6.3


### PR DESCRIPTION
## Summary

Fixes CVE-2026-48526 by upgrading PyJWT from 2.12.0 to 2.13.0 on **rhoai-2.25** branch.

## CVE Details

**CVE-2026-48526**: Authentication bypass due to forged JSON Web Tokens
- PyJWT accepts public-key JWK as HMAC secret, enabling forged HS256 tokens
- CVSS: 7.4 (HIGH)
- Fixed in: **PyJWT 2.13.0**

## Changes

- Updated `dependencies/cve-constraints.txt`: `pyjwt>=2.13.0`
- Regenerated all lockfiles

## Testing

- [ ] Lockfiles regenerated successfully
- [ ] PyJWT resolved to 2.13.0 in all affected images

## References

- Jira: [RHAIENG-5794](https://redhat.atlassian.net/browse/RHAIENG-5794)
- Advisory: [GHSA-xgmm-8j9v-c9wx](https://github.com/advisories/GHSA-xgmm-8j9v-c9wx)

🤖 Generated with Claude Code

[RHAIENG-5794]: https://redhat.atlassian.net/browse/RHAIENG-5794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ