### PR TITLE
fix(ci): run RPM lock renewal on ubuntu-26.04

### DIFF
--- a/.github/workflows/rpms-lock-renewal.yaml
+++ b/.github/workflows/rpms-lock-renewal.yaml
@@ -35,7 +35,10 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   refresh-rpm-lock-files:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    # Match build-notebooks-TEMPLATE / install-podman-action (Podman 5.7+).
+    # ubuntu-latest is still 24.04 and fails the AppArmor pasta peer reload
+    # (apparmor_parser exits 2 when /etc/apparmor.d/usr.bin.pasta is absent).
+    runs-on: ubuntu-26.04
     concurrency:
       group: refresh-rpm-lock-files-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- Follow-up to #2643: `runs-on: ubuntu-latest` resolved to **ubuntu-24.04** and broke `install-podman-action` (AppArmor pasta reload exits 2 when `usr.bin.pasta` is missing).
- Switch RPM lock renewal to **`ubuntu-26.04`**, matching Build Notebooks / `install-podman-action`.

Failed run: https://github.com/red-hat-data-services/notebooks/actions/runs/30529455139/job/90828049465

## Test plan
- [ ] Dispatch **RPM Lock Files Renewal Action** with `--ref fix/rhoai-2.25-rpms-lock-ubuntu-26.04`, `variant=rhds`, `branch=rhoai-2.25`
- [ ] Confirm runner is ubuntu-26.04 and Install Podman succeeds


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the RPM lock-file renewal process to run on a newer Ubuntu environment.
  * Improved workflow documentation explaining the runner requirement and preventing AppArmor-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->