### PR TITLE
[rhoai-2.25] ci(test-containers): add rstudio to the self-test image matrix

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -65,6 +65,7 @@ jobs:
               "jupyter-minimal-ubi9-python-3.12",
               "jupyter-datascience-ubi9-python-3.12",
               "runtime-datascience-ubi9-python-3.12",
+              "rstudio-rhel9-python-3.11",
           ]
 
           result = subprocess.run(


### PR DESCRIPTION
## Description

`.github/workflows/test-containers.yaml`'s "Test Infrastructure Self-Test" workflow had a hardcoded `required` image list (`codeserver`, `jupyter-minimal`, `jupyter-datascience`, `runtime-datascience`) that never included `rstudio-rhel9-python-3.11`. Adding it so the docker/testcontainers-based tests in `tests/containers/workbenches/workbench_image_test.py` (`test_image_entrypoint_starts`, `test_ipv6_only`) get exercised against rstudio too — it has its own TTY/tmpfs startup quirks (see the `WorkbenchContainer` defaults comments in that file) that aren't covered by any other image in this suite.

**Limitation (documented in the commit message):** this workflow's pytest invocation filters `-m 'not openshift and not cuda and not rocm'`, so it still won't run `test_image_run_on_openshift` (the test that exercises `kubernetes_utils.ImageDeployment`, i.e. the code touched by #2674) against rstudio. That test only runs as part of the full per-image `build-notebooks` pipeline (see the "Run OpenShift container tests (in PyTest)" step), which already builds rstudio unconditionally on `push`/`workflow_dispatch`. This PR is purely about closing the coverage gap in the *self-test* workflow, not a substitute for that.

## How Has This Been Tested?

- Validated YAML syntax and the embedded Python (`ast.parse`) locally.
- CI on this PR is the real test: the new `rstudio-rhel9-python-3.11` entry in the "Test Infrastructure Self-Test" matrix should run and pass.

Self checklist (all need to be checked):
- [x] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. — *N/A: this is a rhoai-2.25-specific CI coverage addition, not a code change that needs to flow from odh/notebooks.*

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [ ] The developer has manually tested the changes and verified that the changes work — pending this PR's own CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added the RHEL 9 Python 3.11 image to the automated test coverage matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->