### PR TITLE
RHOAIENG-81140: trial non-hermetic jupyter-baseline Konflux (Tekton)

### DIFF
--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-pull-request.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-jupyter-baseline)"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-workbench-jupyter-baseline-cpu-py312
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-workbench-jupyter-baseline-cpu-py312-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-workbench-jupyter-baseline-cpu-py312-{{revision}}
+  - name: dockerfile
+    value: jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: path-context
+    value: .
+  # Phase 1 trial: non-hermetic (no prefetch). Correct jupyter-baseline conf.
+  - name: hermetic
+    value: "false"
+  - name: build-args-file
+    value: jupyter/baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1-push.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1-push.yaml
@@ -36,10 +36,12 @@ spec:
     value: jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
+  # Phase 1 trial: non-hermetic online RPM + PyPI (no prefetch yet). Promote to
+  # konflux-central if this unblocks RHOAIENG-81140 Konflux builds.
   - name: hermetic
-    value: true
+    value: "false"
   - name: build-args-file
-    value: codeserver-baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+    value: jupyter/baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: build-platforms
     value:
     - linux/x86_64


### PR DESCRIPTION
## Summary
- Trial for [RHOAIENG-81140](https://redhat.atlassian.net/browse/RHOAIENG-81140) Konflux failure on `rhoai-3.6-ea.1`.
- Set `hermetic: false` (phase-1 Dockerfile has no prefetch; matches ODH main).
- Point `build-args-file` at `jupyter/baseline/.../konflux.cpu.conf` (was incorrectly `codeserver-baseline`).
- Edited notebooks `.tekton` directly; **promote to konflux-central** if this unblocks the push PipelineRun.

## Merge order
Prefer merging **this PR first** for a hermetic-only signal. Sibling draft (Tekton + RHSM Dockerfile) includes these same Tekton changes — **do not merge both**.

Note: this component has **no on-PR PipelineRun**; Konflux only runs after merge to `rhoai-3.6-ea.1`.

## Test plan
- [ ] Merge to `rhoai-3.6-ea.1` when ready to trial
- [ ] Watch `odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1` push PipelineRun
- [ ] If past RHSM / further green: promote Tekton to konflux-central; close sibling RHSM PR
- [ ] If still fails on `subscription-manager release --set`: close this and merge the sibling RHSM PR instead


Made with [Cursor](https://cursor.com)

[RHOAIENG-81140]: https://redhat.atlassian.net/browse/RHOAIENG-81140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull-request build coverage for the CPU-based Python 3.12 Jupyter baseline image.
  * Updated image build workflows to support non-hermetic builds and multi-architecture targets.
  * Corrected build configuration to use the appropriate Jupyter settings.
  * Added initial trial-phase annotations to the relevant build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->