### PR TITLE
[rhoai-3.3] fix: limit pyarrow pylock marker by architecture

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -419,17 +419,13 @@ echo "Installing software and packages"
 if [ "$TARGETARCH" = "ppc64le" ]; then
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
     echo "meson<1.11" > build_constraints.txt
-    # pyarrow is preinstalled from the pyarrow-builder wheel for ppc64le.
-    # Remove it from the lock install list to avoid rebuilding from sdist.
-    awk 'BEGIN{RS=""; ORS="\n\n"} $0 !~ /\nname = "pyarrow"\n/ {print}' pylock.toml > pylock.no-pyarrow.toml
     # aipcc does not have some dependencies to build cryptography==43.0.3 on ppc64le, so we need to use pypi.org/simple
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress \
         --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
         --extra-index-url https://pypi.org/simple \
         --build-constraint build_constraints.txt \
-        --requirements=./pylock.no-pyarrow.toml
-    python -c "import pyarrow; print(pyarrow.__version__)"
+        --requirements=./pylock.toml
 elif [ "$TARGETARCH" = "s390x" ]; then
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
     echo "meson<1.11" > build_constraints.txt

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -419,13 +419,17 @@ echo "Installing software and packages"
 if [ "$TARGETARCH" = "ppc64le" ]; then
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
     echo "meson<1.11" > build_constraints.txt
+    # pyarrow is preinstalled from the pyarrow-builder wheel for ppc64le.
+    # Remove it from the lock install list to avoid rebuilding from sdist.
+    awk 'BEGIN{RS=""; ORS="\n\n"} $0 !~ /\nname = "pyarrow"\n/ {print}' pylock.toml > pylock.no-pyarrow.toml
     # aipcc does not have some dependencies to build cryptography==43.0.3 on ppc64le, so we need to use pypi.org/simple
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
     uv pip install --strict --no-deps --no-cache --no-config --no-progress \
         --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
         --extra-index-url https://pypi.org/simple \
         --build-constraint build_constraints.txt \
-        --requirements=./pylock.toml
+        --requirements=./pylock.no-pyarrow.toml
+    python -c "import pyarrow; print(pyarrow.__version__)"
 elif [ "$TARGETARCH" = "s390x" ]; then
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
     echo "meson<1.11" > build_constraints.txt

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -3487,7 +3487,7 @@ wheels = [
 [[packages]]
 name = "pyarrow"
 version = "21.0.0"
-marker = "implementation_name == 'cpython' and sys_platform == 'linux'"
+marker = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
 sdist = { url = "https://files.pythonhosted.org/packages/ef/c2/ea068b8f00905c06329a3dfcd40d0fcc2b7d0f2e355bdb25b65e0a0e4cd4/pyarrow-21.0.0.tar.gz", upload-time = 2025-07-18T00:57:31Z, size = 1133487, hashes = { sha256 = "5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc" } }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/d9/110de31880016e2afc52d8580b397dbe47615defbf09ca8cf55f56c62165/pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl", upload-time = 2025-07-18T00:54:34Z, size = 31196837, hashes = { sha256 = "e563271e2c5ff4d4a4cbeb2c83d5cf0d4938b891518e676025f7268c6fe5fe26" } },

--- a/scripts/pylocks_generator.sh
+++ b/scripts/pylocks_generator.sh
@@ -175,6 +175,35 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
 
   DIR_SUCCESS=true
 
+  apply_lock_policy_overrides() {
+    local lock_file="$1"
+    if [[ "$TARGET_DIR" != "jupyter/datascience/ubi9-python-3.12" ]]; then
+      return 0
+    fi
+    if [[ ! -f "$lock_file" ]]; then
+      warn "Missing lock file for policy override: $lock_file"
+      return 1
+    fi
+
+    python3 - "$lock_file" <<'PY'
+import pathlib
+import re
+import sys
+
+lock_path = pathlib.Path(sys.argv[1])
+content = lock_path.read_text(encoding="utf-8")
+pattern = re.compile(r'(\[\[packages\]\]\nname = "pyarrow"\nversion = "[^"]+"\nmarker = ")([^"]+)(")', re.MULTILINE)
+expected = "implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux'"
+match = pattern.search(content)
+if not match:
+    raise SystemExit("pyarrow block not found in lock file")
+if match.group(2) == expected:
+    raise SystemExit(0)
+updated = pattern.sub(rf"\1{expected}\3", content, count=1)
+lock_path.write_text(updated, encoding="utf-8")
+PY
+  }
+
   run_lock() {
     local flavor="$1"
     local index="$2"
@@ -233,6 +262,11 @@ for TARGET_DIR in "${TARGET_DIRS[@]}"; do
       rm -f "$output"
       DIR_SUCCESS=false
     else
+      if ! apply_lock_policy_overrides "$output"; then
+        warn "Failed to apply lock policy overrides in $TARGET_DIR"
+        DIR_SUCCESS=false
+        return
+      fi
       if [[ "$INDEX_MODE" == "public-index" ]]; then
         ok "pylock.toml generated successfully."
       else


### PR DESCRIPTION
## Summary
- update `jupyter/datascience/ubi9-python-3.12/pylock.toml` so `pyarrow==21.0.0` is not selected on `ppc64le` and `s390x`
- keep Dockerfile behavior unchanged (pyarrow remains provided by dedicated architecture-specific builder stages)

## Regression origin
This behavior came from lock regeneration on `rhoai-3.3` where broad markers were applied (`implementation_name/sys_platform`) and `pyarrow` remained eligible on architectures that do not have matching upstream wheels in this lock context.

On `ppc64le`, the final strict `uv pip install --requirements=pylock.toml` then re-entered pyarrow source-build resolution and failed through a build dependency chain (`libcst` requiring Rust), as seen in the Konflux `build-images-2.log` failure.

## Why this fix
`pyarrow` is already installed earlier for `ppc64le`/`s390x` from dedicated builder stages in `Dockerfile.cpu`. Excluding those arches in the pylock marker avoids the redundant strict-lock reinstallation path while preserving existing architecture-specific build logic.

## Test plan
- [x] pre-commit hook passed on commit
- [ ] re-run Konflux Production Internal check:
  - `odh-workbench-jupyter-datascience-cpu-py312-on-pull-request`
- [ ] verify ppc64le no longer attempts pyarrow source build during final pylock install