### PR TITLE
fix(tests): probe / instead of /api for OpenShift port-forward readiness

### DIFF
--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -203,6 +203,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # install-podman-action's storage.conf enables zstd:chunked partial pulls, which
+      # only matters for `podman build`'s own registry pulls elsewhere. Here we `podman
+      # pull` an already-published ghcr.io image, and ghcr.io's blob endpoint returns
+      # "501 Unsupported client range" for partial/ranged fetches, failing the pull
+      # outright instead of falling back to a full one. Disable it for this job only.
+      - name: Disable zstd:chunked partial image pulls
+        run: sudo sed -i 's/enable_partial_images = "true"/enable_partial_images = "false"/' /etc/containers/storage.conf
+
       - name: Pull and run OpenShift container tests
         env:
           TEST_IMAGE: ${{ matrix.image }}

--- a/.github/workflows/test-containers.yaml
+++ b/.github/workflows/test-containers.yaml
@@ -158,3 +158,68 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml
+
+  openshift-container-tests:
+    name: "openshift: ${{ matrix.name }}"
+    needs: find-images
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.find-images.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          version-file: pyproject.toml
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Install deps
+        run: uv sync --locked
+
+      # Rootful podman sharing image storage with cri-o, same as build-notebooks-TEMPLATE.yaml,
+      # so the pod created by the openshift-marked tests can find the image without re-pulling.
+      - name: Install and configure Podman
+        uses: './.github/actions/install-podman-action'
+        with:
+          platform: linux/amd64
+
+      - name: Provision K8s cluster
+        uses: ./.github/actions/provision-k8s
+
+      - name: Login to GHCR
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c  # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and run OpenShift container tests
+        env:
+          TEST_IMAGE: ${{ matrix.image }}
+          DOCKER_HOST: "unix:///var/run/podman/podman.sock"
+          TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: "/var/run/podman/podman.sock"
+        run: |
+          set -Eeuxo pipefail
+          podman pull "${TEST_IMAGE}"
+          uv run pytest --capture=fd tests/containers \
+            -m 'openshift and not cuda and not rocm' \
+            --image="${TEST_IMAGE}" \
+            --junitxml=junit-openshift.xml \
+            -v
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit-openshift.xml

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -267,12 +267,22 @@ class ImageDeployment:
 
             self.port = p.get_actual_port()
             LOGGER.debug(f"Listening on port {self.port}")
-            # Use 120s timeout for slower cold starts (e.g. code-server on arm64).
+
+            # Use TIMEOUT_2MIN for slower cold starts (e.g. code-server on arm64).
+            # Always probe / (not /api): RStudio's nginx redirects /api to a
+            # hardcoded http://127.0.0.1:8888/api/, which is wrong (and unreachable)
+            # through a port-forward where the local port isn't literally 8888.
+            # https://github.com/red-hat-data-services/notebooks/issues/2684
+            def _ready() -> bool:
+                with requests.Session() as session:
+                    response = session.get(f"http://127.0.0.1:{self.port}/", timeout=5, allow_redirects=True)
+                return response.status_code == 200
+
             Wait.until(
                 "Connecting to pod succeeds",
                 1,
-                120,
-                lambda: requests.get(f"http://127.0.0.1:{self.port}/api", timeout=10).status_code == 200,
+                TestFrameConstants.TIMEOUT_2MIN,
+                _ready,
             )
             LOGGER.debug("Done setting up portforward")
 


### PR DESCRIPTION
## Summary

Three commits, in order:

1. **`fix(tests): probe / instead of /api for OpenShift port-forward readiness`** — restores a previously-working fix that got silently reverted, fixing the recurring RStudio/cuda-rstudio `test_image_run_on_openshift` timeout tracked in #2684.
2. **`ci(test-containers): add a job to run the openshift-marked container tests`** — adds `openshift-container-tests` to the fast, PR-scoped self-test workflow (`test-containers.yaml`), so this exact code path gets exercised on every PR instead of only in the full, expensive image-build workflow. This is what would have caught both regressions described in commit 1 immediately instead of weeks later. See opendatahub-io/notebooks#4257 for the equivalent tracking issue on `main`.
3. **`fix(ci): disable zstd:chunked partial pulls in openshift-container-tests`** — fixes a failure the new job in commit 2 immediately hit in this PR's own CI (3 consecutive runs): `podman pull` of the `codeserver` image failed with `501 Unsupported client range`, because that image's layers happen to be `zstd:chunked`-compressed (a known buildah bug means whether a given build's layers end up `zstd:chunked` vs. plain `gzip` depends on `--cache-from`/`--cache-to` cache hit/miss, not on the image itself) and `install-podman-action`'s `storage.conf` enables partial/ranged fetches for such layers, which `ghcr.io`'s blob endpoint doesn't support. Disabled for this job only.

## Commit 1: RStudio readiness probe fix

Restores a previously-working fix that got silently reverted, fixing the recurring RStudio/cuda-rstudio `test_image_run_on_openshift` timeout tracked in #2684.

- `RHAIENG-6036` (`08f4fe374`, merged 2026-07-11) fixed this correctly: probe `/` with a persistent `requests.Session()` (cookies are required across RStudio's multi-hop redirect chain), because RStudio doesn't support `/api` the way Jupyter and code-server do.
- The hermetic-codeserver backport (`da9540c47`) later silently reverted this hunk back to a bare `30s`/`localhost`/no-session probe (almost certainly because that backport branch was cut before `08f4fe374` merged).
- A same-day follow-up (`74873588f`) noticed only the regressed *timeout* and re-fixed it by copying `main`'s `/api`-only probe — but `main` dropped RStudio entirely, so that path never actually worked here.

### Evidence

Confirmed against real `ghcr.io` `rhoai-2.25` images (jupyter-minimal, rstudio, codeserver) pulled and run directly:

```
rstudio /api  -> ConnectionError: Failed to establish a new connection to 127.0.0.1:8888 (Connection refused)
```

RStudio's nginx redirects `/api` to a **hardcoded** `http://127.0.0.1:8888/api/` — its own internal container port, not the locally-forwarded port — so it's unreachable through any port-forward/proxy.

`/` (session-based, redirects followed) returns 200 for all three:
```
jupyter-minimal 200 http://127.0.0.1:<port>/login?next=%2Flab
rstudio         200 http://127.0.0.1:<port>/rstudio/
codeserver      200 http://127.0.0.1:<port>/codeserver/?folder=/opt/app-root/src
```
(a bare GET without a persistent cookie jar redirect-loops on RStudio's `/`, which is why the session matters, not just the path.)

## Commit 2: add openshift-container-tests to the self-test workflow

`.github/workflows/test-containers.yaml` only ran `pytest -m 'not openshift and not cuda and not rocm'`, explicitly skipping `test_image_run_on_openshift`. That's exactly the code path that regressed twice without anyone noticing (commit 1's history). Adds a job that reuses `find-images`'s matrix and mirrors `build-notebooks-TEMPLATE.yaml`'s own provisioning steps (`install-podman-action` + `provision-k8s`) to run `pytest -m 'openshift and not cuda and not rocm'` against each pulled image in fast, PR-scoped CI.

## Commit 3: fix a pull failure the new job surfaced

The new job in commit 2 failed 3/3 times in this PR's own CI on `codeserver` specifically:

```
Error: unable to copy from source docker://ghcr.io/.../codeserver...:
partial pull of blob sha256:...: read zstd:chunked manifest: fetching
partial blob: received unexpected HTTP status: 501 Unsupported client range
```

`codeserver`'s layers happened to be pushed as `zstd:chunked` (the other 4 images in the matrix are plain `gzip`) — this is a known buildah issue where `--cache-to`/`--cache-from` used to ignore the configured `compression_format` for cache-derived (hit) layers, so which images end up `zstd:chunked` vs. `gzip` depends on build-cache hit/miss, not on the image itself. `install-podman-action`'s `storage.conf` enables partial/ranged pulls for `zstd:chunked` layers, and `ghcr.io`'s blob endpoint returns `501` for the resulting ranged request instead of falling back to a full pull. Disabled `enable_partial_images` for this job only (not the shared `ci/cached-builds/storage.conf`, which other build jobs still benefit from).

## Test plan

- [x] `ruff check` / `pyright` clean on the changed files
- [x] Manually verified `/` + session works for jupyter-minimal, rstudio, and codeserver images pulled from `ghcr.io` (rhoai-2.25 build)
- [x] `actionlint` / YAML-valid on `test-containers.yaml`
- [x] CI: `openshift-container-tests` passes for all 5 images (rstudio/cuda-rstudio no longer time out; codeserver's partial-pull failure fixed) after commit 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port-forward readiness detection by checking the service root endpoint.
  * Added redirect handling and stricter validation for successful HTTP responses.
  * Refined readiness timeouts to provide more reliable startup behavior.

* **Tests**
  * Added automated OpenShift container test coverage across supported images.
  * Added automated result collection and reporting to improve test visibility.
  * Expanded validation across multiple container and cluster configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
