### PR TITLE
docs: prohibit git add -A/./--all in AGENTS.md, require explicit staging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,9 +254,11 @@ When contributing to this project:
      `git status`/`git diff --stat` for that scope so you know exactly what it
      matches, using a tight pattern anchored to a shared prefix and suffix (e.g.
      `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`).
-     Re-run `git status` before committing to confirm nothing else rode along. If the
-     changed set is short enough to read at a glance, just spell out the filenames —
-     a glob earns its keep only when the set is too large to enumerate by hand.
+     Before committing, re-run `git status` and skim `git diff --cached` for the staged
+     paths — `git status` only shows which paths are staged, not which hunks, so a file
+     you explicitly staged can still carry an unrelated edit. If the changed set is short
+     enough to read at a glance, just spell out the filenames — a glob earns its keep only
+     when the set is too large to enumerate by hand.
 3. **Write clear commit messages**
 4. **Add tests** for new functionality
 5. **Update documentation**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,9 +243,23 @@ make undeploy9-${NOTEBOOK_NAME} # Cleanup
 When contributing to this project:
 
 1. **Fork and branch** from main
-2. **Write clear commit messages**
-3. **Add tests** for new functionality
-4. **Update documentation**
+2. **Stage and commit carefully**:
+   - Stage explicitly: `git add <file1> <file2> ...`. Do **NOT** use `git add -A`,
+     `git add .`, or `git add --all` — these stage everything in the tree (scratch
+     files, unrelated in-progress edits, generated artifacts) with no chance to
+     notice until it's already committed.
+   - For genuine bulk-regen output where hand-listing every path is impractical
+     (lockfiles from `make refresh-lock-files`, `.tekton/` pipeline regen, imagestream
+     manifest updates), a scoped pathspec is fine — but only right after checking
+     `git status`/`git diff --stat` for that scope so you know exactly what it
+     matches, using a tight pattern anchored to a shared prefix and suffix (e.g.
+     `git add .tekton/odh-*-pull-request.yaml`, not `git add .tekton/*` or `git add .`).
+     Re-run `git status` before committing to confirm nothing else rode along. If the
+     changed set is short enough to read at a glance, just spell out the filenames —
+     a glob earns its keep only when the set is too large to enumerate by hand.
+3. **Write clear commit messages**
+4. **Add tests** for new functionality
+5. **Update documentation**
 
 For detailed contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
## Description

Adaptation of opendatahub-io/notebooks#4228 onto `rhoai-3.4`, closing opendatahub-io/notebooks#3557 on this branch.

`AGENTS.md` on `rhoai-3.4` predates the `Agent conduct`/`Boundaries` section structure used on `main`, so the cherry-pick conflicted and was resolved manually: the rule is folded into this branch's existing `Contributing` numbered list as a new **"Stage and commit carefully"** item, rather than applied verbatim.

- Bans `git add -A`, `git add .`, `git add --all`.
- Allows a scoped pathspec for genuine bulk-regen output (lockfiles, `.tekton/`, imagestream manifests) — gated on inspecting the change set first and re-checking `git status` before committing.

## How Has This Been Tested?

Docs-only change. Diffed the resolved file against the upstream commit's intent to confirm equivalent content, just relocated into this branch's own section structure.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review — N/A, docs-only change with no code/build impact
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. This is a doc-only exception synced manually because `AGENTS.md` content isn't part of the automated sync, and this branch's copy has diverged in structure from upstream.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidance with clearer instructions for safely staging files.
  * Added recommendations for using scoped paths when staging multiple generated files.
  * Added verification steps using status checks and change summaries before committing.
  * Clarified practices that help contributors review and confirm staged changes accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->