### PR TITLE
update path so runtime builds without failure

### DIFF
--- a/.tekton/odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2-push.yaml
+++ b/.tekton/odh-pipeline-runtime-baseline-cpu-py312-v3-6-ea-2-push.yaml
@@ -33,7 +33,7 @@ spec:
   - name: rhoai-version
     value: "3.6.0-ea.2"
   - name: dockerfile
-    value: baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
+    value: runtimes/baseline/ubi9-python-3.12/Dockerfile.konflux.cpu
   - name: path-context
     value: runtimes/
   - name: hermetic


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Quick .teckon pipeline path fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [ ] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pipeline configuration to reference the correct container build file path, improving pipeline execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->