### PR TITLE
RHAIENG-6623: fix(ci): use three-dot diff to detect only PR changes [rhoai-3.3]

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -22,9 +22,12 @@ def get_github_token() -> str:
 def list_changed_files(from_ref: str, to_ref: str) -> list[str]:
     logging.debug("Getting list of changed files from git diff")
 
+    # Use three-dot diff to show changes from merge-base to to_ref
+    # This correctly shows only changes introduced by the PR, regardless of how much from_ref has advanced
+    # See: https://github.com/opendatahub-io/notebooks/issues/2875
     # https://github.com/red-hat-data-services/notebooks/pull/361: add -- in case to_ref matches a file name in the repo
     files = subprocess.check_output(
-        ["git", "diff", "--name-only", from_ref, to_ref, "--"], encoding="utf-8"
+        ["git", "diff", "--name-only", f"{from_ref}...{to_ref}", "--"], encoding="utf-8"
     ).splitlines()
 
     logging.debug(f"Determined {len(files)} changed files: {files[:100]} (..., printing up to 100 files)")
@@ -152,8 +155,8 @@ class SelfTests(unittest.TestCase):
         }
 
     def test_get_build_directory(self):
-        directory = get_build_directory("rocm-jupyter-pytorch-ubi9-python-3.11")
-        assert directory == "jupyter/rocm/pytorch/ubi9-python-3.11"
+        directory = get_build_directory("rocm-jupyter-pytorch-ubi9-python-3.12")
+        assert directory == "jupyter/rocm/pytorch/ubi9-python-3.12"
 
     def test_get_build_dockerfile(self):
         dockerfile = get_build_dockerfile("rocm-jupyter-pytorch-ubi9-python-3.11")


### PR DESCRIPTION
## Summary

Cherry-pick of #2876 (main) to rhoai-3.3.

PR builds use a two-dot `git diff` to detect changed files, which compares branch tips directly. When the base branch advances after a PR is created, files changed in the base (not the PR) appear as "changed", triggering unnecessary image rebuilds.

Fix: use three-dot diff (`A...B`) which shows only changes introduced by the PR since the merge base.

### Changes

- `ci/cached-builds/gha_pr_changed_files.py`: `from_ref, to_ref` → `f"{from_ref}...{to_ref}"`
- Fix `test_get_build_directory` assertion to reference `ubi9-python-3.12` (the only version that exists on this branch)

### Context

- Original fix: https://github.com/opendatahub-io/notebooks/pull/2876
- Jira: [RHAIENG-6623](https://redhat.atlassian.net/browse/RHAIENG-6623)
- Already fixed on: main, rhoai-3.4, rhoai-3.5
- Still affected: rhoai-2.25 (separate PR), rhoai-3.3 (this PR)

## Test plan

- [ ] "Build Notebooks" PR workflow passes — should only build targets for actually changed files

[RHAIENG-6623]: https://redhat.atlassian.net/browse/RHAIENG-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of changed files in pull request builds.
  * Updated build validation for Python 3.12 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->