### PR TITLE
fix(s390x): install zeromq-devel from rhelai-3.0 for pyzmq builds

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -72,15 +72,15 @@ RUN --mount=type=cache,target=/var/cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Building for architecture: ${TARGETARCH}"
 if [ "$TARGETARCH" = "s390x" ]; then
-    PACKAGES="perl mesa-libGL skopeo gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel"
+    PACKAGES=(perl mesa-libGL skopeo gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel)
     subscription-manager refresh
     subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
-    PACKAGES="$PACKAGES zeromq-devel"
+    PACKAGES+=(zeromq-devel)
 else
-    PACKAGES="perl mesa-libGL skopeo"
+    PACKAGES=(perl mesa-libGL skopeo)
 fi
-echo "Installing: $PACKAGES"
-dnf install -y $PACKAGES
+echo "Installing: ${PACKAGES[*]}"
+dnf install -y "${PACKAGES[@]}"
 dnf clean all && rm -rf /var/cache/yum
 EOF
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -73,6 +73,10 @@ set -Eeuxo pipefail
 echo "Building for architecture: ${TARGETARCH}"
 if [ "$TARGETARCH" = "s390x" ]; then
     PACKAGES="perl mesa-libGL skopeo gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel"
+    if [ -f /etc/yum.repos.d/redhat.repo ] && grep -q '^\[rhelai-3.0-for-rhel-9-s390x-rpms\]' /etc/yum.repos.d/redhat.repo; then
+        subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
+        PACKAGES="$PACKAGES zeromq-devel"
+    fi
 else
     PACKAGES="perl mesa-libGL skopeo"
 fi
@@ -406,9 +410,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
     echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
-        # We need special flags and environment variables when building packages
+        BUILD_CFLAGS="-O3" && \
+        if [ "$TARGETARCH" = "s390x" ] && ! pkg-config --exists libzmq 2>/dev/null; then \
+            BUILD_CFLAGS="-O3 -Dundefined=64"; \
+        fi && \
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
-        CFLAGS="-O3" CXXFLAGS="-O3" \
+        CFLAGS="$BUILD_CFLAGS" CXXFLAGS="$BUILD_CFLAGS" \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress \
             --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
             --build-constraint build_constraints.txt \

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -73,10 +73,9 @@ set -Eeuxo pipefail
 echo "Building for architecture: ${TARGETARCH}"
 if [ "$TARGETARCH" = "s390x" ]; then
     PACKAGES="perl mesa-libGL skopeo gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel"
-    if [ -f /etc/yum.repos.d/redhat.repo ] && grep -q '^\[rhelai-3.0-for-rhel-9-s390x-rpms\]' /etc/yum.repos.d/redhat.repo; then
-        subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
-        PACKAGES="$PACKAGES zeromq-devel"
-    fi
+    subscription-manager refresh
+    subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
+    PACKAGES="$PACKAGES zeromq-devel"
 else
     PACKAGES="perl mesa-libGL skopeo"
 fi
@@ -410,12 +409,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
     echo "meson<1.11" > build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
-        BUILD_CFLAGS="-O3" && \
-        if [ "$TARGETARCH" = "s390x" ] && ! pkg-config --exists libzmq 2>/dev/null; then \
-            BUILD_CFLAGS="-O3 -Dundefined=64"; \
-        fi && \
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
-        CFLAGS="$BUILD_CFLAGS" CXXFLAGS="$BUILD_CFLAGS" \
+        CFLAGS="-O3" CXXFLAGS="-O3" \
         uv pip install --strict --no-deps --no-cache --no-config --no-progress \
             --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
             --build-constraint build_constraints.txt \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -44,21 +44,21 @@ EOF
 RUN --mount=type=cache,target=/var/cache/dnf /bin/bash <<'EOF'
 set -Eeuxo pipefail
 echo "Building for architecture: ${TARGETARCH}"
-PACKAGES="perl mesa-libGL skopeo libxcrypt-compat"
+PACKAGES=(perl mesa-libGL skopeo libxcrypt-compat)
 # Additional dev tools only for s390x
 if [ "$TARGETARCH" = "s390x" ]; then
-    PACKAGES="$PACKAGES gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel openssl zlib-devel"
+    PACKAGES+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel openssl zlib-devel)
     # RH-signed zeromq-devel is in rhelai-3.0 (not UBI AppStream/EPEL). Export repos before dnf.
     subscription-manager refresh
     subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
-    PACKAGES="$PACKAGES zeromq-devel"
+    PACKAGES+=(zeromq-devel)
 fi
 if [ "$TARGETARCH" = "ppc64le" ]; then
-    PACKAGES="$PACKAGES git gcc-toolset-13 make wget unzip rust cargo unixODBC-devel cmake ninja-build"
+    PACKAGES+=(git gcc-toolset-13 make wget unzip rust cargo unixODBC-devel cmake ninja-build)
 fi
-if [ -n "$PACKAGES" ]; then
-    echo "Installing: $PACKAGES"
-    dnf install -y $PACKAGES
+if [ ${#PACKAGES[@]} -gt 0 ]; then
+    echo "Installing: ${PACKAGES[*]}"
+    dnf install -y "${PACKAGES[@]}"
     dnf clean all && rm -rf /var/cache/yum
 fi
 EOF

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -48,11 +48,10 @@ PACKAGES="perl mesa-libGL skopeo libxcrypt-compat"
 # Additional dev tools only for s390x
 if [ "$TARGETARCH" = "s390x" ]; then
     PACKAGES="$PACKAGES gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel openssl zlib-devel"
-    # RH-signed zeromq-devel is in rhelai-3.0 (AIPCC base redhat.repo), not UBI AppStream/EPEL.
-    if [ -f /etc/yum.repos.d/redhat.repo ] && grep -q '^\[rhelai-3.0-for-rhel-9-s390x-rpms\]' /etc/yum.repos.d/redhat.repo; then
-        subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
-        PACKAGES="$PACKAGES zeromq-devel"
-    fi
+    # RH-signed zeromq-devel is in rhelai-3.0 (not UBI AppStream/EPEL). Export repos before dnf.
+    subscription-manager refresh
+    subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
+    PACKAGES="$PACKAGES zeromq-devel"
 fi
 if [ "$TARGETARCH" = "ppc64le" ]; then
     PACKAGES="$PACKAGES git gcc-toolset-13 make wget unzip rust cargo unixODBC-devel cmake ninja-build"
@@ -428,15 +427,9 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
     export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 elif [ "$TARGETARCH" = "s390x" ]; then
-    # For s390x, we need special flags and environment variables for building packages.
-    # When zeromq-devel is unavailable (UBI-only GHA builds), pyzmq bundles libzmq and needs
-    # -Dundefined=64 under qemu-user; do not wipe that via a bare CFLAGS=-O3 override.
-    S390X_BUILD_CFLAGS="-O3"
-    if ! pkg-config --exists libzmq 2>/dev/null; then
-        S390X_BUILD_CFLAGS="-O3 -Dundefined=64"
-    fi
+    # For s390x, we need special flags and environment variables for building packages
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
-    CFLAGS="$S390X_BUILD_CFLAGS" CXXFLAGS="$S390X_BUILD_CFLAGS" \
+    CFLAGS="-O3" CXXFLAGS="-O3" \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -48,6 +48,11 @@ PACKAGES="perl mesa-libGL skopeo libxcrypt-compat"
 # Additional dev tools only for s390x
 if [ "$TARGETARCH" = "s390x" ]; then
     PACKAGES="$PACKAGES gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel openssl zlib-devel"
+    # RH-signed zeromq-devel is in rhelai-3.0 (AIPCC base redhat.repo), not UBI AppStream/EPEL.
+    if [ -f /etc/yum.repos.d/redhat.repo ] && grep -q '^\[rhelai-3.0-for-rhel-9-s390x-rpms\]' /etc/yum.repos.d/redhat.repo; then
+        subscription-manager repos --enable=rhelai-3.0-for-rhel-9-s390x-rpms
+        PACKAGES="$PACKAGES zeromq-devel"
+    fi
 fi
 if [ "$TARGETARCH" = "ppc64le" ]; then
     PACKAGES="$PACKAGES git gcc-toolset-13 make wget unzip rust cargo unixODBC-devel cmake ninja-build"
@@ -423,9 +428,15 @@ if [ "$TARGETARCH" = "ppc64le" ]; then
     export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 elif [ "$TARGETARCH" = "s390x" ]; then
-    # For s390x, we need special flags and environment variables for building packages
+    # For s390x, we need special flags and environment variables for building packages.
+    # When zeromq-devel is unavailable (UBI-only GHA builds), pyzmq bundles libzmq and needs
+    # -Dundefined=64 under qemu-user; do not wipe that via a bare CFLAGS=-O3 override.
+    S390X_BUILD_CFLAGS="-O3"
+    if ! pkg-config --exists libzmq 2>/dev/null; then
+        S390X_BUILD_CFLAGS="-O3 -Dundefined=64"
+    fi
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
-    CFLAGS="-O3" CXXFLAGS="-O3" \
+    CFLAGS="$S390X_BUILD_CFLAGS" CXXFLAGS="$S390X_BUILD_CFLAGS" \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --build-constraint build_constraints.txt --requirements=./pylock.toml
 else
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,


### PR DESCRIPTION
## Summary

- On s390x AIPCC bases, `subscription-manager refresh` then enable `rhelai-3.0-for-rhel-9-s390x-rpms` and install RH-signed `zeromq-devel` so `pyzmq` links system libzmq instead of bundling it under qemu-user emulation.
- Applies to runtime and jupyter datascience `Dockerfile.konflux.cpu`.

## Context

Fixes the recurring `runtime-datascience-ubi9-python-3.12 · linux/s390x` failure (`pyzmq` bundled libzmq CMake error: `ZMQ_CACHELINE_SIZE undefined`) seen on PRs such as #2504 and #2694.

All GHA rhoai builds use subscribed AIPCC bases with entitlements mounted — no UBI-only fallback path, so no `CFLAGS=-Dundefined=64` merge is needed once `zeromq-devel` is installed.

## Test plan

- [ ] GHA `runtime-datascience-ubi9-python-3.12 · linux/s390x [rhoai] / build` passes
- [ ] Konflux/AIPCC build uses `zeromq-devel` from rhelai-3.0 and skips bundled libzmq compile
- [ ] `jupyter-datascience-ubi9-python-3.12 · linux/s390x` still green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved support for s390x CPU image builds.
  - Enabled access to the required RHEL AI 3.0 package repository.
  - Added ZeroMQ development support to the s390x environment.

- **Bug Fixes**
  - Refreshed subscription metadata during image builds to ensure packages are retrieved from current sources.
  - Improved package handling to install architecture-specific dependencies reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->