### PR TITLE
[rhoai-2.25] fix(datascience): update `ARROW_ORC_URL` to match pinned pyarrow's ORC version

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -83,7 +83,9 @@ EOF
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-if [ "$TARGETARCH" = "s390x" ]; then
+# Rust is needed to build libcst from source (a build dep of pyarrow's requirements-build.txt);
+# no prebuilt libcst wheel exists for these architectures.
+if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then
     # Install Rust and set up environment
     mkdir -p /opt/.cargo
     export HOME=/root
@@ -145,6 +147,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    # /etc/profile.d scripts aren't sourced by non-login RUN shells; source explicitly for cargo/rustc.
+    source /etc/profile.d/cargo.sh
     PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform "$TARGETARCH")
     # pylock_version prints raw PEP 440; git tags need apache-arrow- prefix (no +local segment today).
     ARROW_BRANCH="apache-arrow-${PYARROW_VERSION}"

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -155,8 +155,11 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git
     cd arrow/cpp
     mkdir release && cd release
-    # ORC 2.0.1 was removed from downloads.apache.org; archive mirror has the expected tarball hash
-    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.0.1/orc-2.0.1.tar.gz"
+    # Pin to a fixed archive.apache.org URL instead of Arrow's default closer.lua mirror redirect,
+    # which is unreliable in CI. Version must match ARROW_ORC_BUILD_VERSION in
+    # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
+    # fails a checksum mismatch.
+    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/usr/local \
           -DARROW_PYTHON=ON \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -193,13 +193,18 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     pip install --upgrade pip
     # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
     pip install --force-reinstall setuptools==80.9.0 wheel
+    # Arrow 25.0.0 dropped python/setup.py for a PEP 517 (scikit-build-core) build;
+    # `python -m build` replaces `python setup.py build_ext ... bdist_wheel`. The
+    # PYARROW_WITH_*/PYARROW_BUNDLE_ARROW_CPP env vars are still read directly by
+    # python/CMakeLists.txt, so they carry over unchanged; PYARROW_PARALLEL is gone
+    # (Ninja/scikit-build-core parallelize automatically).
     PYARROW_WITH_PARQUET=1 \
     PYARROW_WITH_DATASET=1 \
     PYARROW_WITH_FILESYSTEM=1 \
     PYARROW_WITH_JSON=1 \
     PYARROW_WITH_CSV=1 \
-    PYARROW_PARALLEL=$(nproc) \
-    python setup.py build_ext --build-type=release --bundle-arrow-cpp bdist_wheel
+    PYARROW_BUNDLE_ARROW_CPP=1 \
+    python -m build --wheel --no-isolation --outdir dist .
     mkdir -p /tmp/wheels
     cp dist/pyarrow-*.whl /tmp/wheels/
     chmod -R 777 /tmp/wheels

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -87,17 +87,23 @@ set -Eeuxo pipefail
 # no prebuilt libcst wheel exists for these architectures.
 if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo
+    mkdir -p /opt/.cargo /opt/.rustup
     export HOME=/root
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
     chmod +x rustup-init.sh
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    # RUSTUP_HOME must be set explicitly too: the base image ships a pre-existing
+    # /root/.rustup/settings.toml, which makes rustup-init skip configuring a default
+    # toolchain ("rustup could not choose a version of rustc to run"). Isolating
+    # RUSTUP_HOME (like CARGO_HOME) and pinning --default-toolchain avoids that.
+    CARGO_HOME=/opt/.cargo RUSTUP_HOME=/opt/.rustup HOME=/root ./rustup-init.sh -y --no-modify-path \
+        --default-toolchain stable --profile minimal
     rm -f rustup-init.sh
-    chown -R 1001:0 /opt/.cargo
+    chown -R 1001:0 /opt/.cargo /opt/.rustup
     # Set environment variables
     cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
 export PATH=/opt/.cargo/bin:$PATH
 export CARGO_HOME=/opt/.cargo
+export RUSTUP_HOME=/opt/.rustup
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 CARGO_EOF
 fi

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -159,7 +159,9 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     # pylock_version prints raw PEP 440; git tags need apache-arrow- prefix (no +local segment today).
     ARROW_BRANCH="apache-arrow-${PYARROW_VERSION}"
     # Install build dependencies (shared for pyarrow and onnx)
-    dnf install -y cmake make gcc-c++ pybind11-devel wget
+    # ninja-build is required by scikit-build-core (pyarrow's PEP 517 build backend) to drive
+    # the CMake build; `python -m build` fails with "Missing dependencies: ninja>=1.5" without it.
+    dnf install -y cmake make gcc-c++ pybind11-devel wget ninja-build
     dnf clean all
     # Build and collect pyarrow wheel
     git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -83,7 +83,9 @@ EOF
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-if [ "$TARGETARCH" = "s390x" ]; then
+# Rust is needed to build libcst from source (a build dep of pyarrow's requirements-build.txt);
+# no prebuilt libcst wheel exists for these architectures.
+if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then
     # Install Rust and set up environment
     mkdir -p /opt/.cargo
     export HOME=/root
@@ -145,6 +147,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
+    # /etc/profile.d scripts aren't sourced by non-login RUN shells; source explicitly for cargo/rustc.
+    source /etc/profile.d/cargo.sh
     PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform "$TARGETARCH")
     ARROW_BRANCH="apache-arrow-${PYARROW_VERSION}"
     # Install build dependencies (shared for pyarrow and onnx)

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -154,8 +154,11 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git
     cd arrow/cpp
     mkdir release && cd release
-    # ORC 2.0.1 was removed from downloads.apache.org; archive mirror has the expected tarball hash
-    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.0.1/orc-2.0.1.tar.gz"
+    # Pin to a fixed archive.apache.org URL instead of Arrow's default closer.lua mirror redirect,
+    # which is unreliable in CI. Version must match ARROW_ORC_BUILD_VERSION in
+    # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
+    # fails a checksum mismatch.
+    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/usr/local \
           -DARROW_PYTHON=ON \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -158,7 +158,9 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform "$TARGETARCH")
     ARROW_BRANCH="apache-arrow-${PYARROW_VERSION}"
     # Install build dependencies (shared for pyarrow and onnx)
-    dnf install -y cmake make gcc-c++ pybind11-devel wget
+    # ninja-build is required by scikit-build-core (pyarrow's PEP 517 build backend) to drive
+    # the CMake build; `python -m build` fails with "Missing dependencies: ninja>=1.5" without it.
+    dnf install -y cmake make gcc-c++ pybind11-devel wget ninja-build
     dnf clean all
     # Build and collect pyarrow wheel
     git clone --depth 1 --branch "${ARROW_BRANCH}" https://github.com/apache/arrow.git

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -87,17 +87,23 @@ set -Eeuxo pipefail
 # no prebuilt libcst wheel exists for these architectures.
 if [ "$TARGETARCH" = "s390x" ] || [ "$TARGETARCH" = "ppc64le" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo
+    mkdir -p /opt/.cargo /opt/.rustup
     export HOME=/root
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
     chmod +x rustup-init.sh
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    # RUSTUP_HOME must be set explicitly too: the base image ships a pre-existing
+    # /root/.rustup/settings.toml, which makes rustup-init skip configuring a default
+    # toolchain ("rustup could not choose a version of rustc to run"). Isolating
+    # RUSTUP_HOME (like CARGO_HOME) and pinning --default-toolchain avoids that.
+    CARGO_HOME=/opt/.cargo RUSTUP_HOME=/opt/.rustup HOME=/root ./rustup-init.sh -y --no-modify-path \
+        --default-toolchain stable --profile minimal
     rm -f rustup-init.sh
-    chown -R 1001:0 /opt/.cargo
+    chown -R 1001:0 /opt/.cargo /opt/.rustup
     # Set environment variables
     cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
 export PATH=/opt/.cargo/bin:$PATH
 export CARGO_HOME=/opt/.cargo
+export RUSTUP_HOME=/opt/.rustup
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 CARGO_EOF
 fi

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -192,13 +192,18 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     pip install --upgrade pip
     # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
     pip install --force-reinstall setuptools==80.9.0 wheel
+    # Arrow 25.0.0 dropped python/setup.py for a PEP 517 (scikit-build-core) build;
+    # `python -m build` replaces `python setup.py build_ext ... bdist_wheel`. The
+    # PYARROW_WITH_*/PYARROW_BUNDLE_ARROW_CPP env vars are still read directly by
+    # python/CMakeLists.txt, so they carry over unchanged; PYARROW_PARALLEL is gone
+    # (Ninja/scikit-build-core parallelize automatically).
     PYARROW_WITH_PARQUET=1 \
     PYARROW_WITH_DATASET=1 \
     PYARROW_WITH_FILESYSTEM=1 \
     PYARROW_WITH_JSON=1 \
     PYARROW_WITH_CSV=1 \
-    PYARROW_PARALLEL=$(nproc) \
-    python setup.py build_ext --build-type=release --bundle-arrow-cpp bdist_wheel
+    PYARROW_BUNDLE_ARROW_CPP=1 \
+    python -m build --wheel --no-isolation --outdir dist .
     mkdir -p /tmp/wheels
     cp dist/pyarrow-*.whl /tmp/wheels/
     chmod -R 777 /tmp/wheels

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -82,17 +82,23 @@ RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo
+    mkdir -p /opt/.cargo /opt/.rustup
     export HOME=/root
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
     chmod +x rustup-init.sh
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    # RUSTUP_HOME must be set explicitly too: the base image ships a pre-existing
+    # /root/.rustup/settings.toml, which makes rustup-init skip configuring a default
+    # toolchain ("rustup could not choose a version of rustc to run"). Isolating
+    # RUSTUP_HOME (like CARGO_HOME) and pinning --default-toolchain avoids that.
+    CARGO_HOME=/opt/.cargo RUSTUP_HOME=/opt/.rustup HOME=/root ./rustup-init.sh -y --no-modify-path \
+        --default-toolchain stable --profile minimal
     rm -f rustup-init.sh
-    chown -R 1001:0 /opt/.cargo
+    chown -R 1001:0 /opt/.cargo /opt/.rustup
     # Set environment variables
     cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
 export PATH=/opt/.cargo/bin:$PATH
 export CARGO_HOME=/opt/.cargo
+export RUSTUP_HOME=/opt/.rustup
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 CARGO_EOF
 fi

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -142,6 +142,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
+    # /etc/profile.d scripts aren't sourced by non-login RUN shells; source explicitly for cargo/rustc
+    # (needed to build libcst from source, a build dep of pyarrow's requirements-build.txt).
+    source /etc/profile.d/cargo.sh
     PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform s390x)
     # Install build dependencies
     dnf install -y cmake make gcc-c++ pybind11-devel wget git \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -199,6 +199,11 @@ if [ "$TARGETARCH" = "s390x" ]; then
     # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
     pip install --force-reinstall setuptools==80.9.0 wheel
     # Build Python package
+    # Arrow 25.0.0 dropped python/setup.py for a PEP 517 (scikit-build-core) build;
+    # `python -m build` replaces `python setup.py build_ext ... bdist_wheel`. The
+    # PYARROW_WITH_*/PYARROW_BUNDLE_ARROW_CPP env vars are still read directly by
+    # python/CMakeLists.txt, so they carry over unchanged; PYARROW_PARALLEL is gone
+    # (Ninja/scikit-build-core parallelize automatically).
     PYARROW_WITH_PARQUET=1 \
     PYARROW_WITH_DATASET=1 \
     PYARROW_WITH_FILESYSTEM=1 \
@@ -208,8 +213,7 @@ if [ "$TARGETARCH" = "s390x" ]; then
     PYARROW_WITH_ZSTD=1 \
     PYARROW_WITH_BZ2=1 \
     PYARROW_BUNDLE_ARROW_CPP=1 \
-    PYARROW_PARALLEL=$(nproc) \
-    python setup.py build_ext --build-type=release --bundle-arrow-cpp bdist_wheel
+    python -m build --wheel --no-isolation --outdir dist .
     mkdir -p /tmp/wheels
     cp dist/pyarrow-*.whl /tmp/wheels/
     # Ensure wheels directory exists and has content
@@ -330,7 +334,6 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
         -DARROW_BUILD_TESTS=OFF
     cd cpp/build
     make -j20 install
-    export PYARROW_PARALLEL=20
     export PYARROW_WITH_PARQUET=1
     export PYARROW_WITH_DATASET=1
     export PYARROW_BUNDLE_ARROW_CPP=1
@@ -338,10 +341,12 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
     # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
     pip3 install --force-reinstall setuptools==80.9.0 wheel
     cd ../../python
-    python setup.py build_ext \
-        --build-type=release \
-        --bundle-arrow-cpp \
-        bdist_wheel --dist-dir /arrowwheels
+    # Arrow 25.0.0 dropped python/setup.py for a PEP 517 (scikit-build-core) build;
+    # `python -m build` replaces `python setup.py build_ext ... bdist_wheel`. The
+    # PYARROW_WITH_*/PYARROW_BUNDLE_ARROW_CPP env vars exported above are still read
+    # directly by python/CMakeLists.txt, so they carry over unchanged; PYARROW_PARALLEL
+    # is gone (Ninja/scikit-build-core parallelize automatically).
+    python -m build --wheel --no-isolation --outdir /arrowwheels .
 else
     echo "Not ppc64le, skipping pyarrow build"
     mkdir -p /arrowwheels

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -158,8 +158,11 @@ if [ "$TARGETARCH" = "s390x" ]; then
     # Build C++ library first
     cd cpp
     mkdir build && cd build
-    # ORC 2.0.1 was removed from downloads.apache.org; archive mirror has the expected tarball hash
-    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.0.1/orc-2.0.1.tar.gz"
+    # Pin to a fixed archive.apache.org URL instead of Arrow's default closer.lua mirror redirect,
+    # which is unreliable in CI. Version must match ARROW_ORC_BUILD_VERSION in
+    # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
+    # fails a checksum mismatch.
+    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
           -DARROW_PYTHON=ON \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -82,17 +82,23 @@ RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
     # Install Rust and set up environment
-    mkdir -p /opt/.cargo
+    mkdir -p /opt/.cargo /opt/.rustup
     export HOME=/root
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
     chmod +x rustup-init.sh
-    CARGO_HOME=/opt/.cargo HOME=/root ./rustup-init.sh -y --no-modify-path
+    # RUSTUP_HOME must be set explicitly too: the base image ships a pre-existing
+    # /root/.rustup/settings.toml, which makes rustup-init skip configuring a default
+    # toolchain ("rustup could not choose a version of rustc to run"). Isolating
+    # RUSTUP_HOME (like CARGO_HOME) and pinning --default-toolchain avoids that.
+    CARGO_HOME=/opt/.cargo RUSTUP_HOME=/opt/.rustup HOME=/root ./rustup-init.sh -y --no-modify-path \
+        --default-toolchain stable --profile minimal
     rm -f rustup-init.sh
-    chown -R 1001:0 /opt/.cargo
+    chown -R 1001:0 /opt/.cargo /opt/.rustup
     # Set environment variables
     cat > /etc/profile.d/cargo.sh <<'CARGO_EOF'
 export PATH=/opt/.cargo/bin:$PATH
 export CARGO_HOME=/opt/.cargo
+export RUSTUP_HOME=/opt/.rustup
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
 CARGO_EOF
 fi

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -142,6 +142,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 if [ "$TARGETARCH" = "s390x" ]; then
+    # /etc/profile.d scripts aren't sourced by non-login RUN shells; source explicitly for cargo/rustc
+    # (needed to build libcst from source, a build dep of pyarrow's requirements-build.txt).
+    source /etc/profile.d/cargo.sh
     PYARROW_VERSION=$(python3 /tmp/pylock_version.py /tmp/pylock.toml pyarrow --platform s390x)
     # Install build dependencies
     dnf install -y cmake make gcc-c++ pybind11-devel wget git \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -199,6 +199,11 @@ if [ "$TARGETARCH" = "s390x" ]; then
     # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
     pip install --force-reinstall setuptools==80.9.0 wheel
     # Build Python package
+    # Arrow 25.0.0 dropped python/setup.py for a PEP 517 (scikit-build-core) build;
+    # `python -m build` replaces `python setup.py build_ext ... bdist_wheel`. The
+    # PYARROW_WITH_*/PYARROW_BUNDLE_ARROW_CPP env vars are still read directly by
+    # python/CMakeLists.txt, so they carry over unchanged; PYARROW_PARALLEL is gone
+    # (Ninja/scikit-build-core parallelize automatically).
     PYARROW_WITH_PARQUET=1 \
     PYARROW_WITH_DATASET=1 \
     PYARROW_WITH_FILESYSTEM=1 \
@@ -208,8 +213,7 @@ if [ "$TARGETARCH" = "s390x" ]; then
     PYARROW_WITH_ZSTD=1 \
     PYARROW_WITH_BZ2=1 \
     PYARROW_BUNDLE_ARROW_CPP=1 \
-    PYARROW_PARALLEL=$(nproc) \
-    python setup.py build_ext --build-type=release --bundle-arrow-cpp bdist_wheel
+    python -m build --wheel --no-isolation --outdir dist .
     mkdir -p /tmp/wheels
     cp dist/pyarrow-*.whl /tmp/wheels/
     # Ensure wheels directory exists and has content
@@ -330,7 +334,6 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
         -DARROW_BUILD_TESTS=OFF
     cd cpp/build
     make -j20 install
-    export PYARROW_PARALLEL=20
     export PYARROW_WITH_PARQUET=1
     export PYARROW_WITH_DATASET=1
     export PYARROW_BUNDLE_ARROW_CPP=1
@@ -338,10 +341,12 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
     # RHAIENG-5986: requirements-build.txt may pull setuptools 82+ (no pkg_resources)
     pip3 install --force-reinstall setuptools==80.9.0 wheel
     cd ../../python
-    python setup.py build_ext \
-        --build-type=release \
-        --bundle-arrow-cpp \
-        bdist_wheel --dist-dir /arrowwheels
+    # Arrow 25.0.0 dropped python/setup.py for a PEP 517 (scikit-build-core) build;
+    # `python -m build` replaces `python setup.py build_ext ... bdist_wheel`. The
+    # PYARROW_WITH_*/PYARROW_BUNDLE_ARROW_CPP env vars exported above are still read
+    # directly by python/CMakeLists.txt, so they carry over unchanged; PYARROW_PARALLEL
+    # is gone (Ninja/scikit-build-core parallelize automatically).
+    python -m build --wheel --no-isolation --outdir /arrowwheels .
 else
     echo "Not ppc64le, skipping pyarrow build"
     mkdir -p /arrowwheels

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -158,8 +158,11 @@ if [ "$TARGETARCH" = "s390x" ]; then
     # Build C++ library first
     cd cpp
     mkdir build && cd build
-    # ORC 2.0.1 was removed from downloads.apache.org; archive mirror has the expected tarball hash
-    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.0.1/orc-2.0.1.tar.gz"
+    # Pin to a fixed archive.apache.org URL instead of Arrow's default closer.lua mirror redirect,
+    # which is unreliable in CI. Version must match ARROW_ORC_BUILD_VERSION in
+    # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
+    # fails a checksum mismatch.
+    export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
           -DARROW_PYTHON=ON \


### PR DESCRIPTION
## Problem

The `pyarrow` from-source build for ppc64le/s390x (in `jupyter/datascience` and
`runtimes/datascience` ubi9-python-3.12 images) overrides `ARROW_ORC_URL` to a
fixed `archive.apache.org` URL, to avoid Arrow's default `closer.lua` mirror
redirect (unreliable in CI).

That override was still pinned to `orc-2.0.1`, but the currently-pinned
`pyarrow` version (`25.0.0`, from `pylock.toml`) expects a different ORC
version per Arrow's own dependency manifest
([`arrow/cpp/thirdparty/versions.txt`](https://github.com/apache/arrow/blob/apache-arrow-25.0.0/cpp/thirdparty/versions.txt)):

```
ARROW_ORC_BUILD_VERSION=2.2.1
ARROW_ORC_BUILD_SHA256_CHECKSUM=52fc762332442e8b05d7182f8c035f9e04d945b9a52be22ab69f28b3f37d4500
```

This version/checksum mismatch causes the bundled ORC build to fail.

## Fix

Bump `ARROW_ORC_URL` to `orc-2.2.1` in all 4 affected files:
- `jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu`
- `jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu`
- `runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu`
- `runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu`

Also updated the comment to explain both why the URL is pinned
(mirror-redirect reliability) and that its version must track
`ARROW_ORC_BUILD_VERSION` for whatever `PYARROW_VERSION` is currently pinned,
so this doesn't silently drift again on a future pyarrow bump.

## Verification

- Downloaded the tarball at the new URL and confirmed its sha256 matches
  Arrow's pinned `ARROW_ORC_BUILD_SHA256_CHECKSUM` exactly:
  `52fc762332442e8b05d7182f8c035f9e04d945b9a52be22ab69f28b3f37d4500`
- Cross-checked none of the other in-flight pyarrow-related branches in this
  repo already address this (they only touch the unrelated, pre-existing
  `-DARROW_ORC=ON` CMake flag for S3/Substrait feature enablement).

## Follow-up: fix libcst/Rust build failure surfaced by the ORC fix

The ORC fix above let the ppc64le/s390x pyarrow-from-source build get further
than before, surfacing a previously-masked failure in CI
([build logs](https://github.com/red-hat-data-services/notebooks/pull/2679)):
pyarrow's `python/requirements-build.txt` pulls in `libcst`, which has no
prebuilt wheel for ppc64le/s390x and must build its Rust extension from
source:

```
error: can't find Rust compiler
ERROR: Failed building wheel for libcst
```

Two distinct gaps caused this across the 4 pyarrow-from-source build stages:

- `jupyter/datascience`'s `cpu-base` only installed Rust (via rustup, into
  `/opt/.cargo`) for s390x, never for ppc64le, even though the downstream
  `pyarrow-builder` stage builds pyarrow (and therefore `libcst`) on both.
- Even where Rust was installed, its `PATH`/`CARGO_HOME` were only exported
  via `/etc/profile.d/cargo.sh`, which is not sourced by the non-login
  `RUN /bin/bash <<EOF` shells used in the downstream builder stages (each
  `RUN` is a fresh, non-login shell; profile.d scripts are login-shell-only).
  `runtimes/datascience`'s ppc64le path was unaffected: it installs
  rust/cargo as dnf packages, which land on the standard system `PATH`
  already.

Fix, in a second commit:
- `jupyter/datascience/ubi9-python-3.12/{Dockerfile.cpu,Dockerfile.konflux.cpu}`:
  install Rust via rustup for ppc64le too (not just s390x), and explicitly
  `source /etc/profile.d/cargo.sh` at the top of the `pyarrow-builder`
  stage's if-block, before `requirements-build.txt` is installed.
- `runtimes/datascience/ubi9-python-3.12/{Dockerfile.cpu,Dockerfile.konflux.cpu}`:
  explicitly `source /etc/profile.d/cargo.sh` at the top of the
  `s390x-builder` stage's if-block (Rust was already installed there via
  rustup for s390x, just never put on `PATH` for this stage).

## Follow-up 2: pin rustup's default toolchain

CI still failed after the previous commit, with a new error:

```
error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
```

Cause: the base image already ships a pre-existing `/root/.rustup/settings.toml`
(`warn: It looks like you have an existing rustup settings file`).
`rustup-init.sh` treats that as an existing installation and skips
configuring a default toolchain — and since only `CARGO_HOME` was overridden
to `/opt/.cargo` (not `RUSTUP_HOME`), the install collided with that
pre-existing, incomplete `/root/.rustup` state.

Fix: also override `RUSTUP_HOME` to `/opt/.rustup` (isolated, like
`CARGO_HOME`), and pass `--default-toolchain stable --profile minimal`
explicitly, so a usable toolchain is always configured regardless of any
pre-existing rustup state in the base image. Applied identically to all 4
files that install Rust via rustup for ppc64le/s390x.

## Follow-up 3: `python setup.py build_ext` no longer exists in Arrow 25.0.0

With Rust now working, CI reached the next blocker:

```
python: can't open file '/tmp/build-wheels/arrow/python/setup.py': [Errno 2] No such file or directory
```

Arrow 25.0.0's `python/` directory has no `setup.py`/`setup.cfg`-based
distutils build anymore — it migrated to a PEP 517 build backend
(`scikit-build-core`, via `python/pyproject.toml`'s
`build-backend = "_build_backend"` wrapper). `python setup.py build_ext
--build-type=release --bundle-arrow-cpp bdist_wheel` is simply gone.

This is a partial-fix follow-through, not a new regression: [RHAIENG-5986](https://redhat.atlassian.net/browse/RHAIENG-5986)
("fix pkg_resources via extra-build-deps and pyarrow pins", commit
`55dc724a1`) pinned `setuptools==80.9.0` right before this exact line to fix
a `pkg_resources` import error — a real, valid fix for the symptom it
targeted. But CI never actually exercised this line end-to-end afterwards:
it kept failing earlier in the chain (ARROW_ORC_URL checksum mismatch, then
missing Rust compiler for `libcst`), so the fact that `setup.py` itself no
longer exists in Arrow 25.0.0 was never surfaced until now.

Fix: replace `python setup.py build_ext ...` with
`python -m build --wheel --no-isolation --outdir <dir> .` (the `build`
package Arrow's own `requirements-build.txt` already installs). Verified
against Arrow's `python/CMakeLists.txt` and `python/pyproject.toml`:
- `PYARROW_WITH_PARQUET/DATASET/FILESYSTEM/JSON/CSV/LZ4/ZSTD/BZ2` are still
  read directly from the environment by `python/CMakeLists.txt`'s
  `define_option()` macro, so they carry over unchanged.
- `PYARROW_BUNDLE_ARROW_CPP` is explicitly forwarded to a CMake define in
  `pyproject.toml`'s `[tool.scikit-build.cmake.define]` section, so it also
  carries over unchanged; the old `--bundle-arrow-cpp` CLI flag doesn't
  exist anymore (that's now what the env var controls).
- The old `--build-type=release` CLI flag is redundant:
  `pyproject.toml` already pins `cmake.build-type = "Release"`.
- `PYARROW_PARALLEL` is no longer read anywhere in `python/CMakeLists.txt`;
  dropped (scikit-build-core's Ninja generator parallelizes automatically).

Applied to all 4 pyarrow-from-source build sites: `jupyter/datascience`'s
`pyarrow-builder` stage, and `runtimes/datascience`'s `s390x-builder` and
ppc64le `arrow-builder` stages, across both `Dockerfile.cpu` and
`Dockerfile.konflux.cpu` variants.

## Follow-up 4: `jupyter/datascience` missing `ninja-build`

Switching to `python -m build` (follow-up 3) regressed `jupyter/datascience`'s
ppc64le/s390x build with:

```
ERROR Missing dependencies:
	ninja>=1.5
```

`scikit-build-core` (pyarrow's PEP 517 build backend) requires Ninja to
drive the CMake build unless a different generator is explicitly configured
(`pyproject.toml` doesn't do that). `jupyter/datascience`'s `pyarrow-builder`
stage only ever installed `cmake make gcc-c++ pybind11-devel wget` — `make`
was enough for the old `setup.py`-based build's own C++ compile, but not for
`scikit-build-core`'s separate build of the pyarrow Python extension.

`runtimes/datascience`'s `s390x-builder` and ppc64le
`arrow-builder`/`common-builder` stages already install `ninja-build`, which
is why they weren't hit by this — confirmed by testing on a real s390x QEMU
container using `runtimes/datascience`'s package list, where `ninja` was
already on `PATH`.

Fix: add `ninja-build` to `jupyter/datascience`'s `pyarrow-builder` dnf
install, in both `Dockerfile.cpu` and `Dockerfile.konflux.cpu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python 3.12 data science image builds for s390x and ppc64le architectures.
  * Added reliable, pinned Rust toolchain support for architecture-specific package builds.
  * Updated the bundled ORC component to version 2.2.1.
  * Improved dependency retrieval and verification for more reliable CPU-based image creation.
  * Modernized PyArrow wheel builds using the standard Python packaging workflow.

* **Chores**
  * Aligned build configurations and checksum references with the updated ORC release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




[RHAIENG-5986]: https://redhat.atlassian.net/browse/RHAIENG-5986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
