### PR TITLE
RHAIENG-6622: fix(ci): use composite setup-uv action instead of version: latest [rhoai-3.3]

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,14 +17,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # https://github.com/astral-sh/setup-uv
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
-        with:
-          version: "latest"
-          python-version: "3.14"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+      - uses: ./.github/actions/setup-uv
 
       - name: Run the release notes script
         run: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -15,20 +15,12 @@ jobs:
       contents: read
       security-events: write
     steps:
-
-      # https://github.com/astral-sh/setup-uv
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
-        with:
-          version: "latest"
-          activate-environment: false
-          ignore-empty-workdir: true
-          enable-cache: false
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-uv
 
       # Trivy does not support pylock.toml https://github.com/aquasecurity/trivy/discussions/9408
       - run: find . -name pyproject.toml -execdir uv lock \;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-6622

## Summary

- Replace `version: "latest"` in `docs.yaml` and `security.yaml` with the composite `.github/actions/setup-uv` action
- This reads `version-file: pyproject.toml` (honoring `required-version = ">=0.9,<0.12"`) instead of blindly installing the latest uv release
- Fixes CI breakage caused by uv 0.12.0 release on 2026-07-28

### Root cause

The `docs.yaml` and `security.yaml` workflows used `astral-sh/setup-uv` with `version: "latest"`. When uv 0.12.0 was released, CI installed it, but `pyproject.toml` has `required-version = ">=0.9,<0.12"` — so `uv run` refused to execute.

All other branches (main, rhoai-3.5, rhoai-3.4, rhoai-2.25) were already protected because they use the composite action or `version-file: pyproject.toml`.

### Changes

| File | Before | After |
|---|---|---|
| `docs.yaml` | `version: "latest"` | `.github/actions/setup-uv` composite action |
| `security.yaml` | `version: "latest"` + checkout after uv | checkout first + `.github/actions/setup-uv` composite action |

## Test plan

- [ ] "Docs (release notes)" workflow passes on this PR
- [ ] "Security" workflow passes on this PR

[RHAIENG-6622]: https://redhat.atlassian.net/browse/RHAIENG-6622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation release-note and security workflows to use the repository’s standardized toolchain setup.
  * Preserved existing code checkout, security scanning, and report-upload behavior.
  * No changes to application features or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->