### PR TITLE
[rhoai-2.25] Install pandoc from RHOAI 3.5 wheel and tcolorbox from rhelai

### DIFF
--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 # Install OS dependencies required for JupyterLab PDF export.
-# Uses RHEL/UBI AppStream texlive RPMs plus rhelai texlive-tcolorbox.
+# Uses RHEL/UBI AppStream texlive RPMs plus tcolorbox from CTAN.
 # Pandoc comes from the RHOAI public-rhai pandoc-rhai wheel (x86_64, aarch64, ppc64le, s390x).
 # Requires AppStream (subscription or c9s); plain unsubscribed UBI lacks these packages
 # (see https://github.com/red-hat-data-services/notebooks/issues/2310).
-# Backport of main's RPM approach (RHAIENG-2186 / RHAIENG-2345); replaces Utah/CTAN curl.
+# AppStream texlive RPMs (RHAIENG-2186 / RHAIENG-2345); tcolorbox from CTAN, not EPEL/CDN.
 
 set -Eeuxo pipefail
 
 _arch="$(uname -m)"
 
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
-# texlive-tcolorbox is not in AppStream; do not use EPEL. Install the rhelai 3.5 noarch RPM.
+# texlive-tcolorbox is not in AppStream; do not use EPEL or the rhelai CDN RPM.
+# Install tcolorbox from CTAN after the AppStream texlive set.
 PACKAGES=(
 texlive-adjustbox
 texlive-bibtex
@@ -31,8 +32,6 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-# texlive-tcolorbox rebuild of EPEL package
-https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/t/texlive-tcolorbox-20200406-1.el9ai.noarch.rpm
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -60,6 +59,25 @@ if ! dnf install -y "${PACKAGES[@]}"; then
 fi
 
 dnf clean all
+
+# tcolorbox is not in AppStream. Unpack the CTAN TDS zip into TEXMFLOCAL.
+# https://www.ctan.org/pkg/tcolorbox
+_tcolorbox_zip=/tmp/tcolorbox.tds.zip
+curl --fail --location --show-error \
+    -o "${_tcolorbox_zip}" \
+    "https://mirror.ctan.org/install/macros/latex/contrib/tcolorbox.tds.zip"
+_texmf_local="$(kpsewhich -var-value TEXMFLOCAL)"
+mkdir -p "${_texmf_local}"
+python - "${_texmf_local}" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+dest = pathlib.Path(sys.argv[1])
+with zipfile.ZipFile("/tmp/tcolorbox.tds.zip") as zf:
+    zf.extractall(dest)
+PY
+rm -f "${_tcolorbox_zip}"
 
 # Unpack pandoc from the RHOAI wheel onto PATH.
 # Index: https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/pandoc-rhai/

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Install OS dependencies required for JupyterLab PDF export.
-# Uses RHEL/UBI AppStream texlive RPMs plus tcolorbox from CTAN.
+# Uses RHEL/UBI AppStream texlive RPMs plus tcolorbox 4.42 (TeX Live 2020 vintage).
 # Pandoc comes from the RHOAI public-rhai pandoc-rhai wheel (x86_64, aarch64, ppc64le, s390x).
 # Requires AppStream (subscription or c9s); plain unsubscribed UBI lacks these packages
 # (see https://github.com/red-hat-data-services/notebooks/issues/2310).
-# AppStream texlive RPMs (RHAIENG-2186 / RHAIENG-2345); tcolorbox from CTAN, not EPEL/CDN.
+# AppStream texlive RPMs (RHAIENG-2186 / RHAIENG-2345); tcolorbox 4.42, not current CTAN/EPEL/CDN.
 
 set -Eeuxo pipefail
 
@@ -13,7 +13,7 @@ _arch="$(uname -m)"
 
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
 # texlive-tcolorbox is not in AppStream; do not use EPEL or the rhelai CDN RPM.
-# Install tcolorbox from CTAN after the AppStream texlive set.
+# Current CTAN tcolorbox 6.x needs tikz 2023 / \NewStructureName; pin 4.42 for TeX Live 2020.
 PACKAGES=(
 texlive-adjustbox
 texlive-bibtex
@@ -60,24 +60,36 @@ fi
 
 dnf clean all
 
-# tcolorbox is not in AppStream. Unpack the CTAN TDS zip into TEXMFLOCAL.
-# https://www.ctan.org/pkg/tcolorbox
-_tcolorbox_zip=/tmp/tcolorbox.tds.zip
+# tcolorbox is not in AppStream. Unpack tcolorbox 4.42 (TeX Live 2020 vintage) into TEXMFLOCAL.
+# Current CTAN 6.x fails on RHEL 9 XeTeX (\NewStructureName / tikz 2023).
+# https://github.com/T-F-S/tcolorbox/releases/tag/v4.42
+_tcolorbox_tgz=/tmp/tcolorbox-4.42.tar.gz
 curl --fail --location --show-error \
-    -o "${_tcolorbox_zip}" \
-    "https://mirror.ctan.org/install/macros/latex/contrib/tcolorbox.tds.zip"
+    -o "${_tcolorbox_tgz}" \
+    "https://github.com/T-F-S/tcolorbox/archive/refs/tags/v4.42.tar.gz"
 _texmf_local="$(kpsewhich -var-value TEXMFLOCAL)"
 mkdir -p "${_texmf_local}"
 python - "${_texmf_local}" <<'PY'
 import pathlib
 import sys
-import zipfile
+import tarfile
 
-dest = pathlib.Path(sys.argv[1])
-with zipfile.ZipFile("/tmp/tcolorbox.tds.zip") as zf:
-    zf.extractall(dest)
+dest = pathlib.Path(sys.argv[1]) / "tex" / "latex" / "tcolorbox"
+dest.mkdir(parents=True, exist_ok=True)
+with tarfile.open("/tmp/tcolorbox-4.42.tar.gz", "r:gz") as tf:
+    for member in tf.getmembers():
+        name = pathlib.PurePosixPath(member.name)
+        if not member.isfile() or name.suffix not in {".sty", ".tex", ".def", ".code"}:
+            continue
+        if name.suffix == ".tex" and not str(name).endswith(".code.tex"):
+            continue
+        target = dest / name.name
+        src = tf.extractfile(member)
+        if src is None:
+            continue
+        target.write_bytes(src.read())
 PY
-rm -f "${_tcolorbox_zip}"
+rm -f "${_tcolorbox_tgz}"
 
 # Unpack pandoc from the RHOAI wheel onto PATH.
 # Index: https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/pandoc-rhai/

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -1,21 +1,18 @@
 #!/bin/bash
 
 # Install OS dependencies required for JupyterLab PDF export.
-# Uses RHEL/UBI AppStream texlive RPMs plus EPEL for texlive-tcolorbox and pandoc.
+# Uses RHEL/UBI AppStream texlive RPMs plus rhelai texlive-tcolorbox.
+# Pandoc comes from the RHOAI public-rhai pandoc-rhai wheel (x86_64, aarch64, ppc64le, s390x).
 # Requires AppStream (subscription or c9s); plain unsubscribed UBI lacks these packages
 # (see https://github.com/red-hat-data-services/notebooks/issues/2310).
 # Backport of main's RPM approach (RHAIENG-2186 / RHAIENG-2345); replaces Utah/CTAN curl.
 
 set -Eeuxo pipefail
 
-# Skip PDF export installation for s390x and ppc64le architectures
-if [[ "$(uname -m)" == "s390x" || "$(uname -m)" == "ppc64le" ]]; then
-    echo "PDF export functionality is not supported on $(uname -m) architecture. Skipping installation."
-    exit 0
-fi
+_arch="$(uname -m)"
 
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
-# texlive-tcolorbox is not in AppStream; install from EPEL (do not curl a pinned Fedora RPM URL).
+# texlive-tcolorbox is not in AppStream; do not use EPEL. Install the rhelai 3.5 noarch RPM.
 PACKAGES=(
 texlive-adjustbox
 texlive-bibtex
@@ -34,7 +31,8 @@ texlive-parskip
 texlive-plain
 texlive-pxfonts
 texlive-rsfs
-texlive-tcolorbox
+# texlive-tcolorbox rebuild of EPEL package
+https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/rhelai/3.5/os/Packages/t/texlive-tcolorbox-20200406-1.el9ai.noarch.rpm
 texlive-times
 texlive-titling
 texlive-txfonts
@@ -48,13 +46,13 @@ texlive-xetex
 # dependencies of texlive-tcolorbox
 texlive-environ
 texlive-trimspaces
+# runtime deps of the pandoc-rhai binary
+gmp
+libffi
 )
 
-# EPEL provides texlive-tcolorbox and pandoc (dynamic binary; check-payload friendly).
-dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-
-if ! dnf install -y "${PACKAGES[@]}" pandoc; then
-    echo "ERROR: Failed to install texlive/pandoc RPMs." >&2
+if ! dnf install -y "${PACKAGES[@]}"; then
+    echo "ERROR: Failed to install texlive/pandoc runtime RPMs." >&2
     echo "AppStream texlive packages require a subscribed RHEL/UBI build or c9s AppStream." >&2
     echo "Unsubscribed UBI-only template builds are tracked in" >&2
     echo "https://github.com/red-hat-data-services/notebooks/issues/2310" >&2
@@ -63,9 +61,38 @@ fi
 
 dnf clean all
 
-pdflatex --version
+# Unpack pandoc from the RHOAI wheel onto PATH.
+# Index: https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/pandoc-rhai/
+case "${_arch}" in
+    x86_64|aarch64|ppc64le|s390x) _pandoc_arch="${_arch}" ;;
+    *) echo "ERROR: unsupported arch for pandoc-rhai wheel: ${_arch}" >&2; exit 1 ;;
+esac
+
+_pandoc_whl=/tmp/pandoc_rhai.whl
+curl --fail --location --show-error \
+    -o "${_pandoc_whl}" \
+    "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_${_pandoc_arch}.whl"
+
+python - <<'PY'
+import pathlib
+import zipfile
+
+whl = pathlib.Path("/tmp/pandoc_rhai.whl")
+dest = pathlib.Path("/usr/local/bin/pandoc")
+with zipfile.ZipFile(whl) as zf:
+    names = [name for name in zf.namelist() if name.endswith("/data/bin/pandoc")]
+    if len(names) != 1:
+        raise SystemExit(f"expected one pandoc binary in wheel, found {names!r}")
+    dest.write_bytes(zf.read(names[0]))
+dest.chmod(0o755)
+PY
+rm -f "${_pandoc_whl}"
+
 pandoc --version
+pdflatex --version
+
 texhash
+
 kpsewhich tcolorbox.sty
 command -v pandoc
 command -v pdflatex


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C0BQAUU5W73/p1788163737606609

## Description

Stop using EPEL in `jupyter/utils/install_pdf_deps.sh` for Jupyter PDF export:

- Install `texlive-tcolorbox` from the rhelai 3.5 noarch RPM (`texlive-tcolorbox-20200406-1.el9ai`) together with AppStream texlive packages.
- Download the arch-specific [pandoc-rhai](https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/pandoc-rhai/) wheel and unpack `pandoc` onto `/usr/local/bin` (x86_64, aarch64, ppc64le, s390x), with `gmp`/`libffi` for the binary.
- Enable texlive on IBM arches as well (no early skip).

## How Has This Been Tested?

- [ ] Image rebuild of jupyter-minimal (subscription/CDN access required for the rhelai RPM URL)
- [ ] Confirm `pandoc --version`, `pdflatex --version`, and `kpsewhich tcolorbox.sty` in the image

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved PDF export setup across all supported system architectures.
  - Updated Pandoc and LaTeX components for more reliable PDF generation.
  - Added support for required runtime dependencies and compatible LaTeX packages.
  - Added architecture-specific Pandoc installation and validation.
  - Enhanced dependency and version checks to identify PDF generation issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->