### PR TITLE
[rhoai-2.25] ISSUE#2482: fix(ci): set `persist-credentials` on all checkout steps

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       # https://github.com/astral-sh/setup-uv
       - name: Install uv

--- a/.github/workflows/notebook-digest-updater.yaml
+++ b/.github/workflows/notebook-digest-updater.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
+          persist-credentials: true  # git push in Create a new branch
 
       # Create a new branch
       - name: Create a new branch
@@ -64,6 +65,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
+          persist-credentials: true  # git push in Update the params.env / commit.env file
 
       - name: Update the params.env file
         shell: bash
@@ -159,6 +161,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.DIGEST_UPDATER_BRANCH }}
+          persist-credentials: true  # git push in Update the params.env / commit.env file
 
       - name: Update the params.env file
         shell: bash
@@ -234,6 +237,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: pull-request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5  # v2.12.1

--- a/.github/workflows/notebooks-digest-updater.yaml
+++ b/.github/workflows/notebooks-digest-updater.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
-          persist-credentials: true
+          persist-credentials: true  # git push in Create a new branch / Commit Changes
 
       - name: Create a new branch
         run: |
@@ -66,7 +66,7 @@ jobs:
         with:
           ref: ${{ env.TMP_BRANCH }}
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: true  # git push in Commit Changes
 
       - name: Invoke ci/sha-digest-updater.sh script to handle the updates
         shell: bash

--- a/.github/workflows/notebooks-release.yaml
+++ b/.github/workflows/notebooks-release.yaml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: Check if PR is merged
         id: check_pr
@@ -108,6 +109,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: Check if PR is merged
         id: check_pr

--- a/.github/workflows/piplock-renewal.yaml
+++ b/.github/workflows/piplock-renewal.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: ${{ env.BRANCH }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
-          persist-credentials: true
+          persist-credentials: true  # git push in Pull and push changes
 
       - name: Configure Git
         run: |

--- a/.github/workflows/pr-merge-image-delete.yml
+++ b/.github/workflows/pr-merge-image-delete.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: '0'
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
       - name: Install skopeo
         shell: bash
         run: |

--- a/.github/workflows/sec-scan.yml
+++ b/.github/workflows/sec-scan.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.BRANCH_NAME }}
-          persist-credentials: true
+          persist-credentials: true  # git push in Create a new branch
 
       # Create a new branch
       - name: Create a new branch
@@ -57,6 +57,7 @@ jobs:
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N }}
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: Retrieve latest weekly commit hash from the "N" branch
         id: hash-n
@@ -69,6 +70,7 @@ jobs:
         with:
           repository: opendatahub-io/notebooks.git
           ref: ${{ env.RELEASE_VERSION_N_1 }}
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: Retrieve latest weekly commit hash from the "N - 1" branch
         id: hash-n-1
@@ -81,6 +83,7 @@ jobs:
         with:
           repository: opendatahub-io/notebooks.git
           ref: main
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: Retrieve latest weekly commit hash from the "main" branch
         id: hash-main
@@ -93,7 +96,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ env.SEC_SCAN_BRANCH }}
-          persist-credentials: true
+          persist-credentials: true  # git push in Push the files
 
       - name: setup python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/sync-branches-through-pr.yml
+++ b/.github/workflows/sync-branches-through-pr.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.target }}
           fetch-depth: 0
+          persist-credentials: false  # https://github.com/actions/checkout/issues/2312
 
       - name: Prepare sync branch
         id: prepare

--- a/.github/workflows/update-buildconfigs.yaml
+++ b/.github/workflows/update-buildconfigs.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: true  # git push in Create Target Branch / Add Files and Commit Changes
 
       - name: Configure Git
         run: |

--- a/.github/workflows/update-commit-latest-env.yaml
+++ b/.github/workflows/update-commit-latest-env.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: true
+          persist-credentials: true  # git push in Commit and push changes
 
       - name: Update manifests/base/commit-latest.env
         id: update_env

--- a/.github/workflows/update-tags.yaml
+++ b/.github/workflows/update-tags.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: true  # git push in Commit and push changes to branch
 
       - name: Detect and replace tags in .tekton and params-latest.env files
         id: replace


### PR DESCRIPTION
## Summary

Fixes #2482 by ensuring every `actions/checkout` step in `.github/workflows/**` on `rhoai-2.25` explicitly sets `persist-credentials`:

- **`persist-credentials: false`** on read-only checkouts (docs, pr-merge-image-delete, notebooks-release, sec-scan upstream reads, sync-branches-through-pr, notebook-digest-updater PR step)
- **`persist-credentials: true` with a comment** where a later step runs `git push` (update-tags, piplock-renewal, notebooks-digest-updater, notebook-digest-updater, sec-scan, update-buildconfigs, update-commit-latest-env)

Already compliant (no change needed): `build-notebooks-TEMPLATE.yaml`, `test-containers.yaml`, and most other workflows.

## Test plan

- [ ] zizmor `artipacked` no longer flags the previously listed checkout steps
- [ ] Workflows that push commits (digest updaters, piplock-renewal, update-tags, etc.) still authenticate correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved credential handling across automated repository workflows by limiting credential persistence during read-only operations.
  * Retained credentials only where automation needs to create branches or push generated updates.
* **Chores**
  * Added clearer documentation within workflow configuration to explain credential usage and reduce maintenance ambiguity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->