### PR TITLE
[rhoai-3.3] fix(ppc64le): bump datascience ONNX_VERSION to 1.21.0

### DIFF
--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -85,7 +85,7 @@ if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFIL
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.1
+export ONNX_VERSION=1.21.0
 export PYARROW_VERSION=21.0.0
 export PATH="$HOME/.cargo/bin:$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
@@ -274,7 +274,7 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.1
+ENV ONNX_VERSION=1.21.0
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -85,7 +85,7 @@ if [ "$TARGETARCH" = "ppc64le" ]; then cat > /etc/profile.d/ppc64le.sh <<'PROFIL
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
 export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 export OPENBLAS_VERSION=0.3.30
-export ONNX_VERSION=1.20.1
+export ONNX_VERSION=1.21.0
 export PYARROW_VERSION=21.0.0
 export PATH="$HOME/.cargo/bin:$PATH"
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
@@ -274,7 +274,7 @@ USER root
 WORKDIR /root
 
 ARG TARGETARCH
-ENV ONNX_VERSION=1.20.1
+ENV ONNX_VERSION=1.21.0
 
 RUN echo "onnx-builder stage TARGETARCH: ${TARGETARCH}"
 


### PR DESCRIPTION
## Summary
- Align ppc64le from-source `ONNX_VERSION` in datascience runtime Dockerfiles (`Dockerfile.cpu` / `Dockerfile.konflux.cpu`) from `1.20.1` → `1.21.0`.
- Wheel arches already ship `onnx>=1.21` via [#2222](https://github.com/red-hat-data-services/notebooks/pull/2222) / `dependencies/cve-constraints.txt`; Power still built vulnerable `1.20.1` from git.

Supersedes the remaining useful delta from [#2286](https://github.com/red-hat-data-services/notebooks/pull/2286) ([RHAIENG-3840](https://redhat.atlassian.net/browse/RHAIENG-3840) / CVE-2026-28500). Does **not** bump `onnxconverter-common` (still pinned `~=1.13.0` for protobuf compatibility; not required for this CVE).

## Test plan
- [ ] Confirm `rg ONNX_VERSION= runtimes/datascience/ubi9-python-3.12/Dockerfile*` shows only `1.21.0`
- [ ] ppc64le datascience runtime Konflux/GHA build picks up onnx 1.21.0 from the builder stage


Made with [Cursor](https://cursor.com)

[RHAIENG-3840]: https://redhat.atlassian.net/browse/RHAIENG-3840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the ONNX runtime to version 1.21.0 in the Python 3.12 data science environments.
  * Applies to both standard CPU and Konflux CPU builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->