### PR TITLE
[rhoai-3.4] Fix 10 Node.js CVEs in code-server vendored dependencies

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet/package-lock.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet/package-lock.json
@@ -13,7 +13,7 @@
         "@emmetio/html-matcher": "^0.3.3",
         "@emmetio/math-expression": "^1.0.5",
         "@vscode/emmet-helper": "^2.8.8",
-        "image-size": "~1.0.0",
+        "image-size": "~1.2.0",
         "vscode-languageserver-textdocument": "^1.0.1"
       },
       "devDependencies": {
@@ -122,9 +122,10 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
-      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -132,7 +133,7 @@
         "image-size": "bin/image-size.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.x"
       }
     },
     "node_modules/inherits": {

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet/package.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet/package.json
@@ -492,7 +492,7 @@
     "@emmetio/html-matcher": "^0.3.3",
     "@emmetio/math-expression": "^1.0.5",
     "@vscode/emmet-helper": "^2.8.8",
-    "image-size": "~1.0.0",
+    "image-size": "~1.2.0",
     "vscode-languageserver-textdocument": "^1.0.1"
   },
   "capabilities": {

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json
@@ -12871,9 +12871,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json
@@ -3170,16 +3170,6 @@
         "path-browserify": "^1.0.1"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -3863,16 +3853,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4451,16 +4431,6 @@
         "vscode-l10n-dev": "dist/cli.js"
       }
     },
-    "node_modules/@vscode/l10n-dev/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@vscode/l10n-dev/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4641,16 +4611,6 @@
       },
       "bin": {
         "vscode-test": "out/bin.mjs"
-      }
-    },
-    "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@vscode/test-cli/node_modules/glob": {
@@ -4846,16 +4806,6 @@
       },
       "engines": {
         "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/glob": {
@@ -5055,13 +5005,14 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "deprecated": "this version has critical issues, please update to the latest version",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@xterm/addon-clipboard": {
@@ -5461,16 +5412,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/archiver-utils/node_modules/buffer": {
@@ -6240,9 +6181,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6335,14 +6276,13 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -6796,9 +6736,9 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "node_modules/chrome-remote-interface/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.12",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.12.tgz",
+      "integrity": "sha512-1xGnbYN3zbog9CwuNDQULNRrTCLIn46/WmpR1f0w6PsCYQHkylZr5vkd6kfMZYV6pRnQkcPNRyiA8LsrNKyhpg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -7296,12 +7236,6 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -9478,16 +9412,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/express/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -9738,9 +9662,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -12946,6 +12870,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -14084,10 +14017,21 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -14950,16 +14894,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/mocha/node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -15388,16 +15322,6 @@
       "engines": {
         "node": ">=14",
         "npm": ">=8"
-      }
-    },
-    "node_modules/node-simctl/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/node-simctl/node_modules/glob": {
@@ -17283,16 +17207,6 @@
         "minimatch": "^5.1.0"
       }
     },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -18628,15 +18542,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/socks/node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/source-map": {

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json
@@ -246,7 +246,7 @@
       "uuid": "11.1.1"
     },
     "socks": "2.8.9",
-    "ip-address": "10.2.0",
+    "ip-address": "10.3.1",
     "@xmldom/xmldom": "0.9.8",
     "fast-uri": "3.1.2",
     "brace-expansion": "2.1.2",

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json
@@ -240,13 +240,18 @@
     "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
     "shell-quote": "1.10.0",
     "lodash-es": "4.18.1",
-    "ws@7": "7.5.11",
+    "ws@7": "7.5.12",
     "picomatch@4": "4.0.4",
     "@vscode/deviceid": {
       "uuid": "11.1.1"
     },
     "socks": "2.8.9",
-    "ip-address": "10.1.1"
+    "ip-address": "10.2.0",
+    "@xmldom/xmldom": "0.9.8",
+    "fast-uri": "3.1.2",
+    "brace-expansion": "2.1.2",
+    "basic-ftp": "5.2.1",
+    "linkify-it": "5.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fixes 10 Node.js CVEs in code-server's vendored VS Code dependencies by adding npm overrides to the patched package.json and regenerating package-lock.json.

### CVEs Fixed

| Package | CVEs | Version Change |
|---------|------|---------------|
| **@xmldom/xmldom** | CVE-2026-41672, 41673, 41675 | 0.8.11 → 0.9.8 |
| **fast-uri** | CVE-2026-6322, 13676 | 3.1.0 → 3.1.2 |
| **ip-address** | CVE-2026-42338, 69192 | 10.1.1 → 10.2.0 |
| **ws** | CVE-2026-45736, 48779 | 7.5.11 → 7.5.12 |
| **brace-expansion** | CVE-2026-13149, 69152 | 2.0.2 → 2.1.2 |
| **basic-ftp** | CVE-2026-44240 | 5.2.0 → 5.2.1 |
| **linkify-it** | CVE-2026-48801 | 5.0.0 → 5.0.1 |
| **image-size** | CVE-2025-71329, 71330 | 1.0.0 → 1.2.1 |

### Already Fixed (no change needed)

| Package | CVEs | Current Version | Fix Version |
|---------|------|----------------|-------------|
| undici | CVE-2026-12151, 6734, 9697 | 7.29.0 | >=7.28.0 |
| tar (node-tar) | CVE-2026-59873, 59874 | 7.5.22 | >=7.5.19 |

### Cannot Fix (no patch in current major line)

| Package | CVEs | Current | Issue |
|---------|------|---------|-------|
| js-yaml | CVE-2026-53550, 59869 | 3.14.2 | Fix in 4.2.0 only, no 3.x patch |
| postcss | CVE-2026-45623 | 7.0.39 | Fix in 8.x only, no 7.x patch |
| dompurify | CVE-2026-49978 | not found | Not in codeserver deps |
| mermaid | CVE-2026-71436 | not found | Not a dep, only build script ref |

### Files Changed

- `codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json` — added npm overrides
- `codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json` — regenerated
- `codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet/package.json` — bumped image-size
- `codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/extensions/emmet/package-lock.json` — regenerated

### Testing

- `pytest tests/test_main.py` — 11 passed, 902 subtests (matches baseline)

## Test plan

- [x] `pytest tests/test_main.py` passes
- [ ] Codeserver build: `/kfbuild odh-workbench-codeserver-datascience-cpu-py312-ubi9`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Updated bundled components and supporting packages to newer versions.
  * Applied dependency updates and overrides to improve compatibility, reliability, and security across the included development environment.
  * No user-facing features or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->