### PR TITLE
RHAIENG-7234: Fix Conforma rpm_signature on ppc64le/s390x datascience images

### DIFF
--- a/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/jupyter/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -70,7 +70,7 @@ echo "Building for architecture: ${TARGETARCH}"
 if [ "$TARGETARCH" = "s390x" ]; then
     PACKAGES=(perl mesa-libGL skopeo gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel)
 elif [ "$TARGETARCH" = "ppc64le" ]; then
-    PACKAGES=(perl mesa-libGL skopeo gcc gcc-c++ make autoconf automake libtool)
+    PACKAGES=(perl mesa-libGL skopeo gcc gcc-c++ make autoconf automake libtool cmake openssl-devel)
 else
     PACKAGES=(perl mesa-libGL skopeo)
 fi
@@ -79,8 +79,8 @@ dnf install -y "${PACKAGES[@]}"
 dnf clean all && rm -rf /var/cache/yum
 EOF
 
-COPY scripts/install_zeromq_be.sh /tmp/install_zeromq_be.sh
-RUN chmod +x /tmp/install_zeromq_be.sh && /tmp/install_zeromq_be.sh "$TARGETARCH"
+COPY scripts/install_libzmq_be.sh scripts/install_zeromq_be.sh /tmp/
+RUN chmod +x /tmp/install_libzmq_be.sh /tmp/install_zeromq_be.sh && /tmp/install_zeromq_be.sh "$TARGETARCH"
 
 RUN /bin/bash <<'EOF'
 set -Eeuxo pipefail

--- a/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
+++ b/runtimes/datascience/ubi9-python-3.12/Dockerfile.konflux.cpu
@@ -50,7 +50,7 @@ fi
 if [ "$TARGETARCH" = "s390x" ]; then
     PACKAGES+=(gcc gcc-c++ make openssl-devel autoconf automake libtool cmake python3-devel pybind11-devel openblas-devel unixODBC-devel openssl zlib-devel)
 elif [ "$TARGETARCH" = "ppc64le" ]; then
-    PACKAGES+=(gcc gcc-c++ make unixODBC-devel autoconf automake libtool)
+    PACKAGES+=(gcc gcc-c++ make unixODBC-devel autoconf automake libtool cmake openssl-devel)
 fi
 if [ ${#PACKAGES[@]} -gt 0 ]; then
     echo "Installing: ${PACKAGES[*]}"
@@ -59,8 +59,8 @@ if [ ${#PACKAGES[@]} -gt 0 ]; then
 fi
 EOF
 
-COPY scripts/install_zeromq_be.sh /tmp/install_zeromq_be.sh
-RUN chmod +x /tmp/install_zeromq_be.sh && /tmp/install_zeromq_be.sh "$TARGETARCH"
+COPY scripts/install_libzmq_be.sh scripts/install_zeromq_be.sh /tmp/
+RUN chmod +x /tmp/install_libzmq_be.sh /tmp/install_zeromq_be.sh && /tmp/install_zeromq_be.sh "$TARGETARCH"
 
 # For s390x only, set ENV vars and install Rust
 RUN /bin/bash <<'EOF'

--- a/scripts/install_zeromq_be.sh
+++ b/scripts/install_zeromq_be.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# ppc64le/s390x runtime RPMs for RH prebuilt wheels (pyzmq, numpy/scipy, pyarrow, pillow).
-# RHEL 9 with subscription only (rhoai GHA/Konflux).
+# ppc64le/s390x runtime libs for RH prebuilt wheels (pyzmq, numpy/scipy, pyarrow, pillow).
+# RHEL 9 signed RPMs and source builds only — no EPEL/COPR (Conforma rpm_signature policy).
 set -Eeuxo pipefail
 
 arch="${1:-$(uname -m)}"
@@ -9,20 +9,70 @@ case "${arch}" in
     *) exit 0 ;;
 esac
 
-EPEL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
 
-dnf install -y dnf-plugins-core "${EPEL}"
-subscription-manager repos --enable "codeready-builder-for-rhel-9-${arch}-rpms"
+THRIFT_VERSION=0.24.0
+RE2_VERSION=2023-03-01
 
-dnf install -y \
-    zeromq openblas openblas-threads \
-    lcms2 openjpeg2 re2 utf8proc snappy
+DNF_OPTS=(
+    --disablerepo='*-debug-*'
+    --disablerepo='*-source-*'
+    --disablerepo='*-eus-*'
+)
 
-# EPEL thrift is 0.15; pyarrow 25 needs libthrift-0.24.0.so from COPR.
-dnf install -y 'dnf-command(copr)'
-dnf copr enable -y aaiet-notebooks/rhelai-el9
-dnf install -y thrift
-dnf copr disable -y aaiet-notebooks/rhelai-el9 || true
+subscription-manager refresh || true
+# Konflux builders use full RHEL subs; local UBI activation keys expose ubi-9-* repos only.
+if ! subscription-manager repos --enable "codeready-builder-for-rhel-9-${arch}-rpms" 2>/dev/null; then
+    subscription-manager repos --enable ubi-9-codeready-builder-rpms 2>/dev/null || true
+fi
+
+dnf install -y "${DNF_OPTS[@]}" \
+    openblas openblas-threads \
+    lcms2 openjpeg2 snappy utf8proc
+
+# Build thrift/re2 from source; libzmq via install_libzmq_be.sh (same pattern as minimal).
+dnf install -y "${DNF_OPTS[@]}" cmake boost-devel libevent-devel openssl-devel zlib-devel
+
+curl -fL "https://github.com/apache/thrift/archive/refs/tags/v${THRIFT_VERSION}.tar.gz" \
+    -o "${workdir}/thrift.tar.gz"
+tar -xzf "${workdir}/thrift.tar.gz" -C "${workdir}"
+cmake -S "${workdir}/thrift-${THRIFT_VERSION}" -B "${workdir}/thrift-build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DBUILD_COMPILER=OFF \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_TUTORIALS=OFF \
+    -DBUILD_JAVA=OFF \
+    -DBUILD_JAVASCRIPT=OFF \
+    -DBUILD_NODEJS=OFF \
+    -DBUILD_PYTHON=OFF \
+    -DBUILD_C_GLIB=OFF \
+    -DBUILD_CPP=ON \
+    -DWITH_CPP=ON \
+    -DWITH_LIBEVENT=ON \
+    -DWITH_ZLIB=ON \
+    -DWITH_OPENSSL=ON
+cmake --build "${workdir}/thrift-build" -j"$(nproc)"
+cmake --install "${workdir}/thrift-build"
+
+curl -fL "https://github.com/google/re2/archive/refs/tags/${RE2_VERSION}.tar.gz" \
+    -o "${workdir}/re2.tar.gz"
+tar -xzf "${workdir}/re2.tar.gz" -C "${workdir}"
+cmake -S "${workdir}/re2-${RE2_VERSION}" -B "${workdir}/re2-build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DBUILD_SHARED_LIBS=ON \
+    -DRE2_BUILD_TESTING=OFF
+cmake --build "${workdir}/re2-build" -j"$(nproc)"
+cmake --install "${workdir}/re2-build"
+
+"${script_dir}/install_libzmq_be.sh" "$arch"
+
+ldconfig
+
+dnf remove -y "${DNF_OPTS[@]}" boost-devel libevent-devel zlib-devel openssl-devel || true
 dnf clean all
 
 if test -f /usr/lib64/libopenblasp.so.0 && ! test -e /usr/lib64/libopenblas.so.0; then
@@ -38,3 +88,4 @@ export OMP_NUM_THREADS=1
 EOF
 
 test -f /usr/lib64/libthrift-0.24.0.so
+test -f /usr/lib64/libre2.so || test -f /usr/lib64/libre2.so.10


### PR DESCRIPTION
[RHAIENG-7234](https://redhat.atlassian.net/browse/RHAIENG-7234)

## Summary

- Remove EPEL and COPR usage from `install_zeromq_be.sh`, which caused Conforma `rpm_signature` violations on ppc64le/s390x datascience Konflux builds (EPEL key `8a3872bf3228467c`, COPR key `fece09a8595d8fb2`).
- Install RHEL-signed RPMs via `dnf` (openblas, lcms2, openjpeg2, snappy, utf8proc) and build thrift 0.24, re2, and libzmq from source instead.
- Update jupyter and runtime datascience CPU Dockerfiles to copy `install_libzmq_be.sh` and add cmake/openssl-devel build deps on ppc64le.

## Test plan

- [ ] Konflux build passes for `odh-workbench-jupyter-datascience-cpu-py312-v2-25` on ppc64le and s390x
- [ ] Konflux build passes for runtime datascience CPU on ppc64le and s390x
- [ ] Conforma `rpm_signature` policy passes (no EPEL/COPR GPG keys in image)
- [ ] Local ppc64le smoke test of `install_zeromq_be.sh` completed successfully (thrift, re2, libzmq present)

[RHAIENG-7234]: https://redhat.atlassian.net/browse/RHAIENG-7234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ