### PR TITLE
RHOAIENG-81140: non-hermetic Tekton + RHSM identity gate (cumulative)

### DIFF
--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-pull-request.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-jupyter-baseline)"
+    pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+  labels:
+    appstudio.openshift.io/application: automation
+    appstudio.openshift.io/component: pull-request-pipelines-odh-workbench-jupyter-baseline-cpu-py312
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-workbench-jupyter-baseline-cpu-py312-on-pull-request-{{pull_request_number}}
+  namespace: rhoai-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/rhoai/pull-request-pipelines:odh-workbench-jupyter-baseline-cpu-py312-{{revision}}
+  - name: dockerfile
+    value: jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+  - name: path-context
+    value: .
+  # Phase 1 trial: non-hermetic (no prefetch). Correct jupyter-baseline conf.
+  - name: hermetic
+    value: "false"
+  - name: build-args-file
+    value: jupyter/baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+  - name: rhel-subscription-activation-key
+    value: rhel-subscription-activation-key-rhoai-devops-for-notebooks-rhel9-6
+  - name: image-expires-after
+    value: 5d
+  - name: enable-slack-failure-notification
+    value: "false"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+  pipelineRef:
+    params:
+    - name: url
+      value: https://github.com/red-hat-data-services/konflux-central.git
+    - name: revision
+      value: '{{ target_branch }}'
+    - name: pathInRepo
+      value: pipelines/multi-arch-container-build.yaml
+    resolver: git
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pull-request-pipelines
+    podTemplate:
+      imagePullSecrets:
+      - name: redhat-appstudio-staginguser-pull-secret
+  timeouts:
+    pipeline: 8h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1-push.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1-push.yaml
@@ -36,10 +36,12 @@ spec:
     value: jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: .
+  # Phase 1 trial: non-hermetic online RPM + PyPI (no prefetch yet). Promote to
+  # konflux-central if this unblocks RHOAIENG-81140 Konflux builds.
   - name: hermetic
-    value: true
+    value: "false"
   - name: build-args-file
-    value: codeserver-baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
+    value: jupyter/baseline/ubi9-python-3.12/build-args/konflux.cpu.conf
   - name: build-platforms
     value:
     - linux/x86_64

--- a/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -37,7 +37,16 @@ ARG RHEL_VERSION=9.6
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 
-RUN subscription-manager release --set="${RHEL_VERSION}"
+# Phase-1 non-hermetic: refresh + pin RHSM release when entitlement identity is
+# present (Konflux/local subscribed builds). Skip when unregistered so hermetic
+# or unentitled builds do not die on release --set.
+RUN set -Eeuxo pipefail && \
+    if subscription-manager identity &>/dev/null; then \
+        subscription-manager refresh && \
+        subscription-manager release --set="${RHEL_VERSION}"; \
+    else \
+        echo "No RHSM identity; skipping refresh/release pin"; \
+    fi
 
 # Runtime installs need the OpenShift layered-product repo for openshift-clients.
 RUN basearch="$(rpm --eval '%{_arch}')" && \


### PR DESCRIPTION
## Summary
- **Includes all of** https://github.com/red-hat-data-services/notebooks/pull/2754 (Tekton: `hermetic: false` + correct `jupyter/baseline` `build-args-file`).
- Plus identity-gated `subscription-manager refresh` + `release --set` in `jupyter/baseline/.../Dockerfile.konflux.cpu` so unregistered builds skip RHSM instead of dying at cpu-base.
- Trial for [RHOAIENG-81140](https://redhat.atlassian.net/browse/RHOAIENG-81140); Slack context: subscription-manager not registered on Konflux.

## Merge order
Prefer merging **#2754 first**. Merge **this PR only if** #2754 still fails on RHSM — then close #2754 (do not merge both; Tekton diff is duplicated here).

Note: no on-PR PipelineRun for this component; Konflux fires on push to `rhoai-3.6-ea.1` after merge.

## Test plan
- [ ] Hold until #2754 result is known (or merge this if choosing the cumulative trial immediately)
- [ ] Watch `odh-workbench-jupyter-baseline-cpu-py312-v3-6-ea-1` push PipelineRun past former RHSM step
- [ ] If green Tekton change sticks: promote `.tekton` edit to konflux-central
- [ ] Cherry-pick Dockerfile change to main / ODH if needed for midstream sync


Made with [Cursor](https://cursor.com)

[RHOAIENG-81140]: https://redhat.atlassian.net/browse/RHOAIENG-81140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pull-request build automation for the CPU Python 3.12 Jupyter baseline image.
  - Added multi-architecture build support and configured required build credentials and settings.

- **Bug Fixes**
  - Improved builds for environments without Red Hat subscription registration.
  - Updated build configuration to use the correct Jupyter baseline path.
  - Switched the relevant build to non-hermetic mode for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->