### PR TITLE
test: bump prepare-sboms memory for codeserver PR PipelineRun

### DIFF
--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -206,6 +206,23 @@ spec:
       value: '{{ target_branch }}'
     - name: pathInRepo
       value: pipelines/multi-arch-container-build.yaml
+  # Bump prepare-sboms memory to avoid Syft OOM (default ~256Mi) which hangs upload-sbom
+  # See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1785966291582479 / KFLUXSPRT-8652
+  taskRunSpecs:
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: prepare-sboms
+      computeResources:
+        requests:
+          memory: 8Gi
+        limits:
+          memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          memory: 8Gi
+        limits:
+          memory: 8Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-pull-request-pipelines
   workspaces:


### PR DESCRIPTION
## Summary
- Adds `taskRunSpecs` to the codeserver datascience CPU PR PipelineRun so `prepare-sboms` and `sbom-syft-generate` request/limit **8Gi** (defaults are ~256Mi).
- Intended to unblock the known Syft OOM → `upload-sbom` hang seen on [KFLUXSPRT-8652](https://redhat.atlassian.net/browse/KFLUXSPRT-8652) / [Slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1785966291582479).
- Matches the existing `prepare-sboms` override on the rhoai-3.5 push PipelineRun; also covers `sbom-syft-generate`.

## Test plan
- [ ] Trigger `/build-codeserver` (or apply `kfbuild-codeserver`) on this PR
- [ ] Confirm `build-images` / `prepare-sboms` completes without OOM or multi-hour hang
- [ ] Confirm `upload-sbom` proceeds normally
- [ ] If 8Gi is still insufficient, raise to 16–32Gi (as on ODH main)


Made with [Cursor](https://cursor.com)

[KFLUXSPRT-8652]: https://redhat.atlassian.net/browse/KFLUXSPRT-8652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for image-building tasks to improve reliability during software bill of materials generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->