### PR TITLE
 [rhoai-3.3] RHAIENG-4760: fix(cve): bump follow-redirects >=1.16.0 (CVE-2026-40895)

### DIFF
--- a/jupyter/utils/addons/package.json5
+++ b/jupyter/utils/addons/package.json5
@@ -36,4 +36,10 @@
     'webpack-dev-server': '^5.2.3',
   },
   // "packageManager": "pnpm@10.8.1" // forces install of a precise version, so annoying
+  pnpm: {
+    overrides: {
+      // RHAIENG-4760: CVE-2026-40895 Information disclosure via cross-domain redirects
+      'follow-redirects': '>=1.16.0',
+    },
+  },
 }

--- a/jupyter/utils/addons/pnpm-lock.yaml
+++ b/jupyter/utils/addons/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  follow-redirects: '>=1.16.0'
+
 importers:
 
   .:
@@ -761,8 +764,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2531,7 +2534,7 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -2684,7 +2687,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary

- **[RHAIENG-4760](https://redhat.atlassian.net/browse/RHAIENG-4760)**: CVE-2026-40895 — Information disclosure via cross-domain redirects in follow-redirects <1.16.0
- Added `pnpm.overrides` in `jupyter/utils/addons/package.json5` to force `follow-redirects>=1.16.0`
- Regenerated `jupyter/utils/addons/pnpm-lock.yaml` (1.15.11 → 1.16.0)

## CVE Details

| Field | Value |
|-------|-------|
| CVE | CVE-2026-40895 |
| Package | follow-redirects |
| Severity | 7.7 High |
| Fix | >=1.16.0 |
| Jira | [RHAIENG-4760](https://redhat.atlassian.net/browse/RHAIENG-4760) |

## Test plan

- [ ] Verify `pnpm-lock.yaml` contains `follow-redirects@1.16.0`
- [ ] Verify Konflux builds pass
- [ ] Verify no regressions in webpack-dev-server functionality

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[RHAIENG-4760]: https://redhat.atlassian.net/browse/RHAIENG-4760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-4760]: https://redhat.atlassian.net/browse/RHAIENG-4760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package requirements to use `follow-redirects` version 1.16.0 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->