### PR TITLE
fix: disable Arrow S3 support on S390x

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -171,6 +171,10 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
     # arrow/cpp/thirdparty/versions.txt for the pinned PYARROW_VERSION, or the bundled ORC build
     # fails a checksum mismatch.
     export ARROW_ORC_URL="https://archive.apache.org/dist/orc/orc-2.2.1/orc-2.2.1.tar.gz"
+ARROW_S3_FLAG="-DARROW_S3=OFF"
+if [ "$TARGETARCH" != "s390x" ]; then
+    ARROW_S3_FLAG="-DARROW_S3=ON"
+fi
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/usr/local \
           -DARROW_PYTHON=ON \
@@ -184,6 +188,7 @@ if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then
           -DARROW_WITH_LZ4=OFF \
           -DARROW_WITH_ZSTD=OFF \
           -DARROW_WITH_SNAPPY=OFF \
+${ARROW_S3_FLAG} \
           -DARROW_BUILD_TESTS=OFF \
           -DARROW_BUILD_BENCHMARKS=OFF \
           ..

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -184,6 +184,7 @@ if [ "$TARGETARCH" = "s390x" ]; then
           -DARROW_WITH_LZ4=ON \
           -DARROW_WITH_ZSTD=ON \
           -DARROW_WITH_SNAPPY=OFF \
+          -DARROW_S3=OFF \
           -DARROW_WITH_BZ2=ON \
           -DARROW_WITH_ZLIB=ON \
           -DARROW_BUILD_TESTS=OFF \


### PR DESCRIPTION
## What does this PR do?

Disables Arrow S3 support when building PyArrow for s390x.

## Why?

PyArrow 25.0.0 requires Arrow to be built with S3 support disabled on s390x.

## Validation

Built the Jupyter Data Science Python 3.12 image successfully for linux/s390x.

Validated:

- PyArrow 25.0.0 imports successfully
- `pyarrow.show_info()` reports `S3FileSystem: -`
- Parquet write/read succeeds successfully on s390x



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PyArrow builds across supported CPU architectures.
  * Disabled Arrow S3 support on s390x to ensure successful builds.
  * Retained S3 support on other architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->