### PR TITLE
[rhoai-2.25] docs(lockfile): align custom flavor on Dockerfile.konflux.<flavor>

### DIFF
--- a/scripts/lockfile-generators/README.md
+++ b/scripts/lockfile-generators/README.md
@@ -180,7 +180,7 @@ and a full walkthrough (including jupyter datascience).
 | ---------------------- | ---------------------------------------------------------------------- |
 | `--component-dir DIR`  | Component directory (required), e.g. `codeserver/ubi9-python-3.12`     |
 | `--rhds`               | Use downstream (RHDS) lockfiles instead of upstream (ODH, the default) |
-| `--flavor NAME`        | Lock file flavor (default: `cpu`)                                      |
+| `--flavor NAME`        | Lock file flavor (default: `cpu`, or first available `Dockerfile.konflux.{cpu,cuda,rocm}` when `cpu` is absent) |
 | `--activation-key KEY` | Red Hat activation key for RHEL RPMs (optional)                        |
 | `--org ORG`            | Red Hat organization ID for RHEL RPMs (optional)                       |
 
@@ -850,7 +850,7 @@ The script performs these steps:
 | Option                  | Description                                                                                                                                                                                                          |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--pyproject-toml FILE` | Path to `pyproject.toml` (required). Output files are written to the same directory.                                                                                                                                 |
-| `--flavor NAME`         | Lock file flavor (default: `cpu`). Must match `Dockerfile.konflux.<flavor>` and `build-args/konflux.<flavor>.conf` in the project directory. Determines output filenames (`pylock.<flavor>.toml` and `requirements.<flavor>.txt`). |
+| `--flavor NAME`         | Lock file flavor (default: `cpu`, or the first available `Dockerfile.konflux.{cpu,cuda,rocm}` when `cpu` is absent). Must match `Dockerfile.konflux.<flavor>` in the project directory. The `rh-index` flow also requires `build-args/konflux.<flavor>.conf`. Determines output filenames (`pylock.<flavor>.toml` and `requirements.<flavor>.txt`). |
 | `--download`            | After generating the lock, download all wheels into `cachi2/output/deps/pip/` (for local testing with podman; not needed in Konflux CI).                                                                             |
 
 
@@ -878,7 +878,8 @@ This command:
 ./scripts/lockfile-generators/create-requirements-lockfile.sh \
     --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml
 
-# Custom flavor (e.g. cuda — requires Dockerfile.konflux.cuda and build-args/konflux.cuda.conf)
+# Custom flavor — rh-index flow (downstream 3.5+): requires
+# Dockerfile.konflux.<flavor> and build-args/konflux.<flavor>.conf
 ./scripts/lockfile-generators/create-requirements-lockfile.sh \
     --pyproject-toml jupyter/minimal/ubi9-python-3.12/pyproject.toml \
     --flavor cuda

--- a/scripts/lockfile-generators/README.md
+++ b/scripts/lockfile-generators/README.md
@@ -850,7 +850,7 @@ The script performs these steps:
 | Option                  | Description                                                                                                                                                                                                          |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--pyproject-toml FILE` | Path to `pyproject.toml` (required). Output files are written to the same directory.                                                                                                                                 |
-| `--flavor NAME`         | Lock file flavor (default: `cpu`). Must match a `Dockerfile.<flavor>` and `build-args/<flavor>.conf` in the project directory. Determines output filenames (`pylock.<flavor>.toml` and `requirements.<flavor>.txt`). |
+| `--flavor NAME`         | Lock file flavor (default: `cpu`). Must match `Dockerfile.konflux.<flavor>` and `build-args/konflux.<flavor>.conf` in the project directory. Determines output filenames (`pylock.<flavor>.toml` and `requirements.<flavor>.txt`). |
 | `--download`            | After generating the lock, download all wheels into `cachi2/output/deps/pip/` (for local testing with podman; not needed in Konflux CI).                                                                             |
 
 
@@ -878,9 +878,9 @@ This command:
 ./scripts/lockfile-generators/create-requirements-lockfile.sh \
     --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml
 
-# Custom flavor (e.g. cuda — requires Dockerfile.konflux.cuda and build-args/cuda.conf)
+# Custom flavor (e.g. cuda — requires Dockerfile.konflux.cuda and build-args/konflux.cuda.conf)
 ./scripts/lockfile-generators/create-requirements-lockfile.sh \
-    --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml \
+    --pyproject-toml jupyter/minimal/ubi9-python-3.12/pyproject.toml \
     --flavor cuda
 ```
 

--- a/scripts/lockfile-generators/create-requirements-lockfile.sh
+++ b/scripts/lockfile-generators/create-requirements-lockfile.sh
@@ -24,7 +24,8 @@ set -euo pipefail
 #   ./scripts/lockfile-generators/create-requirements-lockfile.sh \
 #       --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml --download
 #
-#   # Custom flavor (requires Dockerfile.konflux.<flavor> and build-args/konflux.<flavor>.conf)
+#   # Custom flavor — rh-index flow (downstream 3.5+):
+#   # Dockerfile.konflux.<flavor> and build-args/konflux.<flavor>.conf
 #   ./scripts/lockfile-generators/create-requirements-lockfile.sh \
 #       --pyproject-toml jupyter/minimal/ubi9-python-3.12/pyproject.toml --flavor cuda
 
@@ -34,6 +35,7 @@ PYLOCKS_GENERATOR="scripts/pylocks_generator.py"
 # --- Defaults ---
 PYPROJECT=""
 FLAVOR="cpu"
+FLAVOR_EXPLICIT=false
 DO_DOWNLOAD=false
 
 # --- Functions ---
@@ -47,9 +49,11 @@ a pip-compatible requirements.<flavor>.txt with sha256 hashes.
 Options:
   --pyproject-toml FILE  Path to pyproject.toml (required)
                          (e.g. codeserver/ubi9-python-3.12/pyproject.toml)
-  --flavor NAME          Lock file flavor (default: cpu).
-                         Must match Dockerfile.konflux.<flavor> and
-                         build-args/konflux.<flavor>.conf (rh-index flow).
+  --flavor NAME          Lock file flavor (default: cpu, or the first available
+                         Dockerfile.konflux.{cpu,cuda,rocm} when cpu is absent).
+                         Must match Dockerfile.konflux.<flavor> in the
+                         project directory. The rh-index flow also requires
+                         build-args/konflux.<flavor>.conf.
   --download             After generating, download all wheels into
                          cachi2/output/deps/pip/ for offline builds.
   -h, --help             Show this help message and exit
@@ -67,6 +71,35 @@ error_exit() {
   exit 1
 }
 
+# resolve_konflux_flavor PROJECT_DIR FLAVOR FLAVOR_EXPLICIT
+# Echoes the flavor to use. When FLAVOR is the default and its Dockerfile is
+# missing, picks the first available cpu/cuda/rocm Dockerfile.konflux.* instead.
+resolve_konflux_flavor() {
+  local project_dir="$1"
+  local flavor="$2"
+  local explicit="$3"
+  local candidate
+
+  if [[ -f "${project_dir}/Dockerfile.konflux.${flavor}" ]]; then
+    echo "$flavor"
+    return 0
+  fi
+
+  if [[ "$explicit" == true ]]; then
+    error_exit "Konflux Dockerfile not found: ${project_dir}/Dockerfile.konflux.${flavor}"
+  fi
+
+  for candidate in cpu cuda rocm; do
+    if [[ -f "${project_dir}/Dockerfile.konflux.${candidate}" ]]; then
+      echo "Note: auto-selected flavor '${candidate}' (no Dockerfile.konflux.${flavor})" >&2
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  error_exit "No Dockerfile.konflux.{cpu,cuda,rocm} found in ${project_dir}; use --flavor"
+}
+
 # --- Validation ---
 if [[ ! -d "$SCRIPTS_PATH" ]]; then
   error_exit "This script MUST be run from the repository root."
@@ -80,7 +113,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)           show_help; exit 0 ;;
     --pyproject-toml)    PYPROJECT="$2"; shift 2 ;;
-    --flavor)            FLAVOR="$2"; shift 2 ;;
+    --flavor)            FLAVOR="$2"; FLAVOR_EXPLICIT=true; shift 2 ;;
     --download)          DO_DOWNLOAD=true; shift ;;
     *)                   error_exit "Unknown argument: '$1'" ;;
   esac
@@ -91,6 +124,7 @@ done
 
 # Derive paths
 PROJECT_DIR="$(dirname "$PYPROJECT")"
+FLAVOR="$(resolve_konflux_flavor "$PROJECT_DIR" "$FLAVOR" "$FLAVOR_EXPLICIT")"
 REQUIREMENTS_FILE="${PROJECT_DIR}/requirements.${FLAVOR}.txt"
 
 # Use public-index when PROJECT_DIR equals a listed path or is a subdirectory (e.g. .../ubi9-python-3.12).
@@ -112,7 +146,6 @@ fi
 PYLOCK_FILE="${PROJECT_DIR}/uv.lock.d/pylock.${FLAVOR}.toml"
 REQUIREMENTS_INDEX_URL=""
 KONFLUX_DOCKERFILE="${PROJECT_DIR}/Dockerfile.konflux.${FLAVOR}"
-[[ -f "$KONFLUX_DOCKERFILE" ]] || error_exit "Konflux Dockerfile not found: $KONFLUX_DOCKERFILE"
 if [[ "$PYLOCKS_MODE" == "public-index" ]]; then
   PYLOCK_FILE="${PROJECT_DIR}/pylock.toml"
   HERMETO_INDEX_URL="https://pypi.org/simple"

--- a/scripts/lockfile-generators/create-requirements-lockfile.sh
+++ b/scripts/lockfile-generators/create-requirements-lockfile.sh
@@ -24,9 +24,9 @@ set -euo pipefail
 #   ./scripts/lockfile-generators/create-requirements-lockfile.sh \
 #       --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml --download
 #
-#   # Custom flavor
+#   # Custom flavor (requires Dockerfile.konflux.<flavor> and build-args/konflux.<flavor>.conf)
 #   ./scripts/lockfile-generators/create-requirements-lockfile.sh \
-#       --pyproject-toml codeserver/ubi9-python-3.12/pyproject.toml --flavor cuda
+#       --pyproject-toml jupyter/minimal/ubi9-python-3.12/pyproject.toml --flavor cuda
 
 SCRIPTS_PATH="scripts/lockfile-generators"
 PYLOCKS_GENERATOR="scripts/pylocks_generator.py"
@@ -48,8 +48,8 @@ Options:
   --pyproject-toml FILE  Path to pyproject.toml (required)
                          (e.g. codeserver/ubi9-python-3.12/pyproject.toml)
   --flavor NAME          Lock file flavor (default: cpu).
-                         Must match a Dockerfile.<flavor> and
-                         build-args/konflux.<flavor>.conf for the RH-index flow.
+                         Must match Dockerfile.konflux.<flavor> and
+                         build-args/konflux.<flavor>.conf (rh-index flow).
   --download             After generating, download all wheels into
                          cachi2/output/deps/pip/ for offline builds.
   -h, --help             Show this help message and exit
@@ -111,6 +111,8 @@ fi
 
 PYLOCK_FILE="${PROJECT_DIR}/uv.lock.d/pylock.${FLAVOR}.toml"
 REQUIREMENTS_INDEX_URL=""
+KONFLUX_DOCKERFILE="${PROJECT_DIR}/Dockerfile.konflux.${FLAVOR}"
+[[ -f "$KONFLUX_DOCKERFILE" ]] || error_exit "Konflux Dockerfile not found: $KONFLUX_DOCKERFILE"
 if [[ "$PYLOCKS_MODE" == "public-index" ]]; then
   PYLOCK_FILE="${PROJECT_DIR}/pylock.toml"
   HERMETO_INDEX_URL="https://pypi.org/simple"

--- a/scripts/lockfile-generators/prefetch-all.sh
+++ b/scripts/lockfile-generators/prefetch-all.sh
@@ -47,6 +47,7 @@ SCRIPTS_PATH="scripts/lockfile-generators"
 COMPONENT_DIR=""
 VARIANT="odh"       # "odh" = upstream (CentOS Stream), "rhds" = downstream (RHEL)
 FLAVOR="cpu"        # selects which pylock/requirements files to use (cpu, cuda, rocm)
+FLAVOR_EXPLICIT=false
 ACTIVATION_KEY=""
 ORG=""
 
@@ -60,7 +61,8 @@ Options:
   --component-dir DIR     Component directory (required)
                           e.g. codeserver/ubi9-python-3.12
   --rhds                  Use downstream (RHDS) lockfiles instead of upstream (ODH)
-  --flavor NAME           Lock file flavor (default: cpu)
+  --flavor NAME           Lock file flavor (default: cpu, or first available
+                          Dockerfile.konflux.{cpu,cuda,rocm} when cpu is absent)
   --activation-key KEY    Red Hat activation key for RHEL RPMs (optional)
   --org ORG               Red Hat organization ID for RHEL RPMs (optional)
   -h, --help              Show this help
@@ -74,6 +76,33 @@ HELPEOF
 error_exit() {
   echo "Error: $1" >&2
   exit 1
+}
+
+# resolve_konflux_flavor PROJECT_DIR FLAVOR FLAVOR_EXPLICIT
+resolve_konflux_flavor() {
+  local project_dir="$1"
+  local flavor="$2"
+  local explicit="$3"
+  local candidate
+
+  if [[ -f "${project_dir}/Dockerfile.konflux.${flavor}" ]]; then
+    echo "$flavor"
+    return 0
+  fi
+
+  if [[ "$explicit" == true ]]; then
+    error_exit "Konflux Dockerfile not found: ${project_dir}/Dockerfile.konflux.${flavor}"
+  fi
+
+  for candidate in cpu cuda rocm; do
+    if [[ -f "${project_dir}/Dockerfile.konflux.${candidate}" ]]; then
+      echo "Note: auto-selected flavor '${candidate}' (no Dockerfile.konflux.${flavor})" >&2
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  error_exit "No Dockerfile.konflux.{cpu,cuda,rocm} found in ${project_dir}; use --flavor"
 }
 
 # find_tekton_yaml COMPONENT_DIR VARIANT
@@ -119,7 +148,7 @@ while [[ $# -gt 0 ]]; do
                          COMPONENT_DIR="$2"; shift 2 ;;
     --rhds)              VARIANT="rhds"; shift ;;
     --flavor)            [[ $# -ge 2 ]] || error_exit "--flavor requires a value"
-                         FLAVOR="$2"; shift 2 ;;
+                         FLAVOR="$2"; FLAVOR_EXPLICIT=true; shift 2 ;;
     --activation-key)    [[ $# -ge 2 ]] || error_exit "--activation-key requires a value"
                          ACTIVATION_KEY="$2"; shift 2 ;;
     --org)               [[ $# -ge 2 ]] || error_exit "--org requires a value"
@@ -131,6 +160,7 @@ done
 
 [[ -z "$COMPONENT_DIR" ]] && error_exit "--component-dir is required."
 [[ -d "$COMPONENT_DIR" ]] || error_exit "Component directory not found: $COMPONENT_DIR"
+FLAVOR="$(resolve_konflux_flavor "$COMPONENT_DIR" "$FLAVOR" "$FLAVOR_EXPLICIT")"
 
 # CLI args take priority; fall back to env vars so GHA can pass secrets
 # without exposing them on the command line.  GitHub Actions masks env var


### PR DESCRIPTION
## Summary
- Align `--flavor` docs and validation on `Dockerfile.konflux.<flavor>` after #2694 removed legacy `Dockerfile.<flavor>` workbench files.
- Validate `Dockerfile.konflux.${FLAVOR}` in `create-requirements-lockfile.sh` before lock generation.
- Fix README custom-flavor example (`build-args/konflux.cuda.conf`, jupyter/minimal).

Fixes #2700

## Test plan
- [x] `bash -n scripts/lockfile-generators/create-requirements-lockfile.sh`
- [x] `./scripts/lockfile-generators/create-requirements-lockfile.sh --help` shows `Dockerfile.konflux.<flavor>`
- [x] Invalid `--flavor` exits with clear Dockerfile-not-found error

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pip lockfile guidance for custom flavors.
  * Clarified required Konflux Dockerfile and build-argument naming conventions.
  * Updated the custom-flavor example to use the Jupyter minimal component.
  * Documented automatic flavor selection and explicit flavor requirements.

* **Bug Fixes**
  * Automatically selects the first available CPU, CUDA, or ROCm flavor when the default is unavailable.
  * Reports an error when an explicitly requested flavor is unavailable.
  * Ensures lockfile generation uses the resolved flavor consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->