### PR TITLE
[rhoai-2.25] Install pandoc-rhai via uv pip / pylock

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -251,6 +251,7 @@ else
         --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match \
         --requirements=./pylock.toml
 fi
+pandoc --version
 mkdir /opt/app-root/runtimes
 mkdir /opt/app-root/pipeline-runtimes
 rm /opt/app-root/share/jupyter/metadata/runtime-images/*.json

--- a/jupyter/datascience/ubi9-python-3.12/pylock.toml
+++ b/jupyter/datascience/ubi9-python-3.12/pylock.toml
@@ -1712,6 +1712,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "(python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux')"

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,16 @@
 # RH wheel-only overlay for jupyter-datascience public PyPI pylock.toml.
-# Patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py merge-be
+# merge-be: native BE wheels. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+
+[[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
 
 [[packages]]
 name = "pyzmq"

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -109,6 +109,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -100,6 +100,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y

--- a/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/minimal/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -88,6 +88,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # Disable announcement plugin of jupyterlab
 jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 # Replace Notebook's launcher, "(ipykernel)" with Python's version 3.x.y

--- a/jupyter/minimal/ubi9-python-3.12/pylock.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pylock.toml
@@ -698,6 +698,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626
 wheels = [{ url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", upload-time = 2026-04-24T20:15:22Z, size = 100195, hashes = { sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e" } }]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "(python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux')"

--- a/jupyter/minimal/ubi9-python-3.12/pyproject.toml
+++ b/jupyter/minimal/ubi9-python-3.12/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "jupyterlab-git~=0.54.0",
     "nbdime~=4.0.2",
     "nbgitpuller~=1.2.2",
+    # PDF export (nbconvert): pandoc-rhai is RH-index-only; injected into pylock.toml
+    # from uv.lock.d/rh-wheel-only.ref.toml (not listed here — not on public PyPI).
 
     # Base packages
     "wheel~=0.46.2",

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -153,6 +153,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # setup path for runtime configuration
 mkdir /opt/app-root/runtimes
 # Remove default Elyra runtime-images

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/pylock.toml
@@ -1512,6 +1512,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'"

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,5 @@
-# RH wheel-only overlay for jupyter-minimal public PyPI pylock.toml.
-# merge-be: pyzmq. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+# RH wheel-only overlay for pytorch+llmcompressor public PyPI pylock.toml.
+# pandoc-rhai is RH-index-only; patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py replace
 
 [[packages]]
 name = "pandoc-rhai"
@@ -10,13 +10,4 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
-]
-
-[[packages]]
-name = "pyzmq"
-version = "27.1.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-07-18T13:23:49Z, size = 257638, hashes = { sha256 = "0d025fc6144ce2a8e0b0e404107f8ae3ade7a8e89cc080b2e630eeb64dbb2e84" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-07-18T13:23:49Z, size = 314109, hashes = { sha256 = "3e24d002e0b7e5727c32d6c149669555b50ecea275863046038b48f588d24e86" } },
 ]

--- a/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/pytorch/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -153,6 +153,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # setup path for runtime configuration
 mkdir /opt/app-root/runtimes
 # Remove default Elyra runtime-images

--- a/jupyter/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/pylock.toml
@@ -1508,6 +1508,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'"

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,5 @@
-# RH wheel-only overlay for jupyter-minimal public PyPI pylock.toml.
-# merge-be: pyzmq. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+# RH wheel-only overlay for pytorch public PyPI pylock.toml.
+# pandoc-rhai is RH-index-only; patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py replace
 
 [[packages]]
 name = "pandoc-rhai"
@@ -10,13 +10,4 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
-]
-
-[[packages]]
-name = "pyzmq"
-version = "27.1.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-07-18T13:23:49Z, size = 257638, hashes = { sha256 = "0d025fc6144ce2a8e0b0e404107f8ae3ade7a8e89cc080b2e630eeb64dbb2e84" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-07-18T13:23:49Z, size = 314109, hashes = { sha256 = "3e24d002e0b7e5727c32d6c149669555b50ecea275863046038b48f588d24e86" } },
 ]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -150,6 +150,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # setup path for runtime configuration
 mkdir /opt/app-root/runtimes
 # Remove default Elyra runtime-images

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/pylock.toml
@@ -1424,6 +1424,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'"

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,5 @@
-# RH wheel-only overlay for jupyter-minimal public PyPI pylock.toml.
-# merge-be: pyzmq. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+# RH wheel-only overlay for pytorch public PyPI pylock.toml.
+# pandoc-rhai is RH-index-only; patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py replace
 
 [[packages]]
 name = "pandoc-rhai"
@@ -10,13 +10,4 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
-]
-
-[[packages]]
-name = "pyzmq"
-version = "27.1.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-07-18T13:23:49Z, size = 257638, hashes = { sha256 = "0d025fc6144ce2a8e0b0e404107f8ae3ade7a8e89cc080b2e630eeb64dbb2e84" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-07-18T13:23:49Z, size = 314109, hashes = { sha256 = "3e24d002e0b7e5727c32d6c149669555b50ecea275863046038b48f588d24e86" } },
 ]

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.konflux.rocm
@@ -156,6 +156,7 @@ echo "Installing softwares and packages"
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 # Not using --build-constraints=./requirements.txt because error: Unnamed requirements are not allowed as constraints (found: `https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # setup path for runtime configuration
 mkdir /opt/app-root/runtimes
 # Remove default Elyra runtime-images

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1482,6 +1482,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,5 @@
-# RH wheel-only overlay for jupyter-minimal public PyPI pylock.toml.
-# merge-be: pyzmq. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+# RH wheel-only overlay for tensorflow public PyPI pylock.toml.
+# pandoc-rhai is RH-index-only; patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py replace
 
 [[packages]]
 name = "pandoc-rhai"
@@ -10,13 +10,4 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
-]
-
-[[packages]]
-name = "pyzmq"
-version = "27.1.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-07-18T13:23:49Z, size = 257638, hashes = { sha256 = "0d025fc6144ce2a8e0b0e404107f8ae3ade7a8e89cc080b2e630eeb64dbb2e84" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-07-18T13:23:49Z, size = 314109, hashes = { sha256 = "3e24d002e0b7e5727c32d6c149669555b50ecea275863046038b48f588d24e86" } },
 ]

--- a/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
+++ b/jupyter/tensorflow/ubi9-python-3.12/Dockerfile.konflux.cuda
@@ -158,6 +158,7 @@ echo "Installing softwares and packages"
 # This may have to download and compile some dependencies, and as we don't lock requirements from `build-system.requires`,
 #  we often don't know the correct hashes and `--require-hashes` would therefore fail on non amd64, where building is common.
 uv pip install --strict --no-deps --no-cache --no-config --no-progress --verify-hashes --compile-bytecode --index-strategy=unsafe-best-match --requirements=./pylock.toml
+pandoc --version
 # setup path for runtime configuration
 mkdir /opt/app-root/runtimes
 # Remove default Elyra runtime-images

--- a/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/pylock.toml
@@ -1835,6 +1835,17 @@ wheels = [
 ]
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "(python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux')"

--- a/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,5 @@
-# RH wheel-only overlay for jupyter-minimal public PyPI pylock.toml.
-# merge-be: pyzmq. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+# RH wheel-only overlay for tensorflow public PyPI pylock.toml.
+# pandoc-rhai is RH-index-only; patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py replace
 
 [[packages]]
 name = "pandoc-rhai"
@@ -10,13 +10,4 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
-]
-
-[[packages]]
-name = "pyzmq"
-version = "27.1.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-07-18T13:23:49Z, size = 257638, hashes = { sha256 = "0d025fc6144ce2a8e0b0e404107f8ae3ade7a8e89cc080b2e630eeb64dbb2e84" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-07-18T13:23:49Z, size = 314109, hashes = { sha256 = "3e24d002e0b7e5727c32d6c149669555b50ecea275863046038b48f588d24e86" } },
 ]

--- a/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/trustyai/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -224,6 +224,7 @@ echo "Installing softwares and packages"
 printf '%s\n' 'setuptools>=80.9.0,<82' 'cython<3.3' > build_constraints.txt
 # we can ensure wheels are consumed from the cache only by restricting internet access for uv install with '--offline' flag
 UV_LINK_MODE=copy uv pip install --cache-dir /root/.cache/uv --requirements=./pylock.toml --build-constraint build_constraints.txt
+pandoc --version
 # Note: debugpy wheel availabe on pypi (in uv cache) is none-any but bundles amd64.so files
 #       Build debugpy from source instead
 UV_LINK_MODE=copy uv pip install --no-cache git+https://github.com/microsoft/debugpy.git@v$(grep -A1 '\"debugpy\"' ./pylock.toml | grep -Eo '\b[0-9\.]+\b')

--- a/jupyter/trustyai/ubi9-python-3.12/pylock.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/pylock.toml
@@ -1652,6 +1652,17 @@ marker = "(python_full_version == '3.12.*' and platform_machine == 'aarch64' and
 sdist = { url = "https://files.pythonhosted.org/packages/74/ee/146cab1ff6d575b54ace8a6a5994048380dc94879b0125b25e62edcb9e52/pandas-1.5.3.tar.gz", upload-time = 2023-01-19T08:31:39Z, size = 5203060, hashes = { sha256 = "74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1" } }
 
 [[packages]]
+name = "pandoc-rhai"
+version = "3.9.0.2"
+marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_aarch64.whl", upload-time = 2026-06-18T07:23:56Z, size = 77522087, hashes = { sha256 = "8eef0dccbd3e9a9de54c0179e6bbc4140fe6c33407b0b2ec48686b990d817902" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
+]
+
+[[packages]]
 name = "pandocfilters"
 version = "1.5.1"
 marker = "(python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'ppc64le' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'linux') or (python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux')"

--- a/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
+++ b/jupyter/trustyai/ubi9-python-3.12/uv.lock.d/rh-wheel-only.ref.toml
@@ -1,5 +1,5 @@
-# RH wheel-only overlay for jupyter-minimal public PyPI pylock.toml.
-# merge-be: pyzmq. replace/insert: pandoc-rhai (RH-index-only, not on PyPI).
+# RH wheel-only overlay for trustyai public PyPI pylock.toml.
+# pandoc-rhai is RH-index-only; patched by: scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py replace
 
 [[packages]]
 name = "pandoc-rhai"
@@ -10,13 +10,4 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_ppc64le.whl", upload-time = 2026-06-18T07:24:11Z, size = 77077642, hashes = { sha256 = "9d902dc54ab361a59ba3a2f87668a7426be87a15691d235dbe78400c3a6a7f95" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_s390x.whl", upload-time = 2026-06-18T07:39:30Z, size = 166817497, hashes = { sha256 = "40f0c5e3a9a971fe374fbb1d5f37a55adcbe6559ba40f800c948dd52043f14ec" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_x86_64.whl", upload-time = 2026-06-18T07:23:43Z, size = 65861027, hashes = { sha256 = "195086bd39f4724ac02e22187290808cbe19c60a0471a6c9108b4a6da1373947" } },
-]
-
-[[packages]]
-name = "pyzmq"
-version = "27.1.0"
-marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-07-18T13:23:49Z, size = 257638, hashes = { sha256 = "0d025fc6144ce2a8e0b0e404107f8ae3ade7a8e89cc080b2e630eeb64dbb2e84" } },
-    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pyzmq-27.1.0-2-cp312-cp312-linux_s390x.whl", upload-time = 2026-07-18T13:23:49Z, size = 314109, hashes = { sha256 = "3e24d002e0b7e5727c32d6c149669555b50ecea275863046038b48f588d24e86" } },
 ]

--- a/jupyter/utils/install_pdf_deps.sh
+++ b/jupyter/utils/install_pdf_deps.sh
@@ -2,14 +2,12 @@
 
 # Install OS dependencies required for JupyterLab PDF export.
 # Uses RHEL/UBI AppStream texlive RPMs plus tcolorbox 4.42 (TeX Live 2020 vintage).
-# Pandoc comes from the RHOAI public-rhai pandoc-rhai wheel (x86_64, aarch64, ppc64le, s390x).
+# Pandoc is installed later via uv pip from pylock.toml (pandoc-rhai, RH public-rhai index).
 # Requires AppStream (subscription or c9s); plain unsubscribed UBI lacks these packages
 # (see https://github.com/red-hat-data-services/notebooks/issues/2310).
 # AppStream texlive RPMs (RHAIENG-2186 / RHAIENG-2345); tcolorbox 4.42, not current CTAN/EPEL/CDN.
 
 set -Eeuxo pipefail
-
-_arch="$(uname -m)"
 
 # https://github.com/rh-aiservices-bu/workbench-images/blob/main/snippets/ides/1-jupyter/os/os-packages.txt
 # texlive-tcolorbox is not in AppStream; do not use EPEL or the rhelai CDN RPM.
@@ -91,38 +89,9 @@ with tarfile.open("/tmp/tcolorbox-4.42.tar.gz", "r:gz") as tf:
 PY
 rm -f "${_tcolorbox_tgz}"
 
-# Unpack pandoc from the RHOAI wheel onto PATH.
-# Index: https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/pandoc-rhai/
-case "${_arch}" in
-    x86_64|aarch64|ppc64le|s390x) _pandoc_arch="${_arch}" ;;
-    *) echo "ERROR: unsupported arch for pandoc-rhai wheel: ${_arch}" >&2; exit 1 ;;
-esac
-
-_pandoc_whl=/tmp/pandoc_rhai.whl
-curl --fail --location --show-error \
-    -o "${_pandoc_whl}" \
-    "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.5/cpu-ubi9/pandoc_rhai-3.9.0.2-4-py3-none-linux_${_pandoc_arch}.whl"
-
-python - <<'PY'
-import pathlib
-import zipfile
-
-whl = pathlib.Path("/tmp/pandoc_rhai.whl")
-dest = pathlib.Path("/usr/local/bin/pandoc")
-with zipfile.ZipFile(whl) as zf:
-    names = [name for name in zf.namelist() if name.endswith("/data/bin/pandoc")]
-    if len(names) != 1:
-        raise SystemExit(f"expected one pandoc binary in wheel, found {names!r}")
-    dest.write_bytes(zf.read(names[0]))
-dest.chmod(0o755)
-PY
-rm -f "${_pandoc_whl}"
-
-pandoc --version
 pdflatex --version
 
 texhash
 
 kpsewhich tcolorbox.sty
-command -v pandoc
 command -v pdflatex

--- a/scripts/lockfile-generators/create-requirements-lockfile.sh
+++ b/scripts/lockfile-generators/create-requirements-lockfile.sh
@@ -181,8 +181,10 @@ if [[ -f "$RH_WHEEL_REF" ]]; then
   echo ""
   echo "=== Patching RH wheel-only packages for hermeto prefetch ==="
   # Rust sdists break hermeto cargo prefetch — replace on all arches.
-  # pandoc-rhai is RH-index-only (not on PyPI), so uv pip compile never emits it.
-  RH_WHEEL_REPLACE_ALL=(uv ripgrep pandoc-rhai)
+  RH_WHEEL_REPLACE_ALL=(uv ripgrep)
+  if grep -Fq 'name = "pandoc-rhai"' "$RH_WHEEL_REF"; then
+    RH_WHEEL_REPLACE_ALL+=(pandoc-rhai)
+  fi
   # Native deps missing ppc64le/s390x PyPI wheels — merge BE RH wheels only.
   RH_WHEEL_MERGE_BE=(
       argon2-cffi-bindings cryptography debugpy httptools librt markupsafe

--- a/scripts/lockfile-generators/create-requirements-lockfile.sh
+++ b/scripts/lockfile-generators/create-requirements-lockfile.sh
@@ -181,7 +181,8 @@ if [[ -f "$RH_WHEEL_REF" ]]; then
   echo ""
   echo "=== Patching RH wheel-only packages for hermeto prefetch ==="
   # Rust sdists break hermeto cargo prefetch — replace on all arches.
-  RH_WHEEL_REPLACE_ALL=(uv ripgrep)
+  # pandoc-rhai is RH-index-only (not on PyPI), so uv pip compile never emits it.
+  RH_WHEEL_REPLACE_ALL=(uv ripgrep pandoc-rhai)
   # Native deps missing ppc64le/s390x PyPI wheels — merge BE RH wheels only.
   RH_WHEEL_MERGE_BE=(
       argon2-cffi-bindings cryptography debugpy httptools librt markupsafe

--- a/scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py
+++ b/scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py
@@ -3,13 +3,9 @@
 
 Two strategies:
   replace   — swap the entire [[packages]] block from the reference lock (all arches).
-              Use for Rust-backed packages (uv, ripgrep) where PyPI sdists break hermeto,
-              and for RH-index-only packages (pandoc-rhai) that uv pip compile cannot emit.
-              Missing names in the target lock are inserted in name order.
-              Names absent from the reference lock are skipped.
+              Use for Rust-backed packages (uv, ripgrep) where PyPI sdists break hermeto.
   merge-be  — keep PyPI wheels for x86_64/aarch64; add RH wheels for ppc64le/s390x only;
               drop sdists. Aligns rhoai-2.25 with public PyPI on LE while BE stays offline.
-              Names absent from the reference or target lock are skipped.
 
 Usage:
     patch-rh-wheel-only-packages.py replace <pylock.toml> <reference.toml> pkg [pkg ...]
@@ -179,33 +175,23 @@ def strip_sdist(header: str) -> str:
 
 def patch_replace(target: Path, reference: Path, names: list[str]) -> None:
     ref_map = load_package_map(reference)
-    names = [name for name in names if name in ref_map]
-    if not names:
-        print("  No matching RH replace packages in reference lock; skipping")
-        return
+    missing = [name for name in names if name not in ref_map]
+    if missing:
+        raise SystemExit(f"Reference lock missing packages: {', '.join(missing)}")
 
     header, blocks = split_packages(target.read_text(encoding="utf-8"))
-    names_set = set(names)
     updated: list[str] = []
-    inserted: set[str] = set()
-
-    def flush_before(next_name: str | None) -> None:
-        for name in sorted(names_set - inserted):
-            if next_name is None or name < next_name:
-                updated.append(ref_map[name].rstrip() + "\n")
-                inserted.add(name)
-
+    replaced: set[str] = set()
     for block in blocks:
         name = package_name(block)
-        if name in names_set:
-            flush_before(name)
+        if name in names:
             updated.append(ref_map[name].rstrip() + "\n")
-            inserted.add(name)
+            replaced.add(name)
         else:
-            if name:
-                flush_before(name)
             updated.append(block.rstrip() + "\n")
-    flush_before(None)
+
+    for name in sorted(set(names) - replaced):
+        updated.append(ref_map[name].rstrip() + "\n")
 
     target.write_text(header + "\n".join(updated), encoding="utf-8")
     print(f"  Replaced RH wheel-only entries for: {', '.join(names)}")
@@ -213,19 +199,17 @@ def patch_replace(target: Path, reference: Path, names: list[str]) -> None:
 
 def patch_merge_be(target: Path, reference: Path, names: list[str]) -> None:
     ref_map = load_package_map(reference)
-    names = [name for name in names if name in ref_map]
-    if not names:
-        print("  No matching RH merge-be packages in reference lock; skipping")
-        return
+    missing = [name for name in names if name not in ref_map]
+    if missing:
+        raise SystemExit(f"Reference lock missing packages: {', '.join(missing)}")
 
     header, blocks = split_packages(target.read_text(encoding="utf-8"))
     updated: list[str] = []
     merged: set[str] = set()
-    names_set = set(names)
 
     for block in blocks:
         name = package_name(block)
-        if name not in names_set:
+        if name not in names:
             updated.append(block.rstrip() + "\n")
             continue
 
@@ -256,12 +240,11 @@ def patch_merge_be(target: Path, reference: Path, names: list[str]) -> None:
         updated.append(new_block.rstrip() + "\n")
         merged.add(name)
 
-    skipped = sorted(names_set - merged)
-    if skipped:
-        print(f"  Skipped merge-be (not in target lock): {', '.join(skipped)}")
+    if merged != set(names):
+        raise SystemExit(f"Target lock missing packages to merge: {', '.join(sorted(set(names) - merged))}")
 
     target.write_text(header + "\n".join(updated), encoding="utf-8")
-    print(f"  Merged BE RH wheels for: {', '.join(sorted(merged)) if merged else '(none)'}")
+    print(f"  Merged BE RH wheels for: {', '.join(names)}")
 
 
 def _find_wheel_line(block: str, url: str) -> str:

--- a/scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py
+++ b/scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py
@@ -3,9 +3,13 @@
 
 Two strategies:
   replace   — swap the entire [[packages]] block from the reference lock (all arches).
-              Use for Rust-backed packages (uv, ripgrep) where PyPI sdists break hermeto.
+              Use for Rust-backed packages (uv, ripgrep) where PyPI sdists break hermeto,
+              and for RH-index-only packages (pandoc-rhai) that uv pip compile cannot emit.
+              Missing names in the target lock are inserted in name order.
+              Names absent from the reference lock are skipped.
   merge-be  — keep PyPI wheels for x86_64/aarch64; add RH wheels for ppc64le/s390x only;
               drop sdists. Aligns rhoai-2.25 with public PyPI on LE while BE stays offline.
+              Names absent from the reference or target lock are skipped.
 
 Usage:
     patch-rh-wheel-only-packages.py replace <pylock.toml> <reference.toml> pkg [pkg ...]
@@ -175,23 +179,33 @@ def strip_sdist(header: str) -> str:
 
 def patch_replace(target: Path, reference: Path, names: list[str]) -> None:
     ref_map = load_package_map(reference)
-    missing = [name for name in names if name not in ref_map]
-    if missing:
-        raise SystemExit(f"Reference lock missing packages: {', '.join(missing)}")
+    names = [name for name in names if name in ref_map]
+    if not names:
+        print("  No matching RH replace packages in reference lock; skipping")
+        return
 
     header, blocks = split_packages(target.read_text(encoding="utf-8"))
+    names_set = set(names)
     updated: list[str] = []
-    replaced: set[str] = set()
+    inserted: set[str] = set()
+
+    def flush_before(next_name: str | None) -> None:
+        for name in sorted(names_set - inserted):
+            if next_name is None or name < next_name:
+                updated.append(ref_map[name].rstrip() + "\n")
+                inserted.add(name)
+
     for block in blocks:
         name = package_name(block)
-        if name in names:
+        if name in names_set:
+            flush_before(name)
             updated.append(ref_map[name].rstrip() + "\n")
-            replaced.add(name)
+            inserted.add(name)
         else:
+            if name:
+                flush_before(name)
             updated.append(block.rstrip() + "\n")
-
-    if replaced != set(names):
-        raise SystemExit(f"Target lock missing packages to patch: {', '.join(sorted(set(names) - replaced))}")
+    flush_before(None)
 
     target.write_text(header + "\n".join(updated), encoding="utf-8")
     print(f"  Replaced RH wheel-only entries for: {', '.join(names)}")
@@ -199,17 +213,19 @@ def patch_replace(target: Path, reference: Path, names: list[str]) -> None:
 
 def patch_merge_be(target: Path, reference: Path, names: list[str]) -> None:
     ref_map = load_package_map(reference)
-    missing = [name for name in names if name not in ref_map]
-    if missing:
-        raise SystemExit(f"Reference lock missing packages: {', '.join(missing)}")
+    names = [name for name in names if name in ref_map]
+    if not names:
+        print("  No matching RH merge-be packages in reference lock; skipping")
+        return
 
     header, blocks = split_packages(target.read_text(encoding="utf-8"))
     updated: list[str] = []
     merged: set[str] = set()
+    names_set = set(names)
 
     for block in blocks:
         name = package_name(block)
-        if name not in names:
+        if name not in names_set:
             updated.append(block.rstrip() + "\n")
             continue
 
@@ -240,11 +256,12 @@ def patch_merge_be(target: Path, reference: Path, names: list[str]) -> None:
         updated.append(new_block.rstrip() + "\n")
         merged.add(name)
 
-    if merged != set(names):
-        raise SystemExit(f"Target lock missing packages to merge: {', '.join(sorted(set(names) - merged))}")
+    skipped = sorted(names_set - merged)
+    if skipped:
+        print(f"  Skipped merge-be (not in target lock): {', '.join(skipped)}")
 
     target.write_text(header + "\n".join(updated), encoding="utf-8")
-    print(f"  Merged BE RH wheels for: {', '.join(names)}")
+    print(f"  Merged BE RH wheels for: {', '.join(sorted(merged)) if merged else '(none)'}")
 
 
 def _find_wheel_line(block: str, url: str) -> str:

--- a/scripts/sync-python-lockfiles.sh
+++ b/scripts/sync-python-lockfiles.sh
@@ -108,12 +108,15 @@ if [[ ${#FAILED_DIRS[@]} -gt 0 ]]; then
 fi
 
 PATCH_SCRIPT="$ROOT_DIR/scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py"
+# RH-index-only (or all-arch RH) packages: replace/insert the full ref block.
+RH_WHEEL_REPLACE_ALL=(uv ripgrep pandoc-rhai)
 while IFS= read -r -d '' ref_file; do
   lock_dir=$(dirname "$(dirname "$ref_file")")
   lock_file="$lock_dir/pylock.toml"
   if [[ ! -f "$lock_file" ]]; then
     continue
   fi
+  python3 "$PATCH_SCRIPT" replace "$lock_file" "$ref_file" "${RH_WHEEL_REPLACE_ALL[@]}"
   merge_pkgs=()
   while IFS= read -r pkg; do
     [[ -n "$pkg" ]] && merge_pkgs+=("$pkg")
@@ -123,11 +126,14 @@ import sys
 from pathlib import Path
 
 BE_ARCHES = ("ppc64le", "s390x")
+REPLACE_ALL = {"uv", "ripgrep", "pandoc-rhai"}
 text = Path(sys.argv[1]).read_text()
 blocks = [b for b in re.split(r"(?=^\[\[packages\]\])", text, flags=re.M) if b.strip()]
 for block in blocks:
     name_match = re.search(r'^name = "([^"]+)"', block, re.M)
     if not name_match:
+        continue
+    if name_match.group(1) in REPLACE_ALL:
         continue
     urls = re.findall(r'url = "([^"]+)"', block)
     if any(f"linux_{arch}" in url for url in urls for arch in BE_ARCHES):

--- a/scripts/sync-python-lockfiles.sh
+++ b/scripts/sync-python-lockfiles.sh
@@ -108,15 +108,15 @@ if [[ ${#FAILED_DIRS[@]} -gt 0 ]]; then
 fi
 
 PATCH_SCRIPT="$ROOT_DIR/scripts/lockfile-generators/helpers/patch-rh-wheel-only-packages.py"
-# RH-index-only (or all-arch RH) packages: replace/insert the full ref block.
-RH_WHEEL_REPLACE_ALL=(uv ripgrep pandoc-rhai)
 while IFS= read -r -d '' ref_file; do
   lock_dir=$(dirname "$(dirname "$ref_file")")
   lock_file="$lock_dir/pylock.toml"
   if [[ ! -f "$lock_file" ]]; then
     continue
   fi
-  python3 "$PATCH_SCRIPT" replace "$lock_file" "$ref_file" "${RH_WHEEL_REPLACE_ALL[@]}"
+  if grep -Fq 'name = "pandoc-rhai"' "$ref_file"; then
+    python3 "$PATCH_SCRIPT" replace "$lock_file" "$ref_file" pandoc-rhai
+  fi
   merge_pkgs=()
   while IFS= read -r pkg; do
     [[ -n "$pkg" ]] && merge_pkgs+=("$pkg")


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C0BQAUU5W73/p1788163737606609

## Description

Follow-up to #2827. Stop unpacking `pandoc` from the RHOAI 3.5 wheel into `/usr/local/bin`. `nbconvert` uses `PATH`; after `uv pip install --requirements=./pylock.toml` the `pandoc-rhai` console script is `/opt/app-root/bin/pandoc`.

`pandoc-rhai` is not on public PyPI, so it is not listed in `pyproject.toml` (that would break `uv pip compile`). The four-arch 3.5 `cpu-ubi9` wheels live in `uv.lock.d/rh-wheel-only.ref.toml` and are inserted into each Jupyter `pylock.toml`. `patch-rh-wheel-only-packages.py replace` now inserts RH-only packages that compile cannot emit.

`install_pdf_deps.sh` still installs AppStream texlive, tcolorbox 4.42, and `gmp`/`libffi` for the dynamically linked pandoc binary. `pandoc --version` runs after pip in the Jupyter Dockerfiles.

## How Has This Been Tested?

- Hashed the four 3.5 `pandoc_rhai-3.9.0.2-4` wheels from `packages.redhat.com` and pinned those sha256/size/upload-time values in the lock overlay.
- Did not rebuild container images in this change (Konflux / GHA on this PR).

Self checklist (all need to be checked):
- [ ] Ensure that you have run `make test` (`gmake` on macOS) before asking for review
- [x] Changes to everything except `Dockerfile.konflux` files should be done in `odh/notebooks` and automatically synced to `rhds/notebooks`. For Konflux-specific changes, modify `Dockerfile.konflux` files directly in `rhds/notebooks` as these require special attention in the downstream repository and flow to the upcoming RHOAI release.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pandoc support to Python 3.12 Jupyter images across CPU, CUDA, and ROCm variants.
  * Enabled PDF export dependencies across supported architectures.

* **Bug Fixes**
  * Image builds now verify Pandoc availability during construction.
  * Improved package compatibility across supported architectures by refining dependency lock handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->