### PR TITLE
NO-JIRA: fix(ci): build Playwright browser-tests image on rhoai-3.4

### DIFF
--- a/.github/workflows/build-notebooks-TEMPLATE.yaml
+++ b/.github/workflows/build-notebooks-TEMPLATE.yaml
@@ -633,14 +633,35 @@ jobs:
       # https://playwright.dev/docs/ci
       # https://playwright.dev/docs/docker
       # opendatahub-io/notebooks#3965: podman storage is configured to have sufficient disk space
-      - name: Run Playwright tests
+      # Build the same image as .github/workflows/build-browser-tests.yaml so codeserver
+      # Playwright runs use baked-in deps (pnpm + Playwright) from tests/browser/Dockerfile.
+      # Backport of opendatahub-io/notebooks#4096: playwright-test requires playwright-image;
+      # without this step PLAYWRIGHT_IMAGE is empty and `podman inspect ''` fails with
+      # "json: cannot unmarshal array into Go value of type define.InspectContainerData".
+      - name: Build browser tests image
+        id: browser-tests-image
         if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' }}
+        run: |
+          set -Eeuxo pipefail
+          IMAGE="localhost/workbench-images-tests:ci"
+          PLAYWRIGHT_VERSION=$(python3 scripts/get_playwright_version.py tests/browser/package.json5)
+          podman build \
+            --build-arg "PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION}" \
+            -t "${IMAGE}" \
+            -f tests/browser/Dockerfile \
+            tests/browser
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Playwright tests
+        if: ${{ !cancelled() && contains(inputs.target, 'codeserver') && steps.make-target.outcome == 'success' && steps.browser-tests-image.outcome == 'success' }}
         uses: ./.github/actions/playwright-test
         with:
           test-target: ${{ steps.calculated_vars.outputs.OUTPUT_IMAGE }}
+          playwright-image: ${{ steps.browser-tests-image.outputs.image }}
           podman-socket: /var/run/podman/podman.sock
           upload-report: ${{ fromJson(inputs.github).event_name == 'pull_request' }}
           artifact-name: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-report"
+          junit-artifact-file: "${{ inputs.target }}_${{ steps.calculated_vars.outputs.BUILD_TYPE }}_${{ steps.calculated_vars.outputs.SANITIZED_PLATFORM }}_playwright-junit.xml"
           grep-pattern: '@codeserver'
 
       # endregion


### PR DESCRIPTION
## Summary

- Backport the missing `Build browser tests image` step from [opendatahub-io/notebooks#4096](https://github.com/opendatahub-io/notebooks/pull/4096) / `rhoai-3.5` into `rhoai-3.4`'s `build-notebooks-TEMPLATE.yaml`.
- Pass `playwright-image` (and `junit-artifact-file`) into the composite action that already requires it after [PR #2545](https://github.com/red-hat-data-services/notebooks/pull/2545).
- Fixes the codeserver CI failure seen on [PR #2699](https://github.com/red-hat-data-services/notebooks/pull/2699): empty `PLAYWRIGHT_IMAGE` → `podman inspect ''` → `json: cannot unmarshal array into Go value of type define.InspectContainerData`.

## Test plan

* https://github.com/red-hat-data-services/notebooks/actions/runs/31592576281

- [ ] Codeserver GHA jobs build `localhost/workbench-images-tests:ci` before Playwright
- [ ] Playwright verify step no longer hits Podman unmarshalling error
- [ ] Non-codeserver targets unchanged (browser-tests-image step is gated on `codeserver`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved browser test execution reliability by validating the required test environment before running tests.
  - Added automated JUnit test results alongside existing reports, making test outcomes easier to review and troubleshoot.
  - Standardized browser testing across codeserver builds using the detected Playwright version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->