### PR TITLE
RHOAIENG-82298: chore(ci): add post-codefreeze-gatekeeper evaluation workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>red-hat-data-services/konflux-central//renovate/default-renovate.json5"
-  ]
-}

--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,0 +1,12 @@
+name: Post-Codefreeze Gatekeeper
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled]
+    branches:
+      - 'rhoai-3.5'
+jobs:
+  post-codefreeze-gate:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@gatekeeper
+    secrets: inherit

--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,12 +1,18 @@
+---
 name: Post-Codefreeze Gatekeeper
 
-on:
+"on":
   pull_request:
     types: [opened, synchronize, reopened, edited, labeled]
     branches:
       - 'rhoai-3.5'
+
 jobs:
   post-codefreeze-gate:
     if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
-    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@gatekeeper
-    secrets: inherit
+    permissions:
+      issues: write
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@3a2cae1f65fcb1b35600d4083a87241f3660417b  # 3a2cae1
+    secrets:
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds the thin caller workflow (`.github/workflows/post-codefreeze-gatekeeper.yaml`) that delegates to the central reusable workflow in `devops-shared-resources`
- The gatekeeper runs in **evaluation (advisory-only) mode** -- it posts a PR comment with pass/fail results but does **not** block merges
- Teams can use the `run-gatekeeper` label to manually re-trigger the check

Resolves: [RHOAIENG-82298](https://redhat.atlassian.net/browse/RHOAIENG-82298)

[RHOAIENG-82298]: https://redhat.atlassian.net/browse/RHOAIENG-82298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated post-code-freeze checks for pull requests targeting the rhoai-3.5 release.
  * Checks run for selected pull request events and can be enabled with the `run-gatekeeper` label.
  * Streamlined repository automation configuration to support more consistent release-validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->