### PR TITLE
[rhoai-3.5] fix(tests): bound exposing_contextmanager's portforward retry loop

### DIFF
--- a/tests/containers/kubernetes_utils.py
+++ b/tests/containers/kubernetes_utils.py
@@ -464,28 +464,82 @@ class Utils:
             raise ValueError(message)
 
 
+def _portforward_with_timeout(
+    core_v1_api: kubernetes.client.CoreV1Api, pod: kubernetes.client.models.V1Pod, timeout: float
+) -> kubernetes.stream.ws_client.PortForward:
+    """Runs kubernetes.stream.portforward() with a wall-clock bound.
+
+    The kubernetes client doesn't expose a per-call connect timeout for portforward() -- it calls
+    websocket.connect() with no timeout, so a wedged connection to the API server can hang this call
+    forever. The only alternative the library offers is a process-wide `websocket.setdefaulttimeout()`,
+    which isn't safe to use here since multiple SocketProxy instances (one per ImageDeployment) can be
+    making concurrent portforward() calls from different threads. So we run the call in a helper thread
+    and bound it with join(timeout) instead.
+
+    If the call doesn't return in time, it is abandoned rather than joined: the daemon thread and any
+    partially established connection are leaked for the remainder of the test process. That's an
+    accepted tradeoff for test infrastructure that's about to raise TimeoutError and fail the test
+    (and the process will exit soon after) rather than hang forever with no recovery.
+    """
+    pf_result: list[kubernetes.stream.ws_client.PortForward] = []
+    error_result: list[Exception] = []
+
+    def _target() -> None:
+        try:
+            pf = kubernetes.stream.portforward(
+                api_method=core_v1_api.connect_get_namespaced_pod_portforward,
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                ports=",".join(str(p) for p in [8888]),
+            )
+            pf_result.append(pf)
+        except Exception as e:  # propagated to the caller below, not swallowed
+            error_result.append(e)
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if error_result:
+        raise error_result[0]
+    if not pf_result:
+        raise TimeoutError(
+            f"kubernetes.stream.portforward() to {pod.metadata.name} did not return within {timeout:.1f}s"
+        )
+    return pf_result[0]
+
+
 @contextlib.contextmanager
 def exposing_contextmanager(
     core_v1_api: kubernetes.client.CoreV1Api,
     pod: kubernetes.client.models.V1Pod,
+    timeout: float = 30,
 ) -> Generator[socket]:
     # If we e.g., specify the wrong port, the pf = portforward() call succeeds,
     # but pf.connected will later flip to False
     # we need to check that _everything_ works before moving on
+    #
+    # https://github.com/red-hat-data-services/notebooks/issues/2684: bound this retry loop (and each
+    # individual portforward() attempt via _portforward_with_timeout, since a single hung call would
+    # otherwise never let this loop's own deadline check run again) so a pod that never becomes
+    # reachable can't block the single-threaded SocketProxy forever and starve every later
+    # Wait.until retry.
+    deadline = time.monotonic() + timeout
     pf: kubernetes.stream.ws_client.PortForward | None = None
     s = None
     while not pf or not pf.connected or not s:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            if s is not None:
+                s.close()
+            if pf is not None:
+                pf.close()
+            raise TimeoutError(f"Failed to establish a working portforward to {pod.metadata.name} within {timeout}s")
         if s is not None:
             s.close()
             s = None
         if pf is not None:
             pf.close()
-        pf = kubernetes.stream.portforward(
-            api_method=core_v1_api.connect_get_namespaced_pod_portforward,
-            name=pod.metadata.name,
-            namespace=pod.metadata.namespace,
-            ports=",".join(str(p) for p in [8888]),
-        )
+        pf = _portforward_with_timeout(core_v1_api, pod, remaining)
         s = pf.socket(8888)
     assert s, "Failed to establish connection"
 

--- a/tests/containers/socket_proxy.py
+++ b/tests/containers/socket_proxy.py
@@ -94,10 +94,14 @@ class SocketProxy:
                     try:
                         # handle client synchronously, which means that there can be at most one at a time
                         self._handle_client(client_socket)
-                    except (BrokenPipeError, ConnectionResetError) as e:
+                    except (BrokenPipeError, ConnectionResetError, TimeoutError) as e:
                         # BrokenPipeError happens when the proxy connects to the pod, but the service inside is not yet listening.
+                        # TimeoutError is raised by remote_socket_factory() (e.g. exposing_contextmanager) when it can't
+                        # establish a working connection within its own bound -- see https://github.com/red-hat-data-services/notebooks/issues/2684.
                         # The client (Wait.until) will retry.
-                        logging.info(f"Proxy connection to remote failed, likely due to service not being ready: {e}")
+                        logging.info(
+                            f"Proxy connection to remote failed, will retry on the next connection attempt: {e}"
+                        )
                         # The client_socket is closed by the `with` statement in `_handle_client`.
                         # We continue the loop to accept the next connection attempt.
                         continue


### PR DESCRIPTION
## Summary

Implements "Fix #2" from the suggested (not-yet-implemented) hardening ideas in
[#2684](https://github.com/red-hat-data-services/notebooks/issues/2684): bound
`exposing_contextmanager()`'s `kubernetes.stream.portforward()` retry loop in
`tests/containers/kubernetes_utils.py`.

## Why

`exposing_contextmanager()` retried `portforward()` in a
`while not pf or not pf.connected or not s:` loop with **no deadline and no give-up
condition**. Verified via the `kubernetes` client library source that the underlying
`websocket.connect(...)` call has no per-call timeout plumbed through `portforward()`'s
public API -- a single iteration can, in principle, hang forever (e.g. a wedged
connection to the API server), not just retry quickly.

Because `SocketProxy.listen_and_serve_until_canceled()` handles one client
synchronously, a stuck call here blocks the *entire* proxy -- no other `Wait.until`
retry can ever be serviced again for that pod, with no way to recover.

## Changes

- `exposing_contextmanager()` gains a `timeout: float = 30` parameter. Once exceeded,
  cleans up any partial `s`/`pf` and raises `TimeoutError`.
- The deadline check alone only runs *between* retry loop iterations, so a single
  `portforward()` call that itself hangs would never let it fire again -- added
  `_portforward_with_timeout()`, which runs that specific call in a daemon thread
  bounded by `join(timeout)`. On timeout the call is abandoned (thread/connection
  leaked for the remainder of the test process) rather than joined; deliberately not
  using a process-wide `websocket.setdefaulttimeout()` since multiple `SocketProxy`
  instances (one per `ImageDeployment`) can call `portforward()` concurrently from
  different threads.
- `SocketProxy.listen_and_serve_until_canceled()` now also catches the new
  `TimeoutError` alongside the existing `BrokenPipeError`/`ConnectionResetError`, so
  the proxy gives up on just that one connection and keeps serving future retries.

This is a mechanical, identical port of
[red-hat-data-services/notebooks#2691](https://github.com/red-hat-data-services/notebooks/pull/2691)
(`rhoai-2.25`) and [opendatahub-io/notebooks#4273](https://github.com/opendatahub-io/notebooks/pull/4273)
(`main`) -- `rhoai-3.5`'s `tests/containers/kubernetes_utils.py`/`socket_proxy.py`
were confirmed byte-identical to `main`'s pre-change state (modulo one unrelated
`logging.basicConfig` line), where this was already implemented and CI-verified,
including a CodeRabbit review catching a real gap in the first iteration (the
single-hung-call issue this PR's `_portforward_with_timeout()` addresses).

## Verification

- `ast.parse`, `uv run ruff check`, `uv run ruff format --check`, `uv run pyright`
  all clean on both files.
- **Correction from an earlier revision of this description**: unlike `rhoai-2.25`
  (PR #2685) and `main` (opendatahub-io/notebooks#4259), `rhoai-3.5`'s
  `test-containers.yaml` does **not** have an `openshift-container-tests` job -- it
  was never ported here. So this PR's own CI does *not* exercise this exact code
  path (confirmed: no `openshift:` matrix legs run on this PR, only the regular
  `container-tests` job, which excludes `openshift`-marked tests). Verification here
  is limited to the static checks above plus local functional testing of three
  scenarios against this exact code (a `portforward()` call that hangs forever ->
  correctly bounded; a pod that fails fast repeatedly -> unaffected; one that
  succeeds on a later retry -> unaffected). Porting the `openshift-container-tests`
  job to `rhoai-3.5` (mirroring #2685/#4259) would be a separate, follow-up PR if
  wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added configurable timeouts for Kubernetes port-forward setup, preventing connections from hanging indefinitely.
  - Improved handling of connection failures and timed-out setup attempts, including cleanup before retries.
  - Preserved retry behavior when remote connections fail, improving recovery for subsequent connection attempts.
  - Updated error handling and logging to provide clearer feedback during connection retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->