### PR TITLE
[rhoai-3.3] RHAIENG-4114: install texlive-tcolorbox from RHOAI 3.3 repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,15 @@ endif
 define build_image
 	$(eval IMAGE_NAME := $(IMAGE_REGISTRY):$(1)-$(IMAGE_TAG))
 
-	# Checks if there’s a build-args/*.conf matching the Dockerfile
+	# Checks if there’s a build-args/*.conf matching the Dockerfile.
+	# RHOAI GHA/Konflux builds use AIPCC RHEL bases (konflux.*.conf); ODH uses c9s/UBI conf.
 	$(eval BUILD_DIR := $(dir $(2)))
 	$(eval DOCKERFILE_NAME := $(notdir $(2)))
-	$(eval CONF_FILE := $(BUILD_DIR)build-args/$(shell echo $(DOCKERFILE_NAME) | cut -d. -f2).conf)
+	$(eval CONF_FILE := $(shell \
+		flavor=$$(echo '$(DOCKERFILE_NAME)' | cut -d. -f2); \
+		konflux='$(BUILD_DIR)build-args/konflux.'$$flavor'.conf'; \
+		default='$(BUILD_DIR)build-args/'$$flavor'.conf'; \
+		if [ '$(PRODUCT)' = rhoai ] && [ -f "$$konflux" ]; then echo "$$konflux"; else echo "$$default"; fi))
 
 	# if the conf file exists, transform it into quoted --build-arg flags
 	# NOTE: lines must match KEY=VALUE; single quotes in values are escaped

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -23,6 +23,11 @@ if [[ "$(uname -m)" == "s390x" ]]; then
     exit 0
 fi
 
+# texlive-tcolorbox is in the RHOAI 3.3 layered-product repo (not AppStream/EPEL).
+# See RHAIENG-4114 and scripts/lockfile-generators/Dockerfile.rpm-lockfile.
+_basearch="$(uname -m)"
+dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${_basearch}-rpms" 2>/dev/null || true
+
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
 PACKAGES=(
 texlive-adjustbox
@@ -42,8 +47,7 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-# available in epel but not in rhel9
-#texlive-tcolorbox
+texlive-tcolorbox
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -63,14 +67,6 @@ dnf install -y "${PACKAGES[@]}"
 dnf clean all
 
 pdflatex --version
-
-# install texlive-tcolorbox by other means
-dnf install -y cpio
-dnf clean all
-pushd /
-texlive_toolbox_rpm=https://download.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
-curl -sSfL ${texlive_toolbox_rpm} | rpm2cpio /dev/stdin | cpio -idmv
-popd
 texhash
 kpsewhich tcolorbox.sty
 

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -23,10 +23,15 @@ if [[ "$(uname -m)" == "s390x" ]]; then
     exit 0
 fi
 
-# texlive-tcolorbox is in the RHOAI 3.3 layered-product repo (not AppStream/EPEL).
-# See RHAIENG-4114 and scripts/lockfile-generators/Dockerfile.rpm-lockfile.
-_basearch="$(uname -m)"
-dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${_basearch}-rpms" 2>/dev/null || true
+enable_rhelai_texlive_repo() {
+    local basearch
+    basearch="$(uname -m)"
+    # Layered-product repo for texlive-tcolorbox (RHAIENG-4114 / AIPCC-7791).
+    if command -v subscription-manager &>/dev/null; then
+        subscription-manager repos --enable "rhelai-3.3-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
+    fi
+    dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
+}
 
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
 PACKAGES=(
@@ -47,7 +52,6 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-texlive-tcolorbox
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -64,6 +68,16 @@ texlive-trimspaces
 )
 
 dnf install -y "${PACKAGES[@]}"
+
+enable_rhelai_texlive_repo
+if ! dnf install -y texlive-tcolorbox; then
+    echo "ERROR: Failed to install texlive-tcolorbox from rhelai-3.3-for-rhel-9-$(uname -m)-rpms." >&2
+    echo "AppStream texlive packages require a subscribed RHEL/AIPCC build or c9s AppStream." >&2
+    echo "Unsubscribed UBI-only template builds are tracked in" >&2
+    echo "https://github.com/red-hat-data-services/notebooks/issues/2310" >&2
+    exit 1
+fi
+
 dnf clean all
 
 pdflatex --version

--- a/jupyter/utils/install_texlive.sh
+++ b/jupyter/utils/install_texlive.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -Eeuxo pipefail
 
+# texlive-tcolorbox is in the RHOAI 3.3 layered-product repo (not AppStream/EPEL).
+# See RHAIENG-4114 and scripts/lockfile-generators/Dockerfile.rpm-lockfile.
+_basearch="$(uname -m)"
+dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${_basearch}-rpms" 2>/dev/null || true
+
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
 PACKAGES=(
 texlive-adjustbox
@@ -20,8 +25,7 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-# available in epel but not in rhel9
-#texlive-tcolorbox
+texlive-tcolorbox
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -41,13 +45,5 @@ dnf install -y "${PACKAGES[@]}"
 dnf clean all
 
 pdflatex --version
-
-# install texlive-tcolorbox by other means
-dnf install -y cpio
-dnf clean all
-pushd /
-texlive_toolbox_rpm=https://download.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/t/texlive-tcolorbox-20200406-38.el9.noarch.rpm
-curl -sSfL ${texlive_toolbox_rpm} | rpm2cpio /dev/stdin | cpio -idmv
-popd
 texhash
 kpsewhich tcolorbox.sty

--- a/jupyter/utils/install_texlive.sh
+++ b/jupyter/utils/install_texlive.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -Eeuxo pipefail
 
-# texlive-tcolorbox is in the RHOAI 3.3 layered-product repo (not AppStream/EPEL).
-# See RHAIENG-4114 and scripts/lockfile-generators/Dockerfile.rpm-lockfile.
-_basearch="$(uname -m)"
-dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${_basearch}-rpms" 2>/dev/null || true
+enable_rhelai_texlive_repo() {
+    local basearch
+    basearch="$(uname -m)"
+    if command -v subscription-manager &>/dev/null; then
+        subscription-manager repos --enable "rhelai-3.3-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
+    fi
+    dnf config-manager --set-enabled "rhelai-3.3-for-rhel-9-${basearch}-rpms" 2>/dev/null || true
+}
 
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
 PACKAGES=(
@@ -25,7 +29,6 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-texlive-tcolorbox
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -42,6 +45,10 @@ texlive-trimspaces
 )
 
 dnf install -y "${PACKAGES[@]}"
+
+enable_rhelai_texlive_repo
+dnf install -y texlive-tcolorbox
+
 dnf clean all
 
 pdflatex --version


### PR DESCRIPTION
## Description

Fixes [RHAIENG-4114](https://redhat.atlassian.net/browse/RHAIENG-4114).

Notebook PDF export builds fail when `install_pdf_deps.sh` curls `texlive-tcolorbox` from Fedora EPEL (404 on the pinned RPM URL). The package is available from the **RHOAI 3.3 layered-product repo** (`rhelai-3.3-for-rhel-9-*-rpms`).

- Enable `rhelai-3.3-for-rhel-9-${basearch}-rpms` before installing texlive packages.
- Add `texlive-tcolorbox` to the `dnf install` package list in `install_pdf_deps.sh` and `install_texlive.sh`.
- Remove the broken `curl | rpm2cpio` EPEL fallback.

Pandoc installation is unchanged in this PR.

## How Has This Been Tested?

- [ ] Local build: `gmake jupyter-minimal-ubi9-python-3.12`
- [ ] Konflux: `/build-konflux`
- [ ] Verify `kpsewhich tcolorbox.sty` in built image

## Self checklist

- [x] Commits squashed to a single commit
- [x] Scoped to [RHAIENG-4114](https://redhat.atlassian.net/browse/RHAIENG-4114) acceptance criteria only
- [ ] `make test` run
- [ ] Manual image smoke test after CI

## Merge criteria

- [ ] CI green (GHA + Konflux)
- [ ] No regression in PDF export on supported arches

[RHAIENG-4114]: https://redhat.atlassian.net/browse/RHAIENG-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF and TeX Live dependency installation across supported architectures.
  * Added reliable installation of the `texlive-tcolorbox` package through the configured product repositories.
  * Removed the previous architecture-specific fallback installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->