### PR TITLE
[rhoai-2.25] RHAIENG-6622: bump uv ceiling to <0.13 and pin to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.10,<0.12"
+required-version = ">=0.11.8,<0.13"
 package = true
 environments = [
     "sys_platform == 'darwin'",

--- a/uv
+++ b/uv
@@ -13,7 +13,7 @@
 # The pinned version is cached by uvx after the first run.
 set -Eeuo pipefail
 
-UV_VERSION="0.11.27"
+UV_VERSION="0.12.0"
 
 # Fast path: use the system uv directly if it already matches the pinned version
 if current=$(uv --version 2>/dev/null); then


### PR DESCRIPTION
## Summary

Raise the uv version ceiling from `<0.12` to `<0.13` and update the `./uv` wrapper pin from `0.11.27` to `0.12.0` on rhoai-2.25.

### Changes

| File | Before | After |
|---|---|---|
| `pyproject.toml` `required-version` | `>=0.10,<0.12` | `>=0.11.8,<0.13` |
| `./uv` wrapper `UV_VERSION` | `0.11.27` | `0.12.0` |

### Lock files

`gmake refresh-pipfilelock-files` produced no diff — existing locks are already compatible with uv 0.12.0.

### Context

- Original fix on main: https://github.com/opendatahub-io/notebooks/pull/4219
- Jira: [RHAIENG-6622](https://redhat.atlassian.net/browse/RHAIENG-6622)
- uv 0.12.0 was released 2026-07-28

## Test plan

- [ ] CI workflows pass (setup-uv reads `required-version` from pyproject.toml)
- [ ] `./uv --version` reports 0.12.0

[RHAIENG-6622]: https://redhat.atlassian.net/browse/RHAIENG-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported `uv` version range.
  * Updated the project’s pinned `uv` version to 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->