### PR TITLE
[rhoai-3.4] fix(ci): allow requests range for Elyra across pulp flavors

### DIFF
--- a/ci/requirements-elyra.txt
+++ b/ci/requirements-elyra.txt
@@ -1,8 +1,9 @@
 # Downloaded from https://raw.githubusercontent.com/opendatahub-io/elyra/main/etc/generic/requirements-elyra.txt
 # Local change: ipykernel==7.2.0 (7.1.0 is not installable from PyPI for current pip index).
 # Local change: ipython==9.12.0 (aligned with runtime image requirements.*.txt pins).
-# Local change: requests==2.34.2 (2.33.1 is not on RHOAI 3.4 pulp indices used by
-# runtime pip.conf; available there: 2.31.0, 2.32.5, 2.33.0, 2.34.2).
+# Local change: requests==2.33.0 — RHOAI 3.4 runtime pip.conf indices disagree on
+# which newer requests builds exist (one offers 2.33.1 not 2.34.2; another offers
+# 2.34.2 not 2.33.1). Intersection includes 2.31.0, 2.32.5, 2.33.0.
 
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
 ipykernel==7.2.0
@@ -19,7 +20,7 @@ nbformat==5.10.4
 papermill==2.7.0
 pyzmq==27.1.0
 prompt-toolkit==3.0.52
-requests==2.34.2
+requests==2.33.0
 tornado==6.5.5
 traitlets==5.14.3
 urllib3==2.6.3

--- a/ci/requirements-elyra.txt
+++ b/ci/requirements-elyra.txt
@@ -1,7 +1,8 @@
 # Downloaded from https://raw.githubusercontent.com/opendatahub-io/elyra/main/etc/generic/requirements-elyra.txt
 # Local change: ipykernel==7.2.0 (7.1.0 is not installable from PyPI for current pip index).
 # Local change: ipython==9.12.0 (aligned with runtime image requirements.*.txt pins).
-# Local change: requests==2.33.1 (2.32.5 is not on RHOAI pulp indices used by runtime pip.conf).
+# Local change: requests==2.34.2 (2.33.1 is not on RHOAI 3.4 pulp indices used by
+# runtime pip.conf; available there: 2.31.0, 2.32.5, 2.33.0, 2.34.2).
 
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
 ipykernel==7.2.0
@@ -18,7 +19,7 @@ nbformat==5.10.4
 papermill==2.7.0
 pyzmq==27.1.0
 prompt-toolkit==3.0.52
-requests==2.33.1
+requests==2.34.2
 tornado==6.5.5
 traitlets==5.14.3
 urllib3==2.6.3

--- a/ci/requirements-elyra.txt
+++ b/ci/requirements-elyra.txt
@@ -1,9 +1,10 @@
 # Downloaded from https://raw.githubusercontent.com/opendatahub-io/elyra/main/etc/generic/requirements-elyra.txt
 # Local change: ipykernel==7.2.0 (7.1.0 is not installable from PyPI for current pip index).
 # Local change: ipython==9.12.0 (aligned with runtime image requirements.*.txt pins).
-# Local change: requests==2.33.0 — RHOAI 3.4 runtime pip.conf indices disagree on
-# which newer requests builds exist (one offers 2.33.1 not 2.34.2; another offers
-# 2.34.2 not 2.33.1). Intersection includes 2.31.0, 2.32.5, 2.33.0.
+# Local change: requests>=2.32.5,<2.35 — RHOAI pulp flavor indexes disagree on
+# which builds exist (3.4 cuda/rocm: 2.33.0/2.33.1, no 2.34.2; 3.4 cpu: both;
+# 3.5-EA2-test: 2.34.2, no 2.33.x). Exact pins fail across ODH vs AIPCC bases;
+# a range lets pip pick the newest available on each index.
 
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
 ipykernel==7.2.0
@@ -20,7 +21,7 @@ nbformat==5.10.4
 papermill==2.7.0
 pyzmq==27.1.0
 prompt-toolkit==3.0.52
-requests==2.33.0
+requests>=2.32.5,<2.35
 tornado==6.5.5
 traitlets==5.14.3
 urllib3==2.6.3


### PR DESCRIPTION
## Summary
- `validate-runtime-image` installs `ci/requirements-elyra.txt` using the **base image** `PIP_INDEX_URL` (not build-arg `INDEX_URL`).
- RHOAI pulp catalogs disagree on `requests`:
  - `rhoai/3.4/cuda*` / `rocm*`: `2.31.0`, `2.32.5`, `2.33.0`, `2.33.1` (no `2.34.2`)
  - `rhoai/3.4/cpu`: those plus `2.34.2`
  - `rhoai/3.5-EA2/*-test` (ODH-base style): `2.31.0`, `2.32.5`, `2.34.2` (no `2.33.x`)
- Replace exact pins with `requests>=2.32.5,<2.35` so pip picks the newest available on each index.

## Test plan

* https://github.com/red-hat-data-services/notebooks/actions/runs/31777061204

- [ ] Konflux/AIPCC path: `runtime-cuda-pytorch-llmcompressor` `validate-runtime-image` installs Elyra deps
- [ ] ODH `Dockerfile.cuda` path (if still exercised): same check passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation guidance for environments using conflicting package indexes.
  * Broadened the supported `requests` version range while maintaining compatibility constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->