### PR TITLE
[rhoai-2.25] fix(tests): bound exposing_contextmanager's portforward retry loop

### DIFF
--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -505,6 +505,50 @@ class Utils:
             raise ValueError(message)
 
 
+def _portforward_with_timeout(
+    core_v1_api: kubernetes.client.CoreV1Api, pod: kubernetes.client.models.V1Pod, timeout: float
+) -> kubernetes.stream.ws_client.PortForward:
+    """Runs kubernetes.stream.portforward() with a wall-clock bound.
+
+    The kubernetes client doesn't expose a per-call connect timeout for portforward() -- it calls
+    websocket.connect() with no timeout, so a wedged connection to the API server can hang this call
+    forever. The only alternative the library offers is a process-wide `websocket.setdefaulttimeout()`,
+    which isn't safe to use here since multiple SocketProxy instances (one per ImageDeployment) can be
+    making concurrent portforward() calls from different threads. So we run the call in a helper thread
+    and bound it with join(timeout) instead.
+
+    If the call doesn't return in time, it is abandoned rather than joined: the daemon thread and any
+    partially-established connection are leaked for the remainder of the test process. That's an
+    accepted tradeoff for test infrastructure that's about to raise TimeoutError and fail the test
+    (and the process will exit soon after) rather than hang forever with no recovery.
+    """
+    pf_result: list[kubernetes.stream.ws_client.PortForward] = []
+    error_result: list[Exception] = []
+
+    def _target() -> None:
+        try:
+            pf = kubernetes.stream.portforward(
+                api_method=core_v1_api.connect_get_namespaced_pod_portforward,
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                ports=",".join(str(p) for p in [8888]),
+            )
+            pf_result.append(pf)
+        except Exception as e:  # propagated to the caller below, not swallowed
+            error_result.append(e)
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if error_result:
+        raise error_result[0]
+    if not pf_result:
+        raise TimeoutError(
+            f"kubernetes.stream.portforward() to {pod.metadata.name} did not return within {timeout:.1f}s"
+        )
+    return pf_result[0]
+
+
 @contextlib.contextmanager
 def exposing_contextmanager(
     core_v1_api: kubernetes.client.CoreV1Api,
@@ -515,17 +559,17 @@ def exposing_contextmanager(
     # but pf.connected will later flip to False
     # we need to check that _everything_ works before moving on
     #
-    # https://github.com/red-hat-data-services/notebooks/issues/2684: bound this retry loop so a
-    # pod that never becomes reachable (or a single kubernetes.stream.portforward() call that
-    # itself hangs, e.g. on a wedged connection to the API server) can't block the single-threaded
-    # SocketProxy forever and starve every later Wait.until retry. This bounds the *loop*, not an
-    # individual hung portforward() call -- the kubernetes client doesn't expose a per-call
-    # connect timeout for portforward(), only a process-wide `websocket.setdefaulttimeout()`.
+    # https://github.com/red-hat-data-services/notebooks/issues/2684: bound this retry loop (and each
+    # individual portforward() attempt via _portforward_with_timeout, since a single hung call would
+    # otherwise never let this loop's own deadline check run again) so a pod that never becomes
+    # reachable can't block the single-threaded SocketProxy forever and starve every later
+    # Wait.until retry.
     deadline = time.monotonic() + timeout
     pf: kubernetes.stream.ws_client.PortForward | None = None
     s: kubernetes.stream.ws_client.PortForward._Port._Socket | socket.socket | None = None
     while not pf or not pf.connected or not s:
-        if time.monotonic() > deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             if s is not None:
                 s.close()
             if pf is not None:
@@ -536,12 +580,7 @@ def exposing_contextmanager(
             s = None
         if pf is not None:
             pf.close()
-        pf = kubernetes.stream.portforward(
-            api_method=core_v1_api.connect_get_namespaced_pod_portforward,
-            name=pod.metadata.name,
-            namespace=pod.metadata.namespace,
-            ports=",".join(str(p) for p in [8888]),
-        )
+        pf = _portforward_with_timeout(core_v1_api, pod, remaining)
         s = pf.socket(8888)
     assert s, "Failed to establish connection"
 

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -518,7 +518,7 @@ def _portforward_with_timeout(
     and bound it with join(timeout) instead.
 
     If the call doesn't return in time, it is abandoned rather than joined: the daemon thread and any
-    partially-established connection are leaked for the remainder of the test process. That's an
+    partially established connection are leaked for the remainder of the test process. That's an
     accepted tradeoff for test infrastructure that's about to raise TimeoutError and fail the test
     (and the process will exit soon after) rather than hang forever with no recovery.
     """

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -507,21 +507,42 @@ class Utils:
 
 @contextlib.contextmanager
 def exposing_contextmanager(
-    core_v1_api: kubernetes.client.CoreV1Api, pod: kubernetes.client.models.V1Pod
+    core_v1_api: kubernetes.client.CoreV1Api,
+    pod: kubernetes.client.models.V1Pod,
+    timeout: float = 30,
 ) -> Generator[socket]:
     # If we e.g., specify the wrong port, the pf = portforward() call succeeds,
     # but pf.connected will later flip to False
     # we need to check that _everything_ works before moving on
-    pf = None
-    s = None
+    #
+    # https://github.com/red-hat-data-services/notebooks/issues/2684: bound this retry loop so a
+    # pod that never becomes reachable (or a single kubernetes.stream.portforward() call that
+    # itself hangs, e.g. on a wedged connection to the API server) can't block the single-threaded
+    # SocketProxy forever and starve every later Wait.until retry. This bounds the *loop*, not an
+    # individual hung portforward() call -- the kubernetes client doesn't expose a per-call
+    # connect timeout for portforward(), only a process-wide `websocket.setdefaulttimeout()`.
+    deadline = time.monotonic() + timeout
+    pf: kubernetes.stream.ws_client.PortForward | None = None
+    s: kubernetes.stream.ws_client.PortForward._Port._Socket | socket.socket | None = None
     while not pf or not pf.connected or not s:
-        pf: kubernetes.stream.ws_client.PortForward = kubernetes.stream.portforward(
+        if time.monotonic() > deadline:
+            if s is not None:
+                s.close()
+            if pf is not None:
+                pf.close()
+            raise TimeoutError(f"Failed to establish a working portforward to {pod.metadata.name} within {timeout}s")
+        if s is not None:
+            s.close()
+            s = None
+        if pf is not None:
+            pf.close()
+        pf = kubernetes.stream.portforward(
             api_method=core_v1_api.connect_get_namespaced_pod_portforward,
             name=pod.metadata.name,
             namespace=pod.metadata.namespace,
             ports=",".join(str(p) for p in [8888]),
         )
-        s: kubernetes.stream.ws_client.PortForward._Port._Socket | socket.socket | None = pf.socket(8888)
+        s = pf.socket(8888)
     assert s, "Failed to establish connection"
 
     try:

--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -505,23 +505,83 @@ class Utils:
             raise ValueError(message)
 
 
+def _portforward_with_timeout(
+    core_v1_api: kubernetes.client.CoreV1Api, pod: kubernetes.client.models.V1Pod, timeout: float
+) -> kubernetes.stream.ws_client.PortForward:
+    """Runs kubernetes.stream.portforward() with a wall-clock bound.
+
+    The kubernetes client doesn't expose a per-call connect timeout for portforward() -- it calls
+    websocket.connect() with no timeout, so a wedged connection to the API server can hang this call
+    forever. The only alternative the library offers is a process-wide `websocket.setdefaulttimeout()`,
+    which isn't safe to use here since multiple SocketProxy instances (one per ImageDeployment) can be
+    making concurrent portforward() calls from different threads. So we run the call in a helper thread
+    and bound it with join(timeout) instead.
+
+    If the call doesn't return in time, it is abandoned rather than joined: the daemon thread and any
+    partially established connection are leaked for the remainder of the test process. That's an
+    accepted tradeoff for test infrastructure that's about to raise TimeoutError and fail the test
+    (and the process will exit soon after) rather than hang forever with no recovery.
+    """
+    pf_result: list[kubernetes.stream.ws_client.PortForward] = []
+    error_result: list[Exception] = []
+
+    def _target() -> None:
+        try:
+            pf = kubernetes.stream.portforward(
+                api_method=core_v1_api.connect_get_namespaced_pod_portforward,
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                ports=",".join(str(p) for p in [8888]),
+            )
+            pf_result.append(pf)
+        except Exception as e:  # propagated to the caller below, not swallowed
+            error_result.append(e)
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if error_result:
+        raise error_result[0]
+    if not pf_result:
+        raise TimeoutError(
+            f"kubernetes.stream.portforward() to {pod.metadata.name} did not return within {timeout:.1f}s"
+        )
+    return pf_result[0]
+
+
 @contextlib.contextmanager
 def exposing_contextmanager(
-    core_v1_api: kubernetes.client.CoreV1Api, pod: kubernetes.client.models.V1Pod
+    core_v1_api: kubernetes.client.CoreV1Api,
+    pod: kubernetes.client.models.V1Pod,
+    timeout: float = 30,
 ) -> Generator[socket]:
     # If we e.g., specify the wrong port, the pf = portforward() call succeeds,
     # but pf.connected will later flip to False
     # we need to check that _everything_ works before moving on
-    pf = None
-    s = None
+    #
+    # https://github.com/red-hat-data-services/notebooks/issues/2684: bound this retry loop (and each
+    # individual portforward() attempt via _portforward_with_timeout, since a single hung call would
+    # otherwise never let this loop's own deadline check run again) so a pod that never becomes
+    # reachable can't block the single-threaded SocketProxy forever and starve every later
+    # Wait.until retry.
+    deadline = time.monotonic() + timeout
+    pf: kubernetes.stream.ws_client.PortForward | None = None
+    s: kubernetes.stream.ws_client.PortForward._Port._Socket | socket.socket | None = None
     while not pf or not pf.connected or not s:
-        pf: kubernetes.stream.ws_client.PortForward = kubernetes.stream.portforward(
-            api_method=core_v1_api.connect_get_namespaced_pod_portforward,
-            name=pod.metadata.name,
-            namespace=pod.metadata.namespace,
-            ports=",".join(str(p) for p in [8888]),
-        )
-        s: kubernetes.stream.ws_client.PortForward._Port._Socket | socket.socket | None = pf.socket(8888)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            if s is not None:
+                s.close()
+            if pf is not None:
+                pf.close()
+            raise TimeoutError(f"Failed to establish a working portforward to {pod.metadata.name} within {timeout}s")
+        if s is not None:
+            s.close()
+            s = None
+        if pf is not None:
+            pf.close()
+        pf = _portforward_with_timeout(core_v1_api, pod, remaining)
+        s = pf.socket(8888)
     assert s, "Failed to establish connection"
 
     try:

--- a/tests/containers/socket_proxy.py
+++ b/tests/containers/socket_proxy.py
@@ -94,10 +94,14 @@ class SocketProxy:
                     try:
                         # handle client synchronously, which means that there can be at most one at a time
                         self._handle_client(client_socket)
-                    except (BrokenPipeError, ConnectionResetError) as e:
+                    except (BrokenPipeError, ConnectionResetError, TimeoutError) as e:
                         # BrokenPipeError happens when the proxy connects to the pod, but the service inside is not yet listening.
+                        # TimeoutError is raised by remote_socket_factory() (e.g. exposing_contextmanager) when it can't
+                        # establish a working connection within its own bound -- see https://github.com/red-hat-data-services/notebooks/issues/2684.
                         # The client (Wait.until) will retry.
-                        logging.info(f"Proxy connection to remote failed, likely due to service not being ready: {e}")
+                        logging.info(
+                            f"Proxy connection to remote failed, will retry on the next connection attempt: {e}"
+                        )
                         # The client_socket is closed by the `with` statement in `_handle_client`.
                         # We continue the loop to accept the next connection attempt.
                         continue

--- a/tests/containers/socket_proxy.py
+++ b/tests/containers/socket_proxy.py
@@ -99,7 +99,7 @@ class SocketProxy:
                         # TimeoutError is raised by remote_socket_factory() (e.g. exposing_contextmanager) when it can't
                         # establish a working connection within its own bound -- see https://github.com/red-hat-data-services/notebooks/issues/2684.
                         # The client (Wait.until) will retry.
-                        logging.info(f"Proxy connection to remote failed, likely due to service not being ready: {e}")
+                        logging.info(f"Proxy connection to remote failed, will retry on the next connection attempt: {e}")
                         # The client_socket is closed by the `with` statement in `_handle_client`.
                         # We continue the loop to accept the next connection attempt.
                         continue

--- a/tests/containers/socket_proxy.py
+++ b/tests/containers/socket_proxy.py
@@ -99,7 +99,9 @@ class SocketProxy:
                         # TimeoutError is raised by remote_socket_factory() (e.g. exposing_contextmanager) when it can't
                         # establish a working connection within its own bound -- see https://github.com/red-hat-data-services/notebooks/issues/2684.
                         # The client (Wait.until) will retry.
-                        logging.info(f"Proxy connection to remote failed, will retry on the next connection attempt: {e}")
+                        logging.info(
+                            f"Proxy connection to remote failed, will retry on the next connection attempt: {e}"
+                        )
                         # The client_socket is closed by the `with` statement in `_handle_client`.
                         # We continue the loop to accept the next connection attempt.
                         continue

--- a/tests/containers/socket_proxy.py
+++ b/tests/containers/socket_proxy.py
@@ -94,8 +94,10 @@ class SocketProxy:
                     try:
                         # handle client synchronously, which means that there can be at most one at a time
                         self._handle_client(client_socket)
-                    except (BrokenPipeError, ConnectionResetError) as e:
+                    except (BrokenPipeError, ConnectionResetError, TimeoutError) as e:
                         # BrokenPipeError happens when the proxy connects to the pod, but the service inside is not yet listening.
+                        # TimeoutError is raised by remote_socket_factory() (e.g. exposing_contextmanager) when it can't
+                        # establish a working connection within its own bound -- see https://github.com/red-hat-data-services/notebooks/issues/2684.
                         # The client (Wait.until) will retry.
                         logging.info(f"Proxy connection to remote failed, likely due to service not being ready: {e}")
                         # The client_socket is closed by the `with` statement in `_handle_client`.


### PR DESCRIPTION
## Summary

Implements "Fix #2" from the suggested (not-yet-implemented) hardening ideas in
[#2684](https://github.com/red-hat-data-services/notebooks/issues/2684): bound
`exposing_contextmanager()`'s `kubernetes.stream.portforward()` retry loop in
`tests/containers/kubernetes_utils.py`.

## Why

`exposing_contextmanager()` retried `portforward()` in a
`while not pf or not pf.connected or not s:` loop with **no deadline and no give-up
condition**. Verified via the `kubernetes` client library source
(`kubernetes/stream/ws_client.py`) that the underlying `websocket.connect(...)` call
has no per-call timeout plumbed through `portforward()`'s public API -- a single
iteration can, in principle, hang forever (e.g. a wedged connection to the API
server), not just retry quickly.

Because `SocketProxy.listen_and_serve_until_canceled()` handles one client
synchronously, a stuck call here blocks the *entire* proxy -- no other
`Wait.until` retry can ever be serviced again for that pod, with no way to
recover.

Empirical testing of the two other suggested fixes in #2684 (bigger `listen()`
backlog, dropping stale queued connections) showed they're no-ops for
`Wait.until`'s actual serial access pattern -- see the
[follow-up comment](https://github.com/red-hat-data-services/notebooks/issues/2684#issuecomment-5155926829)
for the methodology/results. Only this one addresses a real, currently-unmitigated
gap, so it's the only one implemented here.

Separately verified on a real cluster-less repro (remapped container port,
mimicking the port-forward host/pod port mismatch) that this change is orthogonal
to the RStudio `/api` regression fixed in #2685: that failure is an instant
(~2ms) client-side `ConnectionError` to the wrong hardcoded port, happening
*after* the portforward tunnel is already established -- outside this function's
code path entirely.

## Changes

- `exposing_contextmanager()` gains a `timeout: float = 30` parameter (well under
  the outer `Wait.until(..., TestFrameConstants.TIMEOUT_2MIN, ...)` 120s budget at
  the only call site, so a give-up still leaves room for several fresh retries).
  Once exceeded, cleans up any partial `s`/`pf` and raises `TimeoutError`.
- Incidental fix bundled in because the same loop is being touched: added
  `s.close()`/`pf.close()` cleanup between retry iterations. Previously each
  failed attempt leaked the prior `PortForward`/socket (this is already how
  `opendatahub-io/notebooks:main`'s copy of this function behaves -- rhoai-2.25
  had fallen behind on just this point).
- `SocketProxy.listen_and_serve_until_canceled()` now also catches the new
  `TimeoutError` alongside the existing `BrokenPipeError`/`ConnectionResetError`,
  so the proxy gives up on just that one connection and keeps serving future
  retries. Without this, the exception would escape to the outer
  `except Exception` handler and kill the whole proxy thread instead.

## Verification

- `ast.parse`, `uv run ruff check`, `uv run pyright` all clean on both files.
- No dedicated unit tests exist for `exposing_contextmanager`/`SocketProxy`
  (confirmed via grep) -- real coverage is via the `openshift-container-tests`
  CI job added in #2685, which exercises this exact code path. Treating its 5
  matrix legs going green as the real verification for this PR.

## Rollout

Sequenced as one enhancement PR per branch, this one first: `rhoai-2.25` (this
PR) → `opendatahub-io/notebooks:main` → `rhoai-3.5`, since this is also the only
branch with CI coverage of this code path today (tracked for `main`/`rhoai-3.5`
separately by opendatahub-io/notebooks#4257).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Port-forward connections now have a configurable timeout, preventing indefinite waits during connection setup.
  - Failed or incomplete connection attempts are cleaned up before retries.
  - Connection establishment retries now monitor readiness and stop when the overall timeout is reached.
  - Timeout and remote connection failures are handled gracefully, allowing retry behavior to continue and providing clearer failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->