### PR TITLE
feat: add gatekeeper workflow to main (pull_request_target)

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,0 +1,12 @@
+name: Post-Codefreeze Gatekeeper
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled]
+    branches:
+      - 'rhoai-3.5'
+jobs:
+  post-codefreeze-gate:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the gatekeeper workflow to `main` using `pull_request_target` so it runs for PRs targeting `rhoai-3.5`.

Jira: [RHOAIENG-82825](https://redhat.atlassian.net/browse/RHOAIENG-82825)

[RHOAIENG-82825]: https://redhat.atlassian.net/browse/RHOAIENG-82825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ