### PR TITLE
Remove sbom-syft-generate step from v3-6-ea-2 push pipelines

### DIFF
--- a/.tekton/odh-pipeline-runtime-baseline-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-pipeline-runtime-baseline-cpu-py312-ubi9-ci-push.yaml
@@ -63,14 +63,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-baseline-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-pipeline-runtime-baseline-cpu-py312-ubi9-push.yaml
@@ -63,14 +63,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-v3-6-ea-2-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-v3-6-ea-2-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-v3-6-ea-2-push.yaml
@@ -93,14 +93,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-6-ea-2-push.yaml
@@ -93,14 +93,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-v3-6-ea-2-push.yaml
@@ -92,14 +92,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-v3-6-ea-2-push.yaml
@@ -93,14 +93,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-v3-6-ea-2-push.yaml
@@ -92,14 +92,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-ubi9-ci-push.yaml
@@ -61,14 +61,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-ubi9-push.yaml
@@ -61,14 +61,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-ubi9-ci-push.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-ubi9-ci-push.yaml
@@ -65,14 +65,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-ubi9-push.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-ubi9-push.yaml
@@ -65,14 +65,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-6-ea-2-push.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-v3-6-ea-2-push.yaml
@@ -98,14 +98,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-v3-6-ea-2-push.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-v3-6-ea-2-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-v3-6-ea-2-push.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-v3-6-ea-2-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-v3-6-ea-2-push.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-v3-6-ea-2-push.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-v3-6-ea-2-push.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
Remove sbom-syft-generate computeResources block from all 22 v3-6-ea-2 push PipelineRun files.

Made with [Cursor](https://cursor.com)