### PR TITLE
[rhoai-3.4] RHAIENG-7479: ci(.tekton/): mirror push on-cel-expression triggers in PR pipelines

### DIFF
--- a/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( "runtimes/datascience/ubi9-python-3.12/**".pathChanged() || ".tekton/odh-pipeline-runtime-datascience-cpu-py312-pull-request.yaml".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-datascience)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-cpu, kfbuild-datascience, kfbuild-runtime-datascience-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( "runtimes/minimal/ubi9-python-3.12/**".pathChanged() || ".tekton/odh-pipeline-runtime-minimal-cpu-py312-pull-request.yaml".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-minimal-cpu)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-cpu, kfbuild-minimal, kfbuild-runtime-minimal-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-pipeline-runtime-pytorch-cuda-py312-pull-request.yaml".pathChanged() || "runtimes/pytorch/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-pytorch, kfbuild-cuda, kfbuild-runtime-pytorch-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && (".tekton/odh-pipeline-runtime-pytorch-rocm-py312-pull-request.yaml".pathChanged() || "runtimes/rocm-pytorch/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-pytorch, kfbuild-rocm, kfbuild-runtime-pytorch-rocm]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && (".tekton/odh-pipeline-runtime-tensorflow-cuda-py312-pull-request.yaml".pathChanged() || "runtimes/tensorflow/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-runtime, kfbuild-tensorflow, kfbuild-cuda, kfbuild-runtime-tensorflow-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml
@@ -7,6 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-pipeline-runtime-tensorflow-rocm-py312-pull-request.yaml".pathChanged() || "runtimes/rocm-tensorflow/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-runtime-tensorflow-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml
@@ -8,6 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-codeserver-datascience-cpu-py312-pull-request.yaml".pathChanged() ||
+      "codeserver/ubi9-python-3.12/**".pathChanged() ||
+      "codeserver/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-codeserver)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-cpu, kfbuild-datascience, kfbuild-codeserver, kfbuild-workbench-codeserver-datascience-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/build-args/konflux.cpu.conf".pathChanged() || "prefetch-input/rhds/**".pathChanged() || "prefetch-input/mongocli/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-datascience)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-cpu, kfbuild-datascience, kfbuild-jupyter, kfbuild-workbench-jupyter-datascience-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cpu)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-cpu, kfbuild-minimal, kfbuild-jupyter, kfbuild-workbench-jupyter-minimal-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-cuda, kfbuild-minimal, kfbuild-jupyter, kfbuild-workbench-jupyter-minimal-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-minimal-rocm)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-rocm, kfbuild-minimal, kfbuild-jupyter, kfbuild-workbench-jupyter-minimal-rocm]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-pytorch-cuda-py312-pull-request.yaml".pathChanged() || "jupyter/pytorch/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.4.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-pytorch, kfbuild-cuda, kfbuild-jupyter, kfbuild-workbench-jupyter-pytorch-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-pull-request.yaml".pathChanged() || "jupyter/pytorch+llmcompressor/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-2022.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|kfbuild-llmcompressor-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-pytorch, kfbuild-cuda, kfbuild-jupyter, kfbuild-llmcompressor, kfbuild-workbench-jupyter-pytorch-llmcompressor-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-pytorch-rocm-py312-pull-request.yaml".pathChanged() || "jupyter/rocm/pytorch/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.4.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-pytorch-rocm)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-pytorch, kfbuild-rocm, kfbuild-jupyter, kfbuild-workbench-jupyter-pytorch-rocm]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-tensorflow-cuda-py312-pull-request.yaml".pathChanged() || "jupyter/tensorflow/ubi9-python-3.12/**".pathChanged() || "cuda/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.4.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-cuda)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-tensorflow, kfbuild-cuda, kfbuild-jupyter, kfbuild-workbench-jupyter-tensorflow-cuda]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"

--- a/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml
@@ -7,6 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-tensorflow-rocm-py312-pull-request.yaml".pathChanged() || "jupyter/rocm/tensorflow/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.4.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-tensorflow-rocm)"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
   labels:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -8,6 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml".pathChanged() || "jupyter/trustyai/ubi9-python-3.12/**".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/start-notebook.sh".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mongodb-org-6.0.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/mssql-3.4.repo-x86_64/**".pathChanged() || "jupyter/datascience/ubi9-python-3.12/setup-elyra.sh".pathChanged() )
     pipelinesascode.tekton.dev/on-comment: "^/(build-konflux|build-trustyai)"
     pipelinesascode.tekton.dev/on-label: "[kfbuild-all, kfbuild-workbench, kfbuild-trustyai, kfbuild-cpu, kfbuild-jupyter, kfbuild-workbench-jupyter-trustyai-cpu]"
     pipelinesascode.tekton.dev/on-target-branch: "[{{target_branch}}]"


### PR DESCRIPTION
## Summary

Add the `pipelinesascode.tekton.dev/on-cel-expression` file-change trigger to every `.tekton/` **pull-request** PipelineRun on `rhoai-3.4` whose image has a corresponding **-push** PipelineRun, mirroring the file-change (`pathChanged()`) set that push pipeline already uses.

Previously the PR pipelines fired on **every** `pull_request` event (`on-event: "[pull_request]"` + `on-target-branch`), so a PR touching a single image triggered the whole matrix. With the mirrored triggers, a PR build runs only when files relevant to that image (or the pipeline's own `.tekton` file) change — the same scoping the push builds already have.

## Tickets

- [RHAIENG-7479](https://redhat.atlassian.net/browse/RHAIENG-7479) — Add on-cel-expression path filters to rhoai-3.4 Konflux PR pipelines
- Related: [RHAIENG-6185](https://redhat.atlassian.net/browse/RHAIENG-6185) (rhoai-2.25, the originating ticket), [RHAIENG-6184](https://redhat.atlassian.net/browse/RHAIENG-6184) (per-image /kfbuild comment triggers)

## Changes

`17` files, insertion-only. Each `*-pull-request.yaml` gains one annotation block, adapted from its corresponding `*-v3-4-push.yaml`:

- `event == "pull_request" && target_branch == "rhoai-3.4"` (event/branch glue for the PR context)
- the push's `pathChanged()` disjunction **verbatim** — the `!("manifests/base/params-latest.env".pathChanged())` negative filter is included because the push pipelines on this branch still carry it
- the `.tekton/` self-reference rewritten to the PR file's own path

All existing annotations (`on-comment`, `on-label`, `on-event`, `on-target-branch`, `cancel-in-progress`, …) are preserved, so manual `/build-konflux|build-*` comments and `kfbuild-*` label triggers keep working unchanged.

Example (`odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml`):

```diff
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "rhoai-3.4"
+      && !("manifests/base/params-latest.env".pathChanged())
+      && ( ".tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml".pathChanged() || "jupyter/utils/**".pathChanged() || "jupyter/minimal/ubi9-python-3.12/**".pathChanged() )
```

The llmcompressor image has **two** push components on this branch (`odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-v3-4-push.yaml` at rhoai-version 3.4.0 and the legacy-named `odh-wb-jupyter-pytorch-llmcompressor-cuda-py312-v3-4-push.yaml` at 3.4.4) mapping to the single PR PipelineRun. Their `pathChanged()` sets are identical apart from the self-reference, so the mirrored trigger is unambiguous; the non-`odh-wb-` variant was used as the source.

## Validation

- All `.tekton/*.yaml` files on the branch parse as valid YAML (multi-doc aware).
- Scripted set-equality check: for every PR pipeline, the `pathChanged()` set (and the negated-filter set) now equals its push counterpart's, modulo the `.tekton` self-reference — 17/17 pairs match.
- `tests/test_main.py::test_rhds_pipelines_use_rhds_args` on this branch — 36 subtests, one per .tekton file.
- No other files touched (commit is insertion-only in `.tekton/`).

## Notes / follow-ups

- **konflux-central durability:** per `AGENTS.md`, rhds `.tekton/` files are synced from `red-hat-data-services/konflux-central` (`sync-pipelineruns.yml`). This change is intentionally made in-repo per the tasking; to survive future syncs the same annotation should land in konflux-central as well — a follow-up PR there is needed.
- **main branch (no change):** on `main` the only paired pipelines (the two c9s baseline images) already carry a superset of their push triggers (the PR CELs additionally include `prefetch-input/odh/**`, introduced deliberately upstream in `be82afbef` / [RHAIENG-7140](https://redhat.atlassian.net/browse/RHAIENG-7140) when the baselines went hermetic). The 22 RHOAI-style PR PipelineRuns on `main` have no corresponding `-push` pipeline on that branch. Nothing to add.

<details>
<summary><b>Agent trajectory — how this was produced (incl. dead ends)</b></summary>

### Issue identification

1. Searched Jira (RHAIENG) for the tracking issue → found **[RHAIENG-6185](https://redhat.atlassian.net/browse/RHAIENG-6185)** (*"Add on-cel-expression path filters to rhoai-2.25 Konflux PR pipelines"*) and sibling **[RHAIENG-6184](https://redhat.atlassian.net/browse/RHAIENG-6184)** (*"/kfbuild comment triggers"*). Read both in full; **neither has any comments** (verified via `listJiraIssueComments`, total=0 on 6185, 6184, and related 6036). The 6185 description defines the trigger shape, path-set guidance, and the generator-integration acceptance criterion.
2. GitHub: predecessor issue [opendatahub-io/notebooks#2680](https://github.com/opendatahub-io/notebooks/issues/2680) (closed) documents the odh-io↔rhds PR-pipeline alignment work; its threads confirm the per-repo registry/pipelineRef differences but no CEL guidance beyond what 6185 already specifies.
3. Slack: found the konflux-central PR [#3008 "update on-cel-expression"](https://github.com/red-hat-data-services/konflux-central/pull/3008) — it **removed** the `params-latest.env` negative filter from the **v3.5 push** triggers only. That is why 2.25/3.3/3.4 PR triggers keep the negation but 3.5 does not: mirror the per-branch push state, don't invent.

### Work setup

4. Created one git worktree per maintained branch inside the project dir (`notebooks-worktrees/prcel-<branch>`), each on a fresh `fix/pr-cel-triggers-<branch>` from the remote branch tip.
   - **Dead end:** first fetch attempt used `origin` (opendatahub-io) for the rhoai branches — they don't exist there; the maintained branches live on the `rhds` remote (red-hat-data-services/notebooks). Refetched from `rhds`.

### Analysis (two scripts, two bugs caught)

5. Wrote a comparison script (push vs PR `on-cel-expression` path sets).
   - **Dead end #1:** the YAML block-scalar capture regex stopped at the first line (`.*` doesn't cross newlines), so every push CEL read as just `event == "push"` and the first run *falsely* reported main's pairs as in-sync. Fixed with a line-aware capture and re-ran.
   - **Dead end #2:** naive filename pairing produced 100% "no counterpart" on the rhoai branches — push files carry the Konflux component version suffix (`*-v3-4-push.yaml`) and, on 3.4/3.5, one push uses the abbreviated `odh-wb-` prefix while its PR uses `odh-workbench-`. Fixed with normalized matching (strip `-vX-Y`, `odh-wb-` → `odh-workbench-`).
6. Result of the fixed analysis: on all four rhoai branches, **every PR file had a push counterpart and no CEL at all** (event-only triggers), while every push had the full file-change CEL → the change is a uniform annotation insertion. On `main`, the two paired c9s baseline PRs already contain every push trigger (plus a deliberate extra, see Notes) → no change.
7. **Dead end (generator):** [RHAIENG-6185](https://redhat.atlassian.net/browse/RHAIENG-6185)'s acceptance criteria say "Generator updated so expressions are not hand-edited per release branch". Inspected `scripts/generate_pull_request_pipelineruns.py` (present on 2.25/3.3): it is the **opendatahub-io-side** generator — it emits `open-data-hub-tenant` / `quay.io/opendatahub` / `opendatahub-io/notebooks` artifacts, and the rhds-style PR files (rhoai-tenant, shared `pull-request-pipelines-notebooks` component, no auto-gen header) are **not** produced by it (they sync from konflux-central). So no generator change is required or possible here; the durability path is konflux-central (see Notes).
8. **Design decisions, with the rejected alternatives:**
   - Did **not** append a `body.repository.full_name == "red-hat-data-services/notebooks"` guard: the push triggers (the spec being mirrored) don't have one, and PaC events are already scoped per repo via the Repository CR. The odh-io generator adds that guard only because the same files serve both repos.
   - **Kept** the existing `on-event`/`on-target-branch`/`on-label`/`on-comment` annotations (minimal diff; they are consistent with the CEL and preserve manual retrigger paths).
   - Kept each push's exact CEL formatting (2.25/3.3 use a multi-line disjunction, 3.4/3.5 a compact one) so the diff reads as a direct mirror.

### Application & verification

9. Inserted the annotation (before the first `on-*` PaC annotation) in all 17 PR files; guard checks: file must lack a CEL already, push CEL must contain `event == "push"`, anchor line must exist — all passed, zero skips.
10. Verified: (a) YAML parse of every `.tekton` file on the branch — 0 errors; (b) set-equality of `pathChanged()` + negation sets between each PR and its push, modulo self-reference — 17/17 OK; (c) `test_rhds_pipelines_use_rhds_args` — 36 subtests, one per .tekton file; (d) commit is insertion-only (no deletions) and scoped to `.tekton/odh-*-pull-request.yaml`.

</details>


[RHAIENG-7479]: https://redhat.atlassian.net/browse/RHAIENG-7479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6185]: https://redhat.atlassian.net/browse/RHAIENG-6185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-6184]: https://redhat.atlassian.net/browse/RHAIENG-6184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAIENG-7140]: https://redhat.atlassian.net/browse/RHAIENG-7140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Pull-request validation now runs selectively for Python 3.12 runtimes and workbench images when relevant source, configuration, or build files change.
  * Validation is limited to pull requests targeting the `rhoai-3.4` branch.
  * Changes limited to shared parameter metadata no longer trigger these targeted pipeline runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->