### PR TITLE
[rhoai-3.5] fix(ci): resolve test-containers cross-org GHCR auth failure

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -4,18 +4,15 @@ name: Test Infrastructure Self-Test
 "on":
   workflow_dispatch:
   pull_request:
-    paths:
+    paths: &test-containers-paths
       - 'tests/containers/**'
       - 'tests/conftest.py'
       - 'pytest.ini'
       - '.github/workflows/test-containers.yaml'
+      - 'ci/find_images_for_test_matrix.py'
   push:
     branches: [main, stable, 'rhoai-*']
-    paths:
-      - 'tests/containers/**'
-      - 'tests/conftest.py'
-      - 'pytest.ini'
-      - '.github/workflows/test-containers.yaml'
+    paths: *test-containers-paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,7 +24,7 @@ permissions:
 
 env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
-  IMAGE_REGISTRY: "ghcr.io/opendatahub-io/notebooks/workbench-images"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}/workbench-images"
 
 jobs:
   find-images:
@@ -48,22 +45,34 @@ jobs:
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
         shell: python
         # language=python
         run: |
-          import json, os, subprocess, sys
+          import json, os, re, subprocess, sys
           sys.path.insert(0, "ci")
 
           from find_images_for_test_matrix import find_suitable_sha
 
           registry = os.environ["IMAGE_REGISTRY"]
-          suffix = "_odh_linux_amd64"
+          if os.environ.get("GITHUB_REPOSITORY") == "opendatahub-io/notebooks":
+              tag_suffix = "_odh_linux_amd64"
+          else:
+              tag_suffix = "_rhoai_linux_amd64"
           required = [
               "codeserver-ubi9-python-3.12",
               "jupyter-minimal-ubi9-python-3.12",
               "jupyter-datascience-ubi9-python-3.12",
               "runtime-datascience-ubi9-python-3.12",
           ]
+          # 40 is a placeholder cap, not derived from anything. The exactly-correct
+          # value would mirror build-notebooks-TEMPLATE.yaml's max_ref_len formula
+          # (128 - len(target) - 7-char short sha - len(suffix) - 3 separators),
+          # minimized over `required` since that formula is computed per target
+          # there. In practice it doesn't matter: real branch names (main, stable,
+          # rhoai-X.Y[-eaN]) are far shorter than either cap, so no truncation ever
+          # actually happens on either side.
+          ref_prefix = re.sub(r"[^a-zA-Z0-9._-]", "_", os.environ["REF_NAME"])[:40]
 
           result = subprocess.run(
               ["skopeo", "list-tags", "--creds", f"token:{os.environ['GH_TOKEN']}", f"docker://{registry}"],
@@ -73,11 +82,11 @@ jobs:
               print(f"::error::skopeo list-tags failed: {result.stderr}", file=sys.stderr)
               sys.exit(1)
 
-          sha = find_suitable_sha(suffix, required, result.stdout)
+          sha = find_suitable_sha(ref_prefix, tag_suffix, required, result.stdout)
           matrix = {"include": [
-              {"name": img, "image": f"{registry}:{img}-main_{sha}{suffix}"} for img in required
+              {"name": img, "image": f"{registry}:{img}-{ref_prefix}_{sha}{tag_suffix}"} for img in required
           ]}
-          print(f"Using SHA {sha}")
+          print(f"Using ref {ref_prefix!r}, SHA {sha}")
           print(json.dumps(matrix, indent=2))
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:

--- a/ci/find_images_for_test_matrix.py
+++ b/ci/find_images_for_test_matrix.py
@@ -2,15 +2,20 @@ import json
 import sys
 
 
-def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> str:
-    """Skopeo lists tags oldest to newest."""
+def find_suitable_sha(ref_prefix: str, tag_suffix: str, required: list[str], skopeo_output: str) -> str:
+    """Skopeo lists tags oldest to newest.
+
+    Image tags are formed as ``{target}-{ref_prefix}_{sha}{tag_suffix}``.
+    """
     tags = list(json.loads(skopeo_output)["Tags"])
 
     sha_list: list[list[str]] = []
     for img in required:
-        prefix = f"{img}-main_"
+        prefix = f"{img}-{ref_prefix}_"
         shas = [
-            t.removeprefix(prefix).removesuffix(suffix) for t in tags if t.startswith(prefix) and t.endswith(suffix)
+            t.removeprefix(prefix).removesuffix(tag_suffix)
+            for t in tags
+            if t.startswith(prefix) and t.endswith(tag_suffix) and len(t) > len(prefix) + len(tag_suffix)
         ]
         print(f"  {img}: {len(shas)} builds")
         sha_list.append(shas)
@@ -27,15 +32,19 @@ def find_suitable_sha(suffix: str, required: list[str], skopeo_output: str) -> s
 
 
 def test_find_suitable_sha__single():
-    suffix = "_suffix"
-    required = ["codeserver-ubi9-python-3.12"]
-    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_suffix"]})
-    assert find_suitable_sha(suffix, required, skopeo_output) == "abdcef"
+    skopeo_output = json.dumps({"Tags": ["codeserver-ubi9-python-3.12-main_abdcef_odh_linux_amd64"]})
+    assert find_suitable_sha("main", "_odh_linux_amd64", ["codeserver-ubi9-python-3.12"], skopeo_output) == "abdcef"
+
+
+def test_find_suitable_sha__rhoai_branch_with_platform_suffix():
+    skopeo_output = json.dumps({"Tags": ["jupyter-minimal-ubi9-python-3.12-rhoai-2.25_abc1234_rhoai_linux_amd64"]})
+    assert (
+        find_suitable_sha("rhoai-2.25", "_rhoai_linux_amd64", ["jupyter-minimal-ubi9-python-3.12"], skopeo_output)
+        == "abc1234"
+    )
 
 
 def test_find_suitable_sha__multiple():
-    suffix = "_suffix"
-    required = ["img-a", "img-b"]
     skopeo_output = json.dumps(
         {
             "Tags": [
@@ -46,10 +55,11 @@ def test_find_suitable_sha__multiple():
             ]
         }
     )
-    assert find_suitable_sha(suffix, required, skopeo_output) == "new222"
+    assert find_suitable_sha("main", "_suffix", ["img-a", "img-b"], skopeo_output) == "new222"
 
 
 if __name__ == "__main__":
     test_find_suitable_sha__single()
+    test_find_suitable_sha__rhoai_branch_with_platform_suffix()
     test_find_suitable_sha__multiple()
     print("OK")


### PR DESCRIPTION
## Summary

`test-containers.yaml` on `rhoai-3.5` hardcodes `IMAGE_REGISTRY: ghcr.io/opendatahub-io/notebooks/workbench-images` and authenticates `skopeo list-tags` with `github.token`. That token belongs to this repo's (`red-hat-data-services/notebooks`) GitHub App installation, which has no relationship to the `opendatahub-io` org, so GHCR rejects it outright:

```
skopeo list-tags failed: ... denied: permission_denied: The requested installation does not exist.
```

Observed on PR #2666 (MintMaker `github-actions` bump, which happened to touch this workflow file and re-trigger it): https://github.com/red-hat-data-services/notebooks/actions/runs/30632832792/job/91194084138

This is the same bug already fixed downstream on `rhoai-2.25` ([RHAIENG-6066](https://redhat.atlassian.net/browse/RHAIENG-6066) / #2450) by resolving `IMAGE_REGISTRY`, ref prefix, and tag suffix from `github.repository`/branch name instead of hardcoding the ODH org. That fix has now been ported to `opendatahub-io/notebooks` `main` (opendatahub-io/notebooks#4244, squashed and merged); this PR cherry-picks (`-x`) that squashed commit onto `rhoai-3.5` so it stops inheriting the hardcoded ODH-only registry whenever it syncs from `main`.

Follow-up tracked upstream: a latent (currently unreachable) mismatch between this script's ref-prefix truncation cap and the publisher's per-target `max_ref_len` formula — see opendatahub-io/notebooks#4245.

## Test plan

- [x] `uv run pytest ci/find_images_for_test_matrix.py -v` passes (updated signature/tests)
- [x] YAML parses, anchors resolve correctly
- [ ] CI: "Test Infrastructure Self-Test" workflow finds images successfully on this PR (self-triggering, touches `.github/workflows/test-containers.yaml`)

[RHAIENG-6066]: https://redhat.atlassian.net/browse/RHAIENG-6066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection of test container images for pull requests and pushes.
  * Added support for branch-specific image tags and platform-specific suffixes.
  * Prevented invalid image entries without a matching commit identifier from being selected.

* **Tests**
  * Expanded coverage for repository-specific branches and platform image combinations.
  * Updated validation to confirm image discovery works across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->