### PR TITLE
docs: prohibit git add -A/./--all in AGENTS.md, require explicit staging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,12 @@ make refresh-lock-files
   pipeline regen, imagestream manifest updates), a scoped pathspec is fine — but only right
   after checking `git status`/`git diff --stat` for that scope so you know exactly what it
   matches, using a tight pattern anchored to a shared prefix and suffix (e.g.
-  `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`). Re-run
-  `git status` before committing to confirm nothing else rode along. If the changed set is
-  short enough to read at a glance, just spell out the filenames — a glob earns its keep only
-  when the set is too large to enumerate by hand.
+  `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`). Before
+  committing, re-run `git status` and skim `git diff --cached` for the staged paths —
+  `git status` only shows which paths are staged, not which hunks, so a file you explicitly
+  staged can still carry an unrelated edit. If the changed set is short enough to read at a
+  glance, just spell out the filenames — a glob earns its keep only when the set is too large
+  to enumerate by hand.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,15 @@ make refresh-lock-files
 - Prefer existing docs over guesswork. Read the linked doc before inventing process or policy.
 - Verify bulk edits after scripting them. This repo has generated files and repeated patterns.
 - Update nearby documentation when behavior changes, especially build, dependency, and CI workflows.
+- Stage explicitly: `git add <file1> <file2> ...`. For genuine bulk-regen output where
+  hand-listing every path is impractical (lockfiles from `make refresh-lock-files`, `.tekton/`
+  pipeline regen, imagestream manifest updates), a scoped pathspec is fine — but only right
+  after checking `git status`/`git diff --stat` for that scope so you know exactly what it
+  matches, using a tight pattern anchored to a shared prefix and suffix (e.g.
+  `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`). Re-run
+  `git status` before committing to confirm nothing else rode along. If the changed set is
+  short enough to read at a glance, just spell out the filenames — a glob earns its keep only
+  when the set is too large to enumerate by hand.
 
 ## Boundaries
 
@@ -96,6 +105,9 @@ make refresh-lock-files
   directly (PipelineRuns are synced from `konflux-central`). Bump container OS bases
   to RHEL/UBI/CentOS 10 or accept MintMaker PRs that do — the project stays on EL9;
   see [base-images/README.md](base-images/README.md#os-version-policy-el9-only).
+  Stage with `git add -A`, `git add .`, or `git add --all` — these sweep in whatever
+  else is sitting in the tree (scratch files, unrelated in-progress edits, generated
+  artifacts) with no chance to notice until it's already committed.
 
 ## Communication
 


### PR DESCRIPTION
## Description

Cherry-pick (`-x`) of opendatahub-io/notebooks#4228 onto `rhoai-3.5`, closing opendatahub-io/notebooks#3557 on this branch.

`AGENTS.md` on `rhoai-3.5` was byte-identical to `main` at the time of the cherry-pick, so this applied cleanly with no conflicts.

Adds a git-staging rule to `AGENTS.md`:

- **Boundaries → Never:** don't stage with `git add -A`, `git add .`, or `git add --all`.
- **Agent conduct:** stage explicitly by filename, with a conditional scoped-pathspec exception for genuine bulk-regen output (lockfiles, `.tekton/`, imagestream manifests), gated on inspecting the change set before and re-checking `git status` after.

## How Has This Been Tested?

Docs-only change, cherry-picked verbatim from an already-reviewed upstream PR.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — N/A, docs-only change with no code/build impact
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. This is a doc-only exception synced manually because `AGENTS.md` content isn't part of the automated sync.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidance for safely staging files and reviewing changes before committing.
  * Recommended explicit filenames and scoped path selections for verified generated outputs.
  * Warned against broad staging commands that could include unrelated or generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->