### PR TITLE
ci(tekton): retrigger workbench datascience v2.25 push build

### DIFF
--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-# konflux build manual retrigger - 2026-05-29 15:32:03
+# konflux build manual retrigger - 2026-09-02 02:05:00
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/red-hat-data-services/notebooks?rev={{revision}}
@@ -15,7 +15,9 @@ metadata:
       && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-v2-25-push.yaml".pathChanged() ||
            "jupyter/utils/**".pathChanged() ||
            "jupyter/minimal/ubi9-python-3.12/**".pathChanged() ||
-           "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() )
+           "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+           "jupyter/datascience/ubi9-python-3.12/**".pathChanged() ||
+           "scripts/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v2-25
     appstudio.openshift.io/component: odh-workbench-jupyter-datascience-cpu-py312-v2-25


### PR DESCRIPTION
## Summary
- Manual PAC retrigger for `odh-workbench-jupyter-datascience-cpu-py312-v2-25` after #2834 merge (no push build ran because path filters missed `jupyter/datascience/**` and `scripts/**`).
- Extend on-push CEL paths so future datascience/script changes rebuild automatically.

## Test plan
- [ ] Merge to `rhoai-2.25` and confirm `on-push` PipelineRun starts for workbench datascience.
- [ ] Confirm Conforma single-component succeeds on new image (~20 min after build).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pipeline’s manual retrigger metadata.
  * Expanded automatic build triggers to include changes to Data Science Python 3.12 files, shared scripts, and the Minimal notebook startup script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->