### PR TITLE
NO-JIRA: ci(.tekton/): remove obsolete sbom-syft-generate step override

### DIFF
--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -103,14 +103,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -102,14 +102,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -99,14 +99,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-trustyai-cpu-py312-pull-request.yaml
@@ -102,14 +102,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
## Summary

Removes the obsolete `sbom-syft-generate` step override from the `build-images`
`stepSpecs` in the RHOAI Konflux PipelineRuns.

Buildah task v0.11.0 removed the `sbom-syft-generate` step (SBOM generation now runs
inside the `build` step). A `stepSpecs` entry referencing a removed step fails pipeline
validation with:

    [User error] invalid StepOverride: No Step named sbom-syft-generate

The `prepare-sboms` and `build` overrides are retained (both steps still exist).
5 `.tekton/` pull-request PipelineRun files changed (8 lines removed each).

## Related

- konflux-central already fixed for the push-pipeline source: PR #3382 (main), #3381 (RHOAI-3.4) — merged.
- Migration guidance: buildah 0.11.0 removed `sbom-syft-generate`; SBOM generation moved into the build step.

## Testing

- All modified files still parse as valid YAML.
- No `sbom-syft-generate` references remain in `.tekton/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated image build configurations across CPU, CUDA, ROCm, and TrustyAI variants.
  - Removed the SBOM generation step and its associated resource settings from these build pipelines.
  - Existing image build and remaining SBOM preparation steps are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->