### PR TITLE
fix: use pull_request_target in gatekeeper workflow

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,7 +1,7 @@
 name: Post-Codefreeze Gatekeeper
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled]
     branches:
       - 'rhoai-3.5'


### PR DESCRIPTION
Updates the gatekeeper workflow to use `pull_request_target` instead of `pull_request` and points to `@main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code-freeze gatekeeper workflow trigger while preserving its existing event and branch filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Jira: [RHOAIENG-82825](https://redhat.atlassian.net/browse/RHOAIENG-82825)

[RHOAIENG-82825]: https://redhat.atlassian.net/browse/RHOAIENG-82825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ