### PR TITLE
[rhoai-3.4] Update konflux BASE_IMAGE quay.io-aipcc-base-images-cuda-13.0-el9.6 to v3.4.2-1786385291

### DIFF
--- a/codeserver/ubi9-python-3.12/Dockerfile.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.cpu
@@ -158,7 +158,7 @@ RUN dnf install -y nodejs npm && dnf clean all
 # compat-openssl11 provides libcrypto.so.1.1 for openshift-clients on EL9 (check-payload FIPS scan).
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y tar perl mesa-libGL skopeo compat-openssl11 openshift-clients
+dnf install -y tar perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 dnf clean all
 rm -rf /var/cache/dnf
 EOF

--- a/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/codeserver/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -158,7 +158,7 @@ RUN dnf install -y nodejs npm && dnf clean all
 # compat-openssl11 provides libcrypto.so.1.1 for openshift-clients on EL9 (check-payload FIPS scan).
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-dnf install -y tar perl mesa-libGL skopeo compat-openssl11 openshift-clients
+dnf install -y tar perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 dnf clean all
 rm -rf /var/cache/dnf
 EOF

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -55,7 +55,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # hadolint ignore=DL3041
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-BASE_PKGS=(perl mesa-libGL skopeo compat-openssl11 openshift-clients)
+BASE_PKGS=(perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients)
 dnf install -y "${BASE_PKGS[@]}"
 dnf clean all
 rm -rf /var/cache/yum

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -55,7 +55,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # hadolint ignore=DL3041
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail
-BASE_PKGS=(perl mesa-libGL skopeo compat-openssl11 openshift-clients)
+BASE_PKGS=(perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients)
 dnf install -y "${BASE_PKGS[@]}"
 dnf clean all
 rm -rf /var/cache/yum

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -27,7 +27,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.6"

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
@@ -26,7 +26,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.3"

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -27,7 +27,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.6"

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -26,7 +26,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.3"

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -24,7 +24,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.3"

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
@@ -24,7 +24,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 
 # Install micropipenv/uv from Cachi2 as root.
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]==1.10.0" "uv==0.11.3"

--- a/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/minimal/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.1-1780602628
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.2-1786385291
 PYLOCK_FLAVOR=cuda

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -57,7 +57,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]" "uv"
 
 # Other apps and tools installed as default user

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -57,7 +57,7 @@ COPY prefetch-input/rhds/rpms.lock.yaml /dev/null
 # compat-openssl11 provides libcrypto.so.1.1 required by FIPS-compliance scanning.
 # hadolint ignore=DL3041
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo compat-openssl11 openshift-clients
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo compat-openssl11 openshift-clients
 RUN pip install --no-cache-dir --no-index --find-links /cachi2/output/deps/pip "micropipenv[toml]" "uv"
 
 # Other apps and tools installed as default user

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.1-1780602628
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.2-1786385291
 PYLOCK_FLAVOR=cuda

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -50,7 +50,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -50,7 +50,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -48,7 +48,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -48,7 +48,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -48,7 +48,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -48,7 +48,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -50,7 +50,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -50,7 +50,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -49,7 +49,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -49,7 +49,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo
 
 # Other apps and tools installed as default user
 USER 1001

--- a/rstudio/rhel9-python-3.12/Dockerfile.cpu
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cpu
@@ -42,7 +42,7 @@ RUN set -Eeuxo pipefail && \
 # Install useful OS packages
 # remove skopeo, CVE-2025-4674
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL
 
 # Other apps and tools installed as default user
 USER 1001

--- a/rstudio/rhel9-python-3.12/Dockerfile.cuda
+++ b/rstudio/rhel9-python-3.12/Dockerfile.cuda
@@ -42,7 +42,7 @@ RUN set -Eeuxo pipefail && \
 # Install useful OS packages
 # remove skopeo, CVE-2025-4674
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -31,7 +31,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -31,7 +31,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/konflux.cuda.conf
@@ -1,3 +1,3 @@
 INDEX_URL=https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cuda13.0-ubi9/simple/
-BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.1-1780602628
+BASE_IMAGE=quay.io/aipcc/base-images/cuda-13.0-el9.6:3.4.2-1786385291
 PYLOCK_FLAVOR=cuda

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -31,7 +31,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -31,7 +31,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -29,7 +29,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -29,7 +29,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -29,7 +29,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -29,7 +29,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -33,7 +33,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001

--- a/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/runtimes/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -33,7 +33,7 @@ RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
 
 # Install useful OS packages
 RUN --mount=type=bind,source=base-images/utils,target=/utils,ro \
-    /utils/dnf-helper.sh install perl mesa-libGL skopeo libxcrypt-compat
+    /utils/dnf-helper.sh install perl-interpreter mesa-libGL skopeo libxcrypt-compat
 
 # Other apps and tools installed as default user
 USER 1001


### PR DESCRIPTION
## Summary

Manual bump of `quay.io/aipcc/base-images/cuda-13.0-el9.6` from `3.4.1-1780602628` to `3.4.2-1786385291` on `rhoai-3.4`.

Renovate/MintMaker isn't reliably picking up AIPCC base-image patch bumps on `rhoai-3.x` release branches right now — see opendatahub-io/notebooks#4373 (remote-mode manager extraction gap) and opendatahub-io/notebooks#4374 (blocked minor-version candidate masks the available patch bump). Doing this one manually in the meantime.

This patch-level bump (`3.4.1` -> `3.4.2`, same minor/major line) picks up AIPCC's ffmpeg/libaom package updates (fixes CVE-2026-56208/56209/56210/56211), per internal report that notebook workbench images built from the old base still carry the vulnerable `ffmpeg-free-rhai-6.1.5-2` / `libaom-3.12.0-2.1` versions.

Verified `3.4.2-1786385291` digest matches the current mutable `3.4` tag (published 2026-08-10) via `skopeo inspect`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CUDA-enabled Python 3.12 environments to use the latest UBI9 base image version.
  - Applied the update across minimal, PyTorch, and LLM compressor runtime configurations.
  - Standardized system package installation across CPU, CUDA, and ROCm environments by using the `perl-interpreter` package.
  - Retained existing graphics, container, and runtime packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->