### PR TITLE
[rhoai-2.25] fix(cve): constrain gitpython>=3.1.57 for CVE-2026-73620

### DIFF
--- a/dependencies/cve-constraints.txt
+++ b/dependencies/cve-constraints.txt
@@ -75,8 +75,8 @@ feast>=0.63.0
 # RHAIENG-5853: CVE-2026-48746 vllm (defensive floor; not a direct notebook dependency today)
 vllm>=0.22.0
 
-# CVE-2026-67322 / gitpython CVE batch (fixed in gitpython>=3.1.52)
-gitpython>=3.1.52
+# CVE-2026-73620 / gitpython CVE batch (fixed in gitpython>=3.1.57)
+gitpython>=3.1.57
 
 # CVE-2026-54527 / CVE-2026-54528: jupyterlab-git XSS/RCE (fixed in >=0.54.0)
 jupyterlab-git>=0.54.0


### PR DESCRIPTION
## Summary
- Bump `gitpython>=3.1.57` in `dependencies/cve-constraints.txt` for CVE-2026-73620
## Jira
- [RHAIENG-7009](https://redhat.atlassian.net/browse/RHAIENG-7009)
## Test plan
- [x] gitpython==3.1.57 verified in all affected pylock.toml files
- [ ] CI passes

[RHAIENG-7009]: https://redhat.atlassian.net/browse/RHAIENG-7009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitPython version requirement to address a reported security vulnerability.
  * Refreshed the related security advisory reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->