### PR TITLE
[rhoai-3.5] fix(ci): post-codefreeze gatekeeper yamllint and pinact compliance

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,6 +1,6 @@
+---
 name: Post-Codefreeze Gatekeeper
-
-on:
+"on":
   pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled]
     branches:
@@ -8,5 +8,5 @@ on:
 jobs:
   post-codefreeze-gate:
     if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
-    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@3a2cae1f65fcb1b35600d4083a87241f3660417b  # main
     secrets: inherit

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -6,3 +6,8 @@ version: 3
 # Two spaces before # to satisfy yamllint's "comments" rule
 # (too few spaces before comment: expected 2)
 separator: "  # "
+
+# Devops-managed reusable workflow has no semver tags; pin by commit SHA instead.
+ignore_actions:
+  - name: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml
+    ref: ".*"


### PR DESCRIPTION
## Summary

Fixes branch-level CI failures on `rhoai-3.5` caused by the devops post-codefreeze gatekeeper workflow (not introduced by MintMaker PRs like #2764):

- Add YAML document header and quote `"on"` so `yamllint` passes in `code-static-analysis`
- Pin the devops reusable workflow to commit `3a2cae1f65fcb1b35600d4083a87241f3660417b` instead of mutable `@main`
- Exclude the untagged devops reusable workflow from `pinact` checks via `.pinact.yaml`

## Test plan

- [x] `yamllint --strict` passes on `post-codefreeze-gatekeeper.yaml`
- [x] `pinact run --check` passes locally
- [ ] `code-static-analysis` and `GitHub Actions SHA pinning` jobs pass on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull-request checks to use a fixed, verified workflow version.
  * Improved build and validation consistency by preventing unexpected workflow changes.
  * Updated workflow configuration to support ongoing maintenance of the shared automation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->