### PR TITLE
NO-JIRA: ci(.tekton/): remove obsolete sbom-syft-generate step override

### DIFF
--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-ci-push.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-ci-push.yaml
@@ -227,14 +227,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:

--- a/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-pull-request.yaml
+++ b/.tekton/odh-workbench-codeserver-baseline-cpu-py312-c9s-pull-request.yaml
@@ -230,14 +230,6 @@ spec:
         limits:
           cpu: '4'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '4'
-          memory: 8Gi
-        limits:
-          cpu: '4'
-          memory: 8Gi
   - pipelineTaskName: sast-unicode-check
     computeResources:
       limits:


### PR DESCRIPTION
## Summary

Removes the obsolete `sbom-syft-generate` step override from the `build-images`
`stepSpecs` in the RHOAI Konflux PipelineRuns.

Buildah task v0.11.0 removed the `sbom-syft-generate` step (SBOM generation now runs
inside the `build` step). A `stepSpecs` entry referencing a removed step fails pipeline
validation with:

    [User error] invalid StepOverride: No Step named sbom-syft-generate

The `prepare-sboms` and `build` overrides are retained (both steps still exist).
2 `.tekton/` PipelineRun files (1 push, 1 pull-request) changed (8 lines removed each).

Note: the push pipeline here is konflux-central-owned; the equivalent fix is already merged in konflux-central (PR #3382). Including it keeps this branch building until the next sync.

## Related

- konflux-central already fixed for the push-pipeline source: PR #3382 (main), #3381 (RHOAI-3.4) — merged.
- Migration guidance: buildah 0.11.0 removed `sbom-syft-generate`; SBOM generation moved into the build step.

## Testing

- All modified files still parse as valid YAML.
- No `sbom-syft-generate` references remain in `.tekton/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed resource specifications for SBOM generation from push and pull-request pipeline configurations.
  * Other task resource settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->