### PR TITLE
rhoai-2.25: pin cython<3.3 for BE datascience builds (draft)

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -414,7 +414,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
     #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
     # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds
+    # Cython 3.3.0 breaks pyzmq 27.1.0 sdist builds on ppc64le/s390x (redeclared errors).
     echo "meson<1.11" > build_constraints.txt && \
+    echo "cython<3.3" >> build_constraints.txt && \
     if [ "$TARGETARCH" = "ppc64le" ] || [ "$TARGETARCH" = "s390x" ]; then \
         GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 \
         CFLAGS="-O3" CXXFLAGS="-O3" \

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -423,6 +423,7 @@ set -Eeuxo pipefail
 echo "Installing softwares and packages"
 # RHOAIENG-58277: Meson 1.11.0 breaks pandas 2.3.3 source builds on ppc64le/s390x
 echo "meson<1.11" > build_constraints.txt
+echo "cython<3.3" >> build_constraints.txt
 if [ "$TARGETARCH" = "ppc64le" ]; then
     export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
     export LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}


### PR DESCRIPTION
## Summary

Minimal alternative to the RH-wheel port: pin `cython<3.3` in `build_constraints.txt` for BE `uv pip install` in jupyter-datascience and runtime-datascience.

Cython 3.3.0 (released 2026-08-22) breaks `pyzmq==27.1.0` sdist compilation on ppc64le/s390x with `'hint' redeclared` / `'c_addr' redeclared`. Aug 21 Konflux successes used Cython 3.2.9.

## Test plan

- [ ] Konflux `odh-workbench-jupyter-datascience-cpu-py312-v2-25` on-push ppc64le + s390x
- [ ] Konflux `odh-pipeline-runtime-datascience-cpu-py312-v2-25` on-push ppc64le + s390x
- [ ] Compare CI outcome with RH-wheel PR #2809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package installation reliability for Python environments on ppc64le and s390x.
  - Prevented build failures affecting pyzmq and related dependencies during image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->