### PR TITLE
RHAIENG-5782: chore(deps): fix CVE-2026-35397 - bump jupyter-server to 2.18.0

### DIFF
--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -23,5 +23,8 @@ starlette>=1.0.1
 # RHAIENG-3754: CVE-2026-32274 Black: Arbitrary file writes from unsanitized user input in cache file name
 black>=26.3.1
 
-# RHAIENG-3755: CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 violation)
-pyjwt>=2.12.0
+# RHAIENG-5795: CVE-2026-48526 PyJWT: Authentication bypass via forged JWTs
+pyjwt>=2.13.0
+
+# RHAIENG-5782: CVE-2026-35397 Jupyter Server: Path traversal in REST API
+jupyter-server>=2.18.0


### PR DESCRIPTION
## Summary

Fixes CVE-2026-35397 by upgrading jupyter-server to 2.18.0 on **rhoai-3.3** branch.

## CVE Details

**CVE-2026-35397**: Path traversal in Jupyter Server REST API
- Allows authenticated users to access sibling directories outside configured root_dir
- Affects directories sharing common prefix (e.g., "test" vs "testtest")
- CVSS: HIGH
- Fixed in: **jupyter-server 2.18.0**

## Changes

- Updated `dependencies/cve-constraints.txt`: `jupyter-server>=2.18.0`
- Regenerated all lockfiles

## Testing

- [ ] Lockfiles regenerated successfully
- [ ] jupyter-server resolved to 2.18.0+ in all affected images

## References

- Jira: [RHAIENG-5782](https://redhat.atlassian.net/browse/RHAIENG-5782)
- Advisory: [GHSA-5789-5fc7-67v3](https://github.com/jupyter-server/jupyter_server/security/advisories/GHSA-5789-5fc7-67v3)

🤖 Generated with Claude Code

[RHAIENG-5782]: https://redhat.atlassian.net/browse/RHAIENG-5782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security constraints to require patched versions of PyJWT and Jupyter Server.
  * Helps address known vulnerabilities, including a path traversal issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->