### PR TITLE
[rhoai-2.25] fix(ci): loosen jupyter-minimal/datascience probe timeouts for ppc64le/s390x

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/datascience/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -33,26 +33,29 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Generous delays for slow or constrained nodes (e.g. ppc64le in CI).
+          # Liveness must allow Jupyter + datascience deps to bind before first check (avoids restart loops).
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 120
+            periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 90
+            periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
+          # Jupyter + papermill share the pod cgroup; keep headroom for datascience tests on ppc64le CI.
           resources:
             limits:
               cpu: 500m
-              memory: 2Gi
+              memory: 4Gi
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 4Gi

--- a/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
+++ b/jupyter/minimal/ubi9-python-3.12/kustomize/base/statefulset.yaml
@@ -33,22 +33,23 @@ spec:
             - name: notebook-port
               protocol: TCP
               containerPort: 8888
+          # Generous delays for slow or constrained nodes (e.g. ppc64le in CI)
           livenessProbe:
             tcpSocket:
               port: notebook-port
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /notebook/opendatahub/jovyan/api
               port: notebook-port
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 45
+            periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           resources:
             limits:
               cpu: 500m

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -267,11 +267,12 @@ class ImageDeployment:
 
             self.port = p.get_actual_port()
             LOGGER.debug(f"Listening on port {self.port}")
+            # Use 120s timeout for slower cold starts (e.g. code-server on arm64).
             Wait.until(
                 "Connecting to pod succeeds",
                 1,
-                30,
-                lambda: requests.get(f"http://localhost:{self.port}").status_code == 200,
+                120,
+                lambda: requests.get(f"http://127.0.0.1:{self.port}/api", timeout=10).status_code == 200,
             )
             LOGGER.debug("Done setting up portforward")
 


### PR DESCRIPTION
## Description

Backports a fix for pre-existing, branch-wide CI breakage on `rhoai-2.25`: `jupyter-minimal-ubi9-python-3.12` (ppc64le, s390x) and `jupyter-datascience-ubi9-python-3.12` (ppc64le) fail on essentially every push/PR (confirmed on the last 14+ unrelated runs, e.g. [PR #2641 run 30664191953](https://github.com/red-hat-data-services/notebooks/actions/runs/30664191953)).

**Root cause:** under QEMU emulation (ppc64le/s390x, since GHA runners are amd64), `jupyter lab` takes far longer to bind port 8888 than the hardcoded CI timeouts/probes assume:
- ppc64le goes through `scripts/test_jupyter_with_papermill.sh` → the `jupyter/{minimal,datascience}/ubi9-python-3.12/kustomize/base/statefulset.yaml` StatefulSet. Its `livenessProbe` (`5s` delay, `5s` period, `3` failures ≈ 20s grace) kills the container via SIGTERM before jupyter finishes starting, producing a permanent `CrashLoopBackOff` (`exitCode 143`, observed `restartCount: 9`) until the outer 600s `kubectl wait --for=condition=ready` gives up.
- s390x goes through `tests/containers/kubernetes_utils.py`'s `ImageDeployment.deploy()` instead (no k8s probes at all there), whose own hardcoded app-level check — `Wait.until("Connecting to pod succeeds", 1, 30, ...)` — only allows 30s, too short for the same reason (`WaitError: Timeout after 30 s ... Remote end closed connection`).

**This exact problem was already diagnosed and fixed on `main`, but never backported here.** This PR is a partial cherry-pick of the relevant hunks from 3 upstream commits (each bundles the fix with unrelated work — a hermetic build, a prefetch-input refactor, a code-server nginx security fix — that conflicts heavily with `rhoai-2.25`'s diverged state, so a literal `cherry-pick -x` of any of them fails outright):
- `70bf81778f3b7cc3a76ffe155d983c57e444ba86` — introduced the initial probe loosening for both `jupyter-minimal` and `jupyter-datascience`.
- `b76e061c47c0d1b822b9da5e60169eb83f6b5ffa` — raised `jupyter-datascience`'s liveness further (30→120s) and bumped its memory limit 2Gi→4Gi (comment: *"Jupyter + papermill share the pod cgroup; keep headroom for datascience tests on ppc64le CI"*).
- `f784977a25` / `86608705582326196e7b078fea6648b9f156295d` — raised the `kubernetes_utils.py` connect-wait timeout `30s → 60s → 120s` over time for the same non-native-architecture slowness, plus made the check itself more robust (`127.0.0.1`, explicit `/api` path, per-request `timeout=10`).

Each commit in this PR documents its exact upstream source(s) in the commit message trailer.

**Not changed:** the other 6 jupyter images with kustomize StatefulSets (`trustyai`, `pytorch`, `tensorflow`, `rocm/pytorch`, `rocm/tensorflow`, `pytorch+llmcompressor`) still have tight/moderate probes on `main` too — they haven't needed loosening because they aren't observed failing, so no changes proposed for those here.

Per the merge-criteria note below about `odh/notebooks` → `rhds/notebooks` sync: this PR intentionally goes the other direction (`main` → `rhoai-2.25`) because `rhoai-2.25` diverged from `main` before these fixes landed upstream, and the normal sync doesn't run against release branches.

## How Has This Been Tested?

- Verified each hunk against `main`'s current committed state directly (`git show main:<path>`) rather than reconstructing values from memory — the two `statefulset.yaml` files are now byte-identical to `main` except for one pre-existing, unrelated line (`--ServerApp.tornado_settings`, removed by a separate, unrelated commit on `main`).
- Validated YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`) on both `statefulset.yaml` files.
- Validated Python syntax (`ast.parse`) on `kubernetes_utils.py`; confirmed the pre-existing pyright diagnostics in that file are all in unrelated code, not touched by this change.
- Could not reproduce actual ppc64le/s390x QEMU-emulated jupyter startup timing locally in reasonable time — the real verification is this PR's own CI: the `jupyter-minimal-ubi9-python-3.12` (ppc64le, s390x) and `jupyter-datascience-ubi9-python-3.12` (ppc64le) jobs should go green here where they've been failing on every recent push/PR to `rhoai-2.25`.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release. — *N/A here, see note above: this intentionally backports from `main` to `rhoai-2.25` directly since the branch diverged before these fixes landed.*

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work — pending this PR's own ppc64le/s390x CI run, see "How Has This Been Tested?" above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jupyter startup reliability on slow or resource-constrained nodes by allowing health checks more time to complete.
  * Increased memory capacity for the Data Science environment from 2 GiB to 4 GiB.
  * Improved notebook deployment connectivity by using a more reliable local connection and clearer request timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->