### PR TITLE
RHAIENG-6697: bump mongocli for golang.org/x/crypto 0.52.0 [rhoai-3.5]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = codeserver/ubi9-python-3.12/prefetch-input/code-server
 	url = https://github.com/coder/code-server.git
 	shallow = true
-# mongocli: keep at tag mongocli/v2.0.4 (pinned by parent commit; update via: cd path && git fetch && git checkout mongocli/v2.0.4)
+# mongocli: pin past mongocli/v2.0.4 for golang.org/x/crypto >= 0.52.0 (RHAIENG-6697); no upstream tag yet — pinned to 4a3115cf6 (x/crypto v0.52.0). Update via: cd path && git fetch && git checkout <sha-or-tag>
 [submodule "prefetch-input/mongocli"]
 	path = prefetch-input/mongocli
 	url = https://github.com/mongodb/mongodb-cli


### PR DESCRIPTION
## Summary
- Bump `prefetch-input/mongocli` submodule from `mongocli/v2.0.4` (`x/crypto v0.37.0`) to upstream commit [`4a3115cf6`](https://github.com/mongodb/mongodb-cli/commit/4a3115cf6ad5517a66db760954d10d936b13d6f1) (`x/crypto v0.52.0`, Fixed In for [RHAIENG-6697](https://redhat.atlassian.net/browse/RHAIENG-6697))
- Update `.gitmodules` pin comment (no upstream tag ships ≥0.52 yet; `mongocli/v2.0.7` is still `v0.46.0`)

Resolves (partial): [RHAIENG-6697](https://redhat.atlassian.net/browse/RHAIENG-6697)

**Note:** This clears the notebooks-owned mongocli copy. Residual `golang.org/x/crypto` findings may remain from `oc` / `skopeo` RPM binaries until those move or are VEX'd.

## Test plan
- [ ] Confirm submodule SHA is `4a3115cf6` and `go.mod` has `golang.org/x/crypto v0.52.0`
- [ ] Konflux gomod prefetch + mongocli-builder succeeds on a jupyter image that ships mongocli (e.g. datascience / pytorch)
- [ ] Re-scan built image: mongocli path no longer reports x/crypto < 0.52.0
- [ ] Accept / track residual hits from `openshift-clients` / `skopeo` separately if still present


Made with [Cursor](https://cursor.com)

[RHAIENG-6697]: https://redhat.atlassian.net/browse/RHAIENG-6697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6697]: https://redhat.atlassian.net/browse/RHAIENG-6697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled command-line tooling reference to include the latest security library revision.
  * Refreshed the pinned tooling commit for improved dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->