### PR TITLE
Remove sbom-syft-generate from pull-request pipelines on main

### DIFF
--- a/.tekton/odh-pipeline-runtime-baseline-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-baseline-cpu-py312-ubi9-pull-request.yaml
@@ -75,14 +75,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-ubi9-pull-request.yaml
@@ -67,14 +67,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-baseline-cpu-py312-ubi9-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-baseline-cpu-py312-ubi9-pull-request.yaml
@@ -77,14 +77,6 @@ spec:
         limits:
           cpu: '8'
           memory: 32Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '8'
-          memory: 32Gi
-        limits:
-          cpu: '8'
-          memory: 32Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -99,14 +99,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -98,14 +98,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -96,14 +96,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -95,14 +95,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -98,14 +98,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
Remove obsolete `sbom-syft-generate` step overrides from pull-request PipelineRuns in `.tekton/`.

Buildah task v0.11.0 removed the `sbom-syft-generate` step (SBOM generation now happens in the `build` step). Retaining overrides for removed steps causes `invalid StepOverride` failures.

Migration guidance: https://github.com/konflux-ci/container-build-catalog/blob/main/task/buildah/CHANGELOG.md#0110

Updated 8 pull-request PipelineRuns on `main`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image build configurations across multiple CPU, CUDA, ROCm, and TrustyAI environments.
  * Removed the software bill of materials generation step and its associated compute resource settings from these builds.
  * Existing preparation and image build steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->