### PR TITLE
[rhoai-3.3] RHAIENG-7478: ci(.tekton/): mirror push on-cel-expression triggers in PR pipelines

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -8,6 +8,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( "runtimes/datascience/ubi9-python-3.12/**".pathChanged() ||
+      ".tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-datascience)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -8,6 +8,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( "runtimes/minimal/ubi9-python-3.12/**".pathChanged() ||
+      ".tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-minimal-cpu)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -8,6 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml".pathChanged() ||
+      "runtimes/pytorch/ubi9-python-3.12/**".pathChanged() ||
+      "cuda/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -14,7 +14,7 @@ metadata:
       && target_branch == "rhoai-3.3"
       && !("manifests/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml".pathChanged() ||
-           "runtimes/pytorch-llmcompressor/ubi9-python-3.12/**".pathChanged())
+           "runtimes/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged())
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-v3-3

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -8,6 +8,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && (".tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml".pathChanged() ||
+      "runtimes/rocm-pytorch/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -8,6 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && (".tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml".pathChanged() ||
+      "runtimes/tensorflow/ubi9-python-3.12/**".pathChanged() ||
+      "cuda/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -7,6 +7,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml".pathChanged() ||
+      "runtimes/rocm-tensorflow/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -8,6 +8,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml".pathChanged() ||
+      "codeserver/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-codeserver)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-cpu, kfbuild-datascience, kfbuild-codeserver, kfbuild-workbench-codeserver-datascience-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -15,7 +15,8 @@ metadata:
       && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml".pathChanged() ||
       "jupyter/utils/**".pathChanged() ||
       "jupyter/minimal/ubi9-python-3.12/**".pathChanged() ||
-      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() )
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-datascience)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -8,6 +8,14 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-datascience)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml
@@ -16,7 +16,8 @@ metadata:
       && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-v3-3-push.yaml".pathChanged() ||
            "jupyter/utils/**".pathChanged() ||
            "jupyter/minimal/ubi9-python-3.12/**".pathChanged() ||
-           "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() )
+           "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+           "jupyter/datascience/ubi9-python-3.12/**".pathChanged() )
   labels:
     appstudio.openshift.io/application: rhoai-v3-3
     appstudio.openshift.io/component: odh-workbench-jupyter-datascience-cpu-py312-v3-3

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -8,6 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cpu)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -8,6 +8,14 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/**".pathChanged() ||
+      "cuda/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -8,6 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -8,6 +8,18 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/pytorch/ubi9-python-3.12/**".pathChanged() ||
+      "cuda/**".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mssql-3.3.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml
@@ -14,7 +14,7 @@ metadata:
       && target_branch == "rhoai-3.3"
       && !("manifests/base/params-latest.env".pathChanged())
       && ( ".tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-3-push.yaml".pathChanged() ||
-           "jupyter/pytorch-llmcompressor/ubi9-python-3.12/**".pathChanged() ||
+           "jupyter/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged() ||
            "cuda/**".pathChanged() ||
            "jupyter/utils/**".pathChanged() ||
            "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -8,6 +8,17 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/rocm/pytorch/ubi9-python-3.12/**".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mssql-3.3.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -8,6 +8,18 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/tensorflow/ubi9-python-3.12/**".pathChanged() ||
+      "cuda/**".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mssql-3.3.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
@@ -7,6 +7,17 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/rocm/tensorflow/ubi9-python-3.12/**".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mssql-3.3.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -8,6 +8,17 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.3"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml".pathChanged() ||
+      "jupyter/trustyai/ubi9-python-3.12/**".pathChanged() ||
+      "jupyter/utils/**".pathChanged() ||
+      "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/mssql-3.3.repo-x86_64/**".pathChanged() ||
+      "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-trustyai)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:


### PR DESCRIPTION
/dev/null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Improvements**
  - Pull-request pipelines now run only for relevant Python 3.12 runtime and workbench changes targeting the `rhoai-3.3` branch.
  - Changes limited to shared parameter files no longer trigger these pull-request pipelines.
  - Added coverage for Jupyter utilities, startup configuration, repository setup, Elyra, CUDA, ROCm, TensorFlow, PyTorch, and TrustyAI paths.

- **Bug Fixes**
  - Corrected push-trigger path matching for PyTorch/LLM Compressor and Jupyter Data Science Python 3.12 assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->