### PR TITLE
[rhoai-3.3] RHAIENG-6082: fix(cve): pin go-toolset to 1.26.5 for CVE-2026-32283

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -7,7 +7,7 @@ ARG BASE_IMAGE
 ######################################################
 # mongocli-builder (build stage only, not published) #
 ######################################################
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
 ARG MONGOCLI_VERSION=2.0.4
 

--- a/scripts/dockerfile_fragments.py
+++ b/scripts/dockerfile_fragments.py
@@ -107,7 +107,7 @@ def main():
             ######################################################
             # mongocli-builder (build stage only, not published) #
             ######################################################
-            FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+            FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
             ARG MONGOCLI_VERSION=2.0.4
 
@@ -124,7 +124,7 @@ def main():
             ######################################################
             # mongocli-builder (build stage only, not published) #
             ######################################################
-            FROM registry.access.redhat.com/ubi9/go-toolset:latest AS mongocli-builder
+            FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787080706 AS mongocli-builder
 
             ARG MONGOCLI_VERSION=2.0.4
 


### PR DESCRIPTION
## Summary

- Pin `registry.access.redhat.com/ubi9/go-toolset` from `:latest` to `:1.26.5-1787080706` in all 14 mongocli-builder Dockerfiles and `scripts/dockerfile_fragments.py`
- Go 1.26.5 includes the fix for **CVE-2026-32283** (crypto/tls: Denial of Service via multiple TLS 1.3 key update messages), which was fixed in Go 1.25.9 and Go 1.26.2
- Aligns rhoai-3.3 with the pinned version already used on rhoai-3.4 and rhoai-3.5 branches

## CVE Details

| Field | Value |
|-------|-------|
| CVE | [CVE-2026-32283](https://nvd.nist.gov/vuln/detail/CVE-2026-32283) |
| Component | Go `crypto/tls` (standard library) |
| Impact | Denial of Service via TLS 1.3 key update deadlock |
| Fixed in | Go 1.25.9, Go 1.26.2 |
| Go Issue | [#78334](https://go.dev/issue/78334) |

## Changed files

- 14 Dockerfiles (`jupyter/*/Dockerfile.*`) — mongocli-builder `FROM` line
- `scripts/dockerfile_fragments.py` — both mongocli-builder template variants

## Jira

- [RHAIENG-6082](https://redhat.atlassian.net/browse/RHAIENG-6082) (tracker, blocks 18 image-level issues)

## Test plan

- [ ] Konflux builds pass for all affected images
- [ ] Rebuilt images no longer flag CVE-2026-32283 in vulnerability scans

[RHAIENG-6082]: https://redhat.atlassian.net/browse/RHAIENG-6082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ