### PR TITLE
[rhoai-2.25] fix(gha): stop workflow-only PRs from falsely triggering codeserver builds

### DIFF
--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -169,3 +169,9 @@ class SelfTests(unittest.TestCase):
 
     def test_should_build_target(self):
         assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.11")
+
+    def test_is_file_in_directory_distinguishes_prefix_siblings(self):
+        """Regression test for .github/workflows/... falsely matching the .git dependency."""
+        assert not _is_file_in_directory(".github/workflows/build-notebooks-pr.yaml", ".git")
+        assert _is_file_in_directory(".git/config", ".git")
+        assert _is_file_in_directory(".git", ".git")

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -11,7 +11,7 @@ import unittest
 from typing import Literal
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
-MAKE = shutil.which("gmake") or shutil.which("make")
+MAKE = shutil.which("gmake") or shutil.which("make") or "make"
 
 
 def get_github_token() -> str:
@@ -133,9 +133,12 @@ def filter_out_unchanged(targets: list[str], changed_files: list[str]) -> list[s
 
 
 def get_go_arch() -> Literal["amd64", "arm64", "ppc64le", "s390x"]:
-    arch = os.environ.get("GOARCH")
-    if arch is not None:
-        return arch
+    if goarch := os.environ.get("GOARCH"):
+        match goarch.lower():
+            case "amd64" | "arm64" | "ppc64le" | "s390x" as arch:
+                return arch
+            case _:
+                raise ValueError(f"Unsupported GOARCH value: {goarch!r}")
     match platform.machine().lower():
         case "x86_64" | "amd64":
             arch = "amd64"

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -80,13 +80,18 @@ def find_dockerfiles(directory: str) -> list:
     return matching_files
 
 
+def _is_file_in_directory(changed_file: str, directory: str) -> bool:
+    """Returns True if changed_file is exactly the directory or is within it."""
+    return changed_file == directory or changed_file.startswith(directory + "/")
+
+
 def should_build_target(changed_files: list[str], target_directory: str) -> str:
     """Returns truthy if there is at least one changed file necessitating a build.
     Falsy (empty) string is returned otherwise."""
 
     # detect change in the Dockerfile directory
     for changed_file in changed_files:
-        if changed_file.startswith(target_directory):
+        if _is_file_in_directory(changed_file, target_directory):
             return changed_file
     # detect change in any of the files outside
     dockerfiles = find_dockerfiles(target_directory)
@@ -107,7 +112,7 @@ def should_build_target(changed_files: list[str], target_directory: str) -> str:
         dependencies: list[str] = json.loads(stdout)
         for dependency in dependencies:
             for changed_file in changed_files:
-                if changed_file.startswith(dependency):
+                if _is_file_in_directory(changed_file, dependency):
                     return changed_file
     return ""
 

--- a/ci/cached-builds/gha_pr_changed_files.py
+++ b/ci/cached-builds/gha_pr_changed_files.py
@@ -164,11 +164,11 @@ class SelfTests(unittest.TestCase):
         assert directory == "jupyter/rocm/pytorch/ubi9-python-3.12"
 
     def test_get_build_dockerfile(self):
-        dockerfile = get_build_dockerfile("rocm-jupyter-pytorch-ubi9-python-3.11")
-        assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.11/Dockerfile.rocm"
+        dockerfile = get_build_dockerfile("rocm-jupyter-pytorch-ubi9-python-3.12")
+        assert dockerfile == "jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm"
 
     def test_should_build_target(self):
-        assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.11")
+        assert "" == should_build_target(["README.md"], "jupyter/datascience/ubi9-python-3.12")
 
     def test_is_file_in_directory_distinguishes_prefix_siblings(self):
         """Regression test for .github/workflows/... falsely matching the .git dependency."""


### PR DESCRIPTION
## Problem

Fixes #2553.

`ci/cached-builds/gha_pr_changed_files.py` used `changed_file.startswith(dependency)` to decide
whether a changed file falls inside a build dependency directory. Codeserver's build dependencies
include `.git`, and `".github/workflows/foo.yaml".startswith(".git")` is `True` — so any
`.github/**`-only PR (e.g. MintMaker workflow-pin bumps) falsely triggered expensive
`codeserver-ubi9-python-3.12` amd64/arm64 builds via `Build Notebooks (pr)`. Observed repeatedly,
e.g. https://github.com/red-hat-data-services/notebooks/actions/runs/29920787381 from #2540.

## Fix

Clean `git cherry-pick -x` of the fix already on `main`
([a4be6e813](https://github.com/opendatahub-io/notebooks/commit/a4be6e813d2b48e64964cf10e0b250cfb47bad85),
[opendatahub-io/notebooks#3094](https://github.com/opendatahub-io/notebooks/pull/3094)) — applied
with no conflicts since the surrounding code hasn't drifted. Introduces `_is_file_in_directory()`
requiring an exact match or a `directory + "/"` prefix, so `.github` and `.git` are correctly
distinguished.

Also fixes two pre-existing stale fixtures in the same file's embedded `SelfTests` (referencing
`ubi9-python-3.11` build targets/directories that no longer exist on `rhoai-2.25`, and an outdated
`Dockerfile.rocm` vs `Dockerfile.konflux.rocm` expectation) as separate commits, plus adds a
regression test for the exact `.git`/`.github` scenario from #2553.

**Note:** `SelfTests` in this file is not auto-collected by `make test` — pytest's default
`test_*.py`/`*_test.py` discovery pattern doesn't match `gha_pr_changed_files.py`, and nothing else
in CI invokes it directly. It's effectively dev-only, run manually (`pytest
ci/cached-builds/gha_pr_changed_files.py`). Not fixing that discovery gap here — orthogonal to this
PR's scope. The real fix is exercised through `gen_gha_matrix_jobs.py` → `filter_out_unchanged` →
`should_build_target`, which runs for real in `Build Notebooks (pr)`'s "Generate job matrix" step.

## Verification

- `uv run pytest ci/cached-builds/gha_pr_changed_files.py -v` — all 5 pass locally.
- `uv run pre-commit run --all-files` — clean.
- Real-world verification: open a workflow-only PR (e.g. a `.github/workflows/**`-only change) off
  this branch and confirm `Build Notebooks (pr)` no longer selects `codeserver-*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build change detection to correctly distinguish directories from similarly named sibling paths.
  * Prevented unnecessary builds caused by misleading directory-prefix matches.
  * Added a fallback to `make` when `gmake` is unavailable.
  * Added validation for supported Go architectures to provide clearer errors for unsupported values.

* **Tests**
  * Added regression coverage for directory boundary and prefix matching.
  * Updated build and container test environments to Python 3.12 and current naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->