### PR TITLE
RHAIENG-6002: fix: bind-mount utils directory instead of single file for dnf-helper.sh [rhoai-3.4]

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -129,7 +129,7 @@ USER 0
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -127,7 +127,7 @@ USER 0
 COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 COPY --from=mongocli-builder /tmp/mongocli /opt/app-root/bin/

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -26,7 +26,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -25,7 +25,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -26,7 +26,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -25,7 +25,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -23,7 +23,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -23,7 +23,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -56,7 +56,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]" "uv"
 
@@ -119,7 +119,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 # Copy dynamically-linked mongocli built in earlier build stage

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -56,7 +56,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # Install useful OS packages (versions follow UBI stream; pinning each would drift with point releases)
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]" "uv"
 
@@ -119,7 +119,7 @@ COPY prefetch-input/odh/rpms.lock.yaml /dev/null
 COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat protobuf
 
 # Copy dynamically-linked mongocli built in earlier build stage

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -43,13 +43,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -111,7 +111,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -43,13 +43,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -111,7 +111,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -41,13 +41,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -109,7 +109,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -41,13 +41,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -109,7 +109,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -41,13 +41,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -117,7 +117,7 @@ ENV UV_DEFAULT_INDEX=https://pypi.org/simple
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -41,13 +41,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -117,7 +117,7 @@ ENV UV_DEFAULT_INDEX=https://pypi.org/simple
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -43,13 +43,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -111,7 +111,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -43,13 +43,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -111,7 +111,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -42,13 +42,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -110,7 +110,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -42,13 +42,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo
 
 # Other apps and tools installed as default user
@@ -110,7 +110,7 @@ WORKDIR /opt/app-root/bin
 USER root
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install jq unixODBC postgresql git-lfs libsndfile libxcrypt-compat
 
 ### BEGIN Copy mongocli from builder

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -41,7 +41,7 @@ RUN set -Eeuxo pipefail && \
 
 # Install useful OS packages
 # remove skopeo, CVE-2025-4674
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL
 
 # Other apps and tools installed as default user

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -41,7 +41,7 @@ RUN set -Eeuxo pipefail && \
 
 # Install useful OS packages
 # remove skopeo, CVE-2025-4674
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL
 
 # Other apps and tools installed as default user

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -26,7 +26,7 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -26,7 +26,7 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -22,7 +22,7 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities

--- a/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -22,7 +22,7 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -24,13 +24,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -24,13 +24,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -24,13 +24,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -24,13 +24,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -22,13 +22,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -22,13 +22,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -22,13 +22,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -22,13 +22,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -26,13 +26,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -26,13 +26,13 @@ if command -v subscription-manager &> /dev/null; then
 fi
 EOF
 
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh upgrade
 
 ### END upgrade first to avoid fixable vulnerabilities
 
 # Install useful OS packages
-RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
     /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -213,7 +213,7 @@ def main():
         "Subscribe with subscription manager": textwrap.dedent(subscription_manager_register_refresh),
         "upgrade first to avoid fixable vulnerabilities": textwrap.dedent(ntb.process_template_with_indents(rt"""
             {subscription_manager_register_refresh}
-            RUN --mount=type=bind,source=base-images/utils/dnf-helper.sh,target=/utils/dnf-helper.sh,ro \
+            RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
                 /utils/dnf-helper.sh upgrade
 
         """)),


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C0BHCE9C9PU/p1786465402065999

## Summary

Backport [RHAIENG-6002](https://redhat.atlassian.net/browse/RHAIENG-6002) to `rhoai-3.4` via cherry-pick (`-x`) of opendatahub-io/notebooks@24567c5.

Fixes Konflux `build-images` failures on multiple notebook components (trustyai, tensorflow, pytorch, rocm variants) caused by buildah bind-mount TOCTOU subdirectory sanitization ([buildah#6631](https://github.com/containers/buildah/issues/6631)) rejecting file-level bind sources.

Change all `RUN --mount=type=bind` directives from `base-images/utils/dnf-helper.sh` (file) to `base-images/utils` (directory) across 17 `Dockerfile.konflux.*` files and `scripts/dockerfile_fragments.py`.

This is **not** caused by go-toolset PR #2720 — that merge only triggered rebuilds that exposed the latent issue already fixed on `rhoai-3.5` and ODH `main`.

## Test plan

- [ ] Comment `/ok-to-test` and confirm Konflux builds pass the `dnf-helper.sh upgrade` step for affected workbenches
- [x] Verified no remaining file-level bind mounts in `Dockerfile.konflux.*` (except rstudio, not in `.tekton/` for 3.4)


Made with [Cursor](https://cursor.com)

[RHAIENG-6002]: https://redhat.atlassian.net/browse/RHAIENG-6002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Updated container build processes across runtime, Jupyter, and machine-learning images to use the complete utility directory during operating-system package upgrades and installations.
- Preserved existing package-management commands, installed packages, and behavior across CPU, CUDA, and ROCm variants.
- Applied the change consistently to supported Python 3.12 image configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->