### PR TITLE
[rhoai-2.25] RHAIENG-7237: Fix Code static analysis failures on rhoai-2.25

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -214,6 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify SHAs match version comments
         # aquasecurity org has an IP allowlist that blocks GHA runners
-        run: pinact run --verify --exclude '^aquasecurity/trivy-action$'
+        # devops-shared-resources reusable workflow cannot be verified by pinact --verify
+        run: pinact run --verify --exclude '^aquasecurity/trivy-action$' --exclude '^red-hat-data-services/devops-shared-resources/.*'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -1,6 +1,7 @@
+---
 name: Post-Codefreeze Gatekeeper
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled]
     branches:
@@ -8,5 +9,5 @@ on:
 jobs:
   post-codefreeze-gate:
     if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
-    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@f140b2f4770d56a9c9e7cbccec0f04fe43f08c2d  # main
     secrets: inherit

--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -10,5 +10,5 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   post-codefreeze-gate:
     if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
-    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@f140b2f4770d56a9c9e7cbccec0f04fe43f08c2d # main
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@f140b2f4770d56a9c9e7cbccec0f04fe43f08c2d  # main
     secrets: inherit


### PR DESCRIPTION
[RHAIENG-7237](https://redhat.atlassian.net/browse/RHAIENG-7237)

## Summary

Fixes four recurring **Code static analysis** failures on `rhoai-2.25` (yamllint + pinact on both push and pull_request), caused by `.github/workflows/post-codefreeze-gatekeeper.yaml` added in #2804 — unrelated to other in-flight PRs.

- Add YAML document start and yamllint `truthy` disable on `on:` (matches other workflows)
- Pin the `devops-shared-resources` reusable workflow to commit `f140b2f` instead of `@main`
- Exclude that reusable workflow from `pinact run --verify` (same pattern as `aquasecurity/trivy-action`)

## Test plan

- [x] `yamllint --strict` passes on `post-codefreeze-gatekeeper.yaml`
- [x] `pinact run --check` passes locally
- [x] `pinact run --verify` passes locally with the new exclude
- [ ] CI **Code static analysis** workflow is green on this PR

[RHAIENG-7237]: https://redhat.atlassian.net/browse/RHAIENG-7237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow checks to handle supported reusable workflows more reliably.
  - Extended post-code-freeze validation to pull requests targeting the main branch.
  - Improved workflow consistency and validation by locking shared automation to verified revisions and accommodating standard YAML syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->