### PR TITLE
RHAIENG-7433: lock corrected pandas 2.3.3 build-4 wheel across EA1 images

### DIFF
--- a/codeserver/ubi9-python-3.12/requirements.cpu.txt
+++ b/codeserver/ubi9-python-3.12/requirements.cpu.txt
@@ -370,7 +370,11 @@ pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:448cb61682a3e28102675a13569439021a4cd9ef78d93f1d7d7c9a2a7938952a \
     --hash=sha256:47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c \
     --hash=sha256:592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693 \
-    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e
+    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e \
+    --hash=sha256:5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35 \
+    --hash=sha256:24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006 \
+    --hash=sha256:ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e \
+    --hash=sha256:68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a4b4cb2c5bf334d29c8288652669cffc0809ea7e7c30f6344204493be297df3f
 paramiko==5.0.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and platform_machine != 'ppc64le' and platform_machine != 's390x' and sys_platform == 'linux' \

--- a/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/codeserver/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -1040,6 +1040,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 12941471, hashes = { sha256 = "47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 16095328, hashes = { sha256 = "592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 12761080, hashes = { sha256 = "4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:45:03Z, size = 12053826, hashes = { sha256 = "5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-28T01:52:37Z, size = 12925504, hashes = { sha256 = "24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-28T01:10:19Z, size = 16064649, hashes = { sha256 = "ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:39:05Z, size = 12742532, hashes = { sha256 = "68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7" } },
 ]
 
 [[packages]]

--- a/jupyter/datascience/ubi9-python-3.12/requirements.cpu.txt
+++ b/jupyter/datascience/ubi9-python-3.12/requirements.cpu.txt
@@ -425,7 +425,11 @@ pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:448cb61682a3e28102675a13569439021a4cd9ef78d93f1d7d7c9a2a7938952a \
     --hash=sha256:47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c \
     --hash=sha256:592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693 \
-    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e
+    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e \
+    --hash=sha256:5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35 \
+    --hash=sha256:24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006 \
+    --hash=sha256:ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e \
+    --hash=sha256:68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:5d462b652bf0beb76435dc6e07dbb6583efbdfba15e8491a4071687ca18f5570 \
     --hash=sha256:52099276f67227cc89734c4aa296bbbba4c1e3cd48640845499a65933552635b \

--- a/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/jupyter/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -1201,6 +1201,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 12941471, hashes = { sha256 = "47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 16095328, hashes = { sha256 = "592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 12761080, hashes = { sha256 = "4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:45:03Z, size = 12053826, hashes = { sha256 = "5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-28T01:52:37Z, size = 12925504, hashes = { sha256 = "24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-28T01:10:19Z, size = 16064649, hashes = { sha256 = "ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:39:05Z, size = 12742532, hashes = { sha256 = "68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
@@ -445,7 +445,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:82db81c4684f6adbccf842766e8331afc357f894224290991bc631d290f05fbe \
     --hash=sha256:eabba6cc75f2f13e312d06a722ee95fe8f7e523201d8865cd349d299bdfc6201

--- a/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1343,6 +1343,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]

--- a/jupyter/pytorch/ubi9-python-3.12/requirements.cuda.txt
+++ b/jupyter/pytorch/ubi9-python-3.12/requirements.cuda.txt
@@ -394,7 +394,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:82db81c4684f6adbccf842766e8331afc357f894224290991bc631d290f05fbe \
     --hash=sha256:eabba6cc75f2f13e312d06a722ee95fe8f7e523201d8865cd349d299bdfc6201

--- a/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1190,6 +1190,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.rocm.txt
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/requirements.rocm.txt
@@ -370,7 +370,8 @@ opentelemetry-semantic-conventions==0.65b0 ; python_full_version == '3.12.*' and
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:799bf47192d30b1f8abdebe52e7159d4e061e73f1cca84db3766eeb70af0df22
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1118,7 +1118,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandoc-rhai"

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/requirements.rocm.txt
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/requirements.rocm.txt
@@ -384,7 +384,8 @@ optree==0.19.1 ; python_full_version == '3.12.*' and implementation_name == 'cpy
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:799bf47192d30b1f8abdebe52e7159d4e061e73f1cca84db3766eeb70af0df22
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/jupyter/rocm/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/jupyter/rocm/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -1160,7 +1160,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandoc-rhai"

--- a/jupyter/tensorflow/ubi9-python-3.12/requirements.cuda.txt
+++ b/jupyter/tensorflow/ubi9-python-3.12/requirements.cuda.txt
@@ -410,7 +410,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:4ff10c33baae07c17d38d7bf83d734762ae7e42000bb5957eaa2a7ecaa79cfaa
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2 \
-    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0
+    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0 \
+    --hash=sha256:610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99 \
+    --hash=sha256:e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698
 pandoc-rhai==3.9.0.2+rhaiv.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:38003fe8745508e83684f99424598b2901fb4ab7ba74889379003f33831cb8a0 \
     --hash=sha256:a5fa43cad0d6756207706577ba37f93aa2ec258976aa16118532508609cdeb61

--- a/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/jupyter/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1238,6 +1238,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-15T05:36:58Z, size = 12065020, hashes = { sha256 = "1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T05:23:21Z, size = 12761081, hashes = { sha256 = "0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:54:15Z, size = 12053826, hashes = { sha256 = "610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:49:38Z, size = 12742529, hashes = { sha256 = "e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698" } },
 ]
 
 [[packages]]

--- a/runtimes/datascience/ubi9-python-3.12/requirements.cpu.txt
+++ b/runtimes/datascience/ubi9-python-3.12/requirements.cpu.txt
@@ -329,7 +329,11 @@ pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpyt
     --hash=sha256:448cb61682a3e28102675a13569439021a4cd9ef78d93f1d7d7c9a2a7938952a \
     --hash=sha256:47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c \
     --hash=sha256:592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693 \
-    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e
+    --hash=sha256:4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e \
+    --hash=sha256:5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35 \
+    --hash=sha256:24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006 \
+    --hash=sha256:ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e \
+    --hash=sha256:68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a4b4cb2c5bf334d29c8288652669cffc0809ea7e7c30f6344204493be297df3f
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
+++ b/runtimes/datascience/ubi9-python-3.12/uv.lock.d/pylock.cpu.toml
@@ -913,6 +913,10 @@ wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-14T02:07:25Z, size = 12941471, hashes = { sha256 = "47e593b4c53c26f63e20f86284bc78b9e343aa38d7feac970afcc7378a8b191c" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-14T04:06:59Z, size = 16095328, hashes = { sha256 = "592417e78fbaf4d2883974d4c497d8452d7170655ef1974558de83a80f663693" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T02:04:25Z, size = 12761080, hashes = { sha256 = "4022dee33a365dc25d470914b5fe17d02d362916fd88d6c34e3a4011aebb813e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:45:03Z, size = 12053826, hashes = { sha256 = "5038ae553c89c51e9331f5f10b5449f08d32eacda8c5db93fb195ddfaf798f35" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_ppc64le.whl", upload-time = 2026-08-28T01:52:37Z, size = 12925504, hashes = { sha256 = "24e50ed147843934ff92aee51d67ad3c929e34599d964c9722c693b5533c7006" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_s390x.whl", upload-time = 2026-08-28T01:10:19Z, size = 16064649, hashes = { sha256 = "ee19dbe75ade04677ce73ca34a8c3688db7d17a9b184cf1b8803b38bd5aaba7e" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cpu-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:39:05Z, size = 12742532, hashes = { sha256 = "68aecccaf52044863b751c2cdf88a5553593edc448f459d60e80491d38fc76e7" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/requirements.cuda.txt
@@ -349,7 +349,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e910fdfb5465e33f4007a3f9e90a56a79f78a62a150ad24d6ebe7d846dedb95e
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch+llmcompressor/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -1055,6 +1055,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]

--- a/runtimes/pytorch/ubi9-python-3.12/requirements.cuda.txt
+++ b/runtimes/pytorch/ubi9-python-3.12/requirements.cuda.txt
@@ -294,7 +294,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:78b6de736023f1d0527818f140c4c9fe41a24ba50ea5ab48e0971b948b3b8025
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860 \
-    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665
+    --hash=sha256:0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665 \
+    --hash=sha256:900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f \
+    --hash=sha256:7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:e910fdfb5465e33f4007a3f9e90a56a79f78a62a150ad24d6ebe7d846dedb95e
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/pytorch/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -890,6 +890,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-14T07:19:22Z, size = 12065023, hashes = { sha256 = "0534f0ffc31cfc27209f097aa958ac0d6d0625c02e50f368d251b2fb3e57c860" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T14:12:57Z, size = 12761080, hashes = { sha256 = "0a1c798d214f04d70828e492071350d40630d2250825869d137cc1e69b683665" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:52:18Z, size = 12053826, hashes = { sha256 = "900b4202267fd4921a2cbf16dcb6e6ce0b1f331f8ea25657610ae33d7599c58f" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda13.0-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:45:38Z, size = 12742529, hashes = { sha256 = "7eadb0e55acd1fc3c1c3129ddde47629ff38b0dead0ff023d5626c3d2d05a9e0" } },
 ]
 
 [[packages]]

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.rocm.txt
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/requirements.rocm.txt
@@ -270,7 +270,8 @@ opentelemetry-semantic-conventions==0.65b0 ; python_full_version == '3.12.*' and
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b81a13ee5e71ca470cf7650a70ef61fbd72ea6970526ce49feef1494557df834
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-pytorch/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -818,7 +818,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandocfilters"

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/requirements.rocm.txt
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/requirements.rocm.txt
@@ -288,7 +288,8 @@ optree==0.19.1 ; python_full_version == '3.12.*' and implementation_name == 'cpy
 packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:7079b80152e9f62c90775b5247618ba10877a235d12ee5348d6053fbd13105fb
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
-    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc
+    --hash=sha256:22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc \
+    --hash=sha256:d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:b81a13ee5e71ca470cf7650a70ef61fbd72ea6970526ce49feef1494557df834
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/rocm-tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
+++ b/runtimes/rocm-tensorflow/ubi9-python-3.12/uv.lock.d/pylock.rocm.toml
@@ -872,7 +872,10 @@ wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoa
 name = "pandas"
 version = "2.3.3"
 marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux'"
-wheels = [{ url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } }]
+wheels = [
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-14T07:40:51Z, size = 12761083, hashes = { sha256 = "22f61dca84beed5b41f59cc67f39f13b283019f2492e2248361d2ead9de1cfbc" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/rocm7.14-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:56:33Z, size = 12742531, hashes = { sha256 = "d7197b45ce7baa4d574d8b00ab2e52daa36a62b132363dc908d8d53daba0651e" } },
+]
 
 [[packages]]
 name = "pandocfilters"

--- a/runtimes/tensorflow/ubi9-python-3.12/requirements.cuda.txt
+++ b/runtimes/tensorflow/ubi9-python-3.12/requirements.cuda.txt
@@ -314,7 +314,9 @@ packaging==26.3 ; python_full_version == '3.12.*' and implementation_name == 'cp
     --hash=sha256:4ff10c33baae07c17d38d7bf83d734762ae7e42000bb5957eaa2a7ecaa79cfaa
 pandas==2.3.3 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2 \
-    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0
+    --hash=sha256:0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0 \
+    --hash=sha256:610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99 \
+    --hash=sha256:e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698
 pandocfilters==1.5.1 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \
     --hash=sha256:a293260e58a82f52644c3a189227ec3f445b5149480eef442b3de894b9173d78
 papermill==2.7.0 ; python_full_version == '3.12.*' and implementation_name == 'cpython' and sys_platform == 'linux' \

--- a/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
+++ b/runtimes/tensorflow/ubi9-python-3.12/uv.lock.d/pylock.cuda.toml
@@ -950,6 +950,8 @@ marker = "python_full_version == '3.12.*' and implementation_name == 'cpython' a
 wheels = [
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-15T05:36:58Z, size = 12065020, hashes = { sha256 = "1f2a842fe7c61ad27f3d902342f895ef6796076820504aefe6c2788a7d119be2" } },
     { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-3-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-15T05:23:21Z, size = 12761081, hashes = { sha256 = "0e986de1de580e015c24b089694d3dc7559f8bc63123dc66de4945f242f9b0e0" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_aarch64.whl", upload-time = 2026-08-28T00:54:15Z, size = 12053826, hashes = { sha256 = "610b441b84812783ca795d00e5b9a1686ea5676f5a3c8d84f757f2b5c493fa99" } },
+    { url = "https://packages.redhat.com/api/pulp-content/public-rhai/rhoai/3.6-EA1/cuda12.9-ubi9/pandas-2.3.3-4-cp312-cp312-linux_x86_64.whl", upload-time = 2026-08-28T00:49:38Z, size = 12742529, hashes = { sha256 = "e8e3140cb0c145643b45347e7668faf3c3480c045390542ffdb1a6fb6e5ab698" } },
 ]
 
 [[packages]]

--- a/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
+++ b/tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py
@@ -61,6 +61,52 @@ print("Scikit-learn smoke test completed successfully.")
             assert "Scikit-learn smoke test completed successfully." in output_str
             assert "Prediction: [1]" in output_str
 
+    @allure.issue("RHAIENG-7433")
+    @allure.description(
+        "Regression: converting a pandas DataFrame with a datetime64 column to a pyarrow "
+        "Table must not segfault. The 3.6-EA1 pandas 2.3.3 build-3 wheel had a numpy ABI "
+        "mismatch in its datetime64 C extension that crashed the kernel (exit 139); the "
+        "corrected build-4 wheel is now locked."
+    )
+    def test_pandas_pyarrow_datetime64(self, datascience_image: conftest.Image) -> None:
+        container = WorkbenchContainer(image=datascience_image.name, user=4321, group_add=[0])
+        # language=Python
+        repro_script = """
+import sys
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+print(f"python: {sys.version.split()[0]}")
+print(f"numpy: {np.__version__}, pandas: {pd.__version__}, pyarrow: {pa.__version__}")
+
+df = pd.DataFrame({"t": [pd.Timestamp("2020-01-01")], "v": [1.0]})
+table = pa.Table.from_pandas(df)
+assert table.num_rows == 1, f"unexpected row count: {table.num_rows}"
+dtype = table.column("t").type
+assert str(dtype).startswith("timestamp"), f"unexpected datetime column type: {dtype}"
+print("pandas->pyarrow datetime64 conversion completed successfully.")
+"""
+        with container:
+            container.with_command("/bin/sh -c 'sleep infinity'")
+            container.start(wait_for_readiness=False)
+
+            # Match the interpreter present in the image: code-server exposes only python3.
+            name_label = datascience_image.labels.get("name", "")
+            is_codeserver = "-code-server-" in name_label or "codeserver" in datascience_image.name.lower()
+            python_exe = "/opt/app-root/bin/python3" if is_codeserver else "python"
+            print(f"Using python executable: {python_exe}")
+
+            exit_code, output = container.exec([python_exe, "-c", repro_script])
+            output_str = output.decode()
+            print(output_str)
+
+            assert exit_code == 0, (
+                f"pandas->pyarrow datetime64 conversion failed with exit code {exit_code} "
+                f"(139 = SIGSEGV from the defective pandas build-3)"
+            )
+            assert "pandas->pyarrow datetime64 conversion completed successfully." in output_str
+
     @allure.description("Check that mysql client functionality is working with SASL plain auth.")
     def test_mysql_connection(self, tf: TestFrame, datascience_image: Image, subtests):
         MYSQL_CONNECTOR_PYTHON_VERSION = "26.7.0"


### PR DESCRIPTION
## Summary

Fix a kernel `SIGSEGV` (exit 139) in the 3.6‑EA1 notebook images by locking the corrected
`pandas` **2.3.3 build‑4** wheel. The defective **build‑3** wheel has a numpy ABI mismatch in
its datetime64 C extension. The change is **surgical**: per image, only the `pandas`
build‑4 wheel/hash entries are added (build‑3 is retained); every other package stays at its
locked version.

- **Ticket:** [RHAIENG-7433](https://redhat.atlassian.net/browse/RHAIENG-7433)
- **Base image used for verification:** quay.io/aipcc/base-images/cpu-el9.8:3.6.0-ea.1-1787611401

## Symptom

Any `pa.Table.from_pandas(df)` where `df` contains a `datetime64` column crashes the kernel:

```python
import pandas as pd, pyarrow as pa
pa.Table.from_pandas(pd.DataFrame({"t": [pd.Timestamp("2020-01-01")] }))
# -> SIGSEGV, exit 139
```

This blocks Feast `write_to_offline_store` / `write_to_online_store` on the Data Science
CPU workbench.

## Root cause

The EA1 pylocks pin `pandas-2.3.3-3`. That wheel's datetime64 C extension was built against a
different numpy ABI, so calling it under `numpy` 2.5.2 segfaults. A corrected
`pandas-2.3.3-4` wheel was published to the RH index on 2026‑08‑28.

## Trajectory

1. **Report** — Data Science CPU workbench (3.6‑EA1) reported a pyarrow/pandas segfault
   originating in Feast (surfaced via internal Slack).
2. **Reproduce** — on the branch's pinned base image, the pinned `pandas==2.3.3` (build‑3)
   segfaults on `pa.Table.from_pandas` with a datetime64 column (exit 139).
3. **Root‑cause** — the build‑3 wheel's datetime64 extension has a numpy ABI mismatch.
4. **Find the fix** — `pandas-2.3.3-4` exists in the RH index; verified it does **not** segfault.
5. **Scope the change** — the source‑of‑truth pylocks pin only build‑3, so an explicit relock is
   required. A plain `gmake refresh-lock-files` re‑resolves against the current index and bumps
   many packages (e.g. ~48 for the datascience workbench, including a `plotly` 6→7 **major**) —
   out of scope for this defect fix.
6. **Surgical approach** — for each image, keep only the `pandas` change (add build‑4, retain
   build‑3) and revert every other package bump back to its locked version.
7. **Confirm availability** — build‑4 is present in all four indexes used by EA1 images
   (cpu‑ubi9, cuda12.9‑ubi9, cuda13.0‑ubi9, rocm7.14‑ubi9) for the same arches as build‑3.
8. **Verify build mechanics** — with both wheels in `--find-links`, the installer
   (`uv pip install --no-verify-hashes --index-strategy=unsafe-best-match`) selects the highest
   PEP 440 build tag (build‑4); the repro then passes.
9. **Apply to all affected images** — 13 images relocked, then reduced to pandas‑only.
10. **Add a regression test** — the exact reproducer is added to the container test suite so a
    build‑3 re-lock fails CI.

## Verification (branch base image, linux/amd64)

| pandas build | pa.Table.from_pandas(datetime64) |
|---|---|
| 2.3.3‑3 | SIGSEGV (exit 139) |
| 2.3.3‑4 | OK |
| both in --find-links (installer picks build‑4) | OK |

## Change

- **Lockfiles (26):** 13 `uv.lock.d/pylock.<flavor>.toml` + 13 `requirements.<flavor>.txt`.
  Each diff is limited to `pandas` (adds the build‑4 wheel/hash lines; the single‑wheel ROCm
  entries are reflowed from an inline to a multi‑line array by uv). No other package version changes.
- **Regression test (1):** `tests/containers/workbenches/jupyterlab/jupyterlab_datascience_test.py`
  adds `TestJupyterLabDatascienceImage::test_pandas_pyarrow_datetime64`.

## Regression test

`test_pandas_pyarrow_datetime64` runs the exact reproducer inside the image (build a `datetime64`
DataFrame, call `pa.Table.from_pandas`) and asserts a zero exit code. It targets the datascience
image chain (workbench + runtime, both ship pandas + pyarrow + Feast); the interpreter is detected
per image (code‑server exposes only `python3`). On a build‑3 wheel it fails with exit 139
(SIGSEGV), guarding the regression. Runs under
`make test-integration PYTEST_ARGS="--image=<datascience image>"`.

## Images updated (13)

- `codeserver` (cpu)
- `jupyter/datascience` (cpu); `jupyter/pytorch`, `jupyter/pytorch+llmcompressor`,
  `jupyter/tensorflow` (cuda); `jupyter/rocm/pytorch`, `jupyter/rocm/tensorflow` (rocm)
- `runtimes/datascience` (cpu); `runtimes/pytorch`, `runtimes/pytorch+llmcompressor`,
  `runtimes/tensorflow` (cuda); `runtimes/rocm-pytorch`, `runtimes/rocm-tensorflow` (rocm)

## Follow‑up (out of scope)

A full `refresh-lock-files` renewal (the ~48‑package set, including `plotly` 6→7) is a separate,
non‑urgent change and is intentionally **not** part of this defect fix.


[RHAIENG-7433]: https://redhat.atlassian.net/browse/RHAIENG-7433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ