### PR TITLE
Fix 15 Node.js CVEs in code-server vendored dependencies [rhoai-2.25]

### DIFF
--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package-lock.json
@@ -149,7 +149,7 @@
         "sinon-test": "^3.1.3",
         "source-map": "0.6.1",
         "source-map-support": "^0.3.2",
-        "tar": "^7.5.9",
+        "tar": "^7.5.22",
         "tsec": "0.2.7",
         "tslib": "^2.6.3",
         "typescript": "^6.0.0-dev.20260306",
@@ -1649,16 +1649,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/@hediet/semver/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@hediet/semver/node_modules/eslint": {
       "version": "7.32.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
@@ -1853,20 +1843,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@hediet/semver/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@hediet/semver/node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1893,13 +1869,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/@hediet/semver/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@hediet/semver/node_modules/type-fest": {
       "version": "0.20.2",
@@ -3170,16 +3139,6 @@
         "path-browserify": "^1.0.1"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -3863,16 +3822,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4451,16 +4400,6 @@
         "vscode-l10n-dev": "dist/cli.js"
       }
     },
-    "node_modules/@vscode/l10n-dev/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@vscode/l10n-dev/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4641,16 +4580,6 @@
       },
       "bin": {
         "vscode-test": "out/bin.mjs"
-      }
-    },
-    "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@vscode/test-cli/node_modules/glob": {
@@ -4846,16 +4775,6 @@
       },
       "engines": {
         "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/glob": {
@@ -5461,16 +5380,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/archiver-utils/node_modules/buffer": {
@@ -6240,9 +6149,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6335,14 +6244,13 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -6796,9 +6704,10 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "node_modules/chrome-remote-interface/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -7295,12 +7204,6 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -9475,16 +9378,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/express/node_modules/accepts": {
@@ -12946,13 +12839,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -13600,10 +13490,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13611,11 +13511,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -14966,16 +14861,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/mocha/node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -15289,21 +15174,6 @@
         "path-to-regexp": "^1.7.0"
       }
     },
-    "node_modules/nise/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8= sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
-    "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/node-abi": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.8.0.tgz",
@@ -15404,16 +15274,6 @@
       "engines": {
         "node": ">=14",
         "npm": ">=8"
-      }
-    },
-    "node_modules/node-simctl/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/node-simctl/node_modules/glob": {
@@ -16547,9 +16407,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -17311,16 +17171,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
@@ -18802,7 +18652,9 @@
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/stable": {
       "version": "0.1.8",
@@ -19442,9 +19294,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -20209,9 +20061,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
-      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -20776,16 +20628,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/webdriver/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/webdriverio": {
       "version": "9.24.0",
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.24.0.tgz",
@@ -21087,9 +20929,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/package.json
@@ -219,7 +219,7 @@
     "sinon-test": "^3.1.3",
     "source-map": "0.6.1",
     "source-map-support": "^0.3.2",
-    "tar": "^7.5.9",
+    "tar": "^7.5.22",
     "tsec": "0.2.7",
     "tslib": "^2.6.3",
     "typescript": "^6.0.0-dev.20260306",
@@ -237,7 +237,16 @@
     "@vscode/l10n-dev@0.0.35": {
       "web-tree-sitter": "0.23.0"
     },
-    "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
+    "es5-ext": "npm:@unes/es5-ext@0.10.64-1",
+    "undici": "$undici",
+    "tar": "$tar",
+    "ws@7": "7.5.11",
+    "ws@8": "8.21.0",
+    "ip-address": "10.3.1",
+    "brace-expansion": "2.1.4",
+    "basic-ftp": "5.3.1",
+    "js-yaml": "4.3.0",
+    "path-to-regexp": "8.4.0"
   },
   "repository": {
     "type": "git",

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote/package-lock.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote/package-lock.json
@@ -1422,9 +1422,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote/package.json
+++ b/codeserver/ubi9-python-3.12/prefetch-input/patches/code-server-v4.112.0/lib/vscode/remote/package.json
@@ -46,6 +46,7 @@
     "node-gyp-build": "4.8.1",
     "kerberos@2.1.1": {
       "node-addon-api": "7.1.0"
-    }
+    },
+    "undici": "7.29.0"
   }
 }


### PR DESCRIPTION
## Summary

Fixes 15 Node.js CVEs in code-server's vendored VS Code dependencies by adding npm overrides and bumping the `tar` direct dependency. Regenerates `package-lock.json` to resolve all vulnerable nested copies.

## Jira Trackers

| Jira | CVE | Package | Status |
|------|-----|---------|--------|
| [RHOAIENG-69822](https://redhat.atlassian.net/browse/RHOAIENG-69822) | CVE-2026-12151 | undici (WebSocket DoS) | **Fixed** — 7.24.0 → 7.29.0 |
| [RHOAIENG-69793](https://redhat.atlassian.net/browse/RHOAIENG-69793) | CVE-2026-6734 | undici (SOCKS5 info disclosure) | **Fixed** — 7.24.0 → 7.29.0 |
| [RHOAIENG-69808](https://redhat.atlassian.net/browse/RHOAIENG-69808) | CVE-2026-9697 | undici (SOCKS5 MITM) | **Fixed** — 7.24.0 → 7.29.0 |
| [RHOAIENG-70811](https://redhat.atlassian.net/browse/RHOAIENG-70811) | CVE-2026-45736 | ws (memory disclosure) | **Fixed** — 7.5.10→7.5.11, 8.19.0→8.21.0 |
| [RHOAIENG-69457](https://redhat.atlassian.net/browse/RHOAIENG-69457) | CVE-2026-48779 | ws (WebSocket fragment DoS) | **Fixed** — 7.5.10→7.5.11, 8.19.0→8.21.0 |
| [RHOAIENG-72679](https://redhat.atlassian.net/browse/RHOAIENG-72679) | CVE-2026-13149 | brace-expansion (ReDoS) | **Fixed** — 2.0.2 → 2.1.4 |
| [RHOAIENG-80371](https://redhat.atlassian.net/browse/RHOAIENG-80371) | CVE-2026-69152 | brace-expansion (unbounded arrays) | **Fixed** — 2.0.2 → 2.1.4 |
| [RHOAIENG-67969](https://redhat.atlassian.net/browse/RHOAIENG-67969) | CVE-2026-42338 | ip-address (XSS) | **Fixed** — 9.0.5/10.1.0 → 10.3.1 |
| [RHOAIENG-80553](https://redhat.atlassian.net/browse/RHOAIENG-80553) | CVE-2026-69192 | ip-address (SSRF) | **Fixed** — 9.0.5/10.1.0 → 10.3.1 |
| [RHOAIENG-77629](https://redhat.atlassian.net/browse/RHOAIENG-77629) | CVE-2026-44240 | basic-ftp (FTP client DoS) | **Fixed** — 5.2.0 → 5.3.1 |
| [RHOAIENG-71581](https://redhat.atlassian.net/browse/RHOAIENG-71581) | CVE-2026-53550 | js-yaml (merge key DoS) | **Fixed** — 3.14.2/4.1.1 → 4.3.0 |
| [RHOAIENG-76540](https://redhat.atlassian.net/browse/RHOAIENG-76540) | CVE-2026-59869 | js-yaml (crafted YAML DoS) | **Fixed** — 3.14.2/4.1.1 → 4.3.0 |
| [RHOAIENG-76015](https://redhat.atlassian.net/browse/RHOAIENG-76015) | CVE-2026-59873 | tar (gzip bomb DoS) | **Fixed** — 7.5.11 → 7.5.22 |
| [RHOAIENG-76043](https://redhat.atlassian.net/browse/RHOAIENG-76043) | CVE-2026-59874 | tar (malformed tar DoS) | **Fixed** — 7.5.11 → 7.5.22 |
| [RHOAIENG-55752](https://redhat.atlassian.net/browse/RHOAIENG-55752) | CVE-2026-4926 | path-to-regexp (ReDoS) | **Fixed** — 1.9.0/8.3.0 → 8.4.0 |
| [RHOAIENG-66122](https://redhat.atlassian.net/browse/RHOAIENG-66122) | CVE-2026-42258 | Net::IMAP (Ruby, not Node.js) | **VEX** — Ruby lib, not in Node.js execution path |

## Affected image

- `codeserver/ubi9-python-3.12` (`odh-workbench-codeserver-datascience-cpu-py312-rhel9`)

## Fix approach

Per Pattern 7 from agent knowledge (code-server npm overrides):

1. Added npm `overrides` in `lib/vscode/package.json` to force fixed versions of transitive deps
2. Bumped `tar` in `devDependencies` (direct dep — npm `overrides` can't override direct deps, throws `EOVERRIDE`)
3. Used `$undici` and `$tar` self-reference overrides to collapse nested vulnerable copies to root version
4. Regenerated `package-lock.json` with `npm install --package-lock-only --ignore-scripts --legacy-peer-deps`

## Why this is safe

All overrides are minor/patch version bumps within compatible semver ranges. The `js-yaml` override from 3.x→4.x affects only `@hediet/semver` (dev dependency, not used at runtime). The `brace-expansion` override from 1.x→2.x drops `concat-map` dependency (breaking for 1.x consumers using the old API, but all VS Code internal consumers use the 2.x API).

## Test plan

- [ ] Konflux build succeeds for codeserver image
- [ ] code-server starts and connects to workspace
- [ ] File editing and terminal work in code-server

[RHOAIENG-69822]: https://redhat.atlassian.net/browse/RHOAIENG-69822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-69793]: https://redhat.atlassian.net/browse/RHOAIENG-69793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-69808]: https://redhat.atlassian.net/browse/RHOAIENG-69808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-70811]: https://redhat.atlassian.net/browse/RHOAIENG-70811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-69457]: https://redhat.atlassian.net/browse/RHOAIENG-69457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-72679]: https://redhat.atlassian.net/browse/RHOAIENG-72679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled package versions to newer releases.
  * Added compatibility overrides for several supporting packages to improve dependency consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->