### PR TITLE
[rhoai-3.5] fix(manifests): add JupyterLab and Codeflare-SDK to code-server 3.5 annotations

### DIFF
--- a/manifests/odh/base/code-server-notebook-imagestream.yaml
+++ b/manifests/odh/base/code-server-notebook-imagestream.yaml
@@ -26,6 +26,7 @@ spec:
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "Boto3", "version": "1.43"},
+            {"name": "Codeflare-SDK", "version": "0.38"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.11"},
             {"name": "Numpy", "version": "2.5"},
@@ -34,6 +35,7 @@ spec:
             {"name": "Scipy", "version": "1.18"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.3"},
+            {"name": "JupyterLab", "version": "4.6"},
             {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.63"}

--- a/manifests/rhoai/base/code-server-notebook-imagestream.yaml
+++ b/manifests/rhoai/base/code-server-notebook-imagestream.yaml
@@ -26,6 +26,7 @@ spec:
         opendatahub.io/notebook-python-dependencies: |
           [
             {"name": "Boto3", "version": "1.43"},
+            {"name": "Codeflare-SDK", "version": "0.38"},
             {"name": "Kafka-Python-ng", "version": "2.2"},
             {"name": "Matplotlib", "version": "3.11"},
             {"name": "Numpy", "version": "2.5"},
@@ -34,6 +35,7 @@ spec:
             {"name": "Scipy", "version": "1.18"},
             {"name": "Sklearn-onnx", "version": "1.20"},
             {"name": "ipykernel", "version": "7.3"},
+            {"name": "JupyterLab", "version": "4.6"},
             {"name": "Kubeflow-Training", "version": "1.9"},
             {"name": "MLflow", "version": "3.14"},
             {"name": "Feast", "version": "0.63"}


### PR DESCRIPTION
## Summary

- Add `JupyterLab` (4.6) and `Codeflare-SDK` (0.38) to **tag 3.5** (current GA) `notebook-python-dependencies` in ODH and RHOAI `code-server-notebook-imagestream.yaml`.
- Versions match the published 3.5 image lockfile at `commit-n` (`955afa6`).

## Context

Backport of opendatahub-io/notebooks#4294 for the `rhoai-3.5` release branch. The 3.5 Quay image contains `jupyterlab` and `codeflare-sdk` but manifest annotations were never updated after #3586 / #4020 landed.

Upstream PR: https://github.com/opendatahub-io/notebooks/pull/4294

## Test plan

- [ ] `validation-of-sw-versions-in-imagestreams` passes for code-server tag 3.5 (ODH + RHOAI)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the latest notebook image to include Codeflare SDK 0.38 and JupyterLab 4.6.
  * The updated versions are available in both supported notebook image configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->