### PR TITLE
[rhoai-3.4] NO-JIRA: ci(.tekton/): remove obsolete sbom-syft-generate step override

### DIFF
--- a/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-datascience-cpu-py312-pull-request.yaml
@@ -104,14 +104,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cpu-py312-pull-request.yaml
@@ -103,14 +103,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-cuda-py312-pull-request.yaml
@@ -101,14 +101,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:

--- a/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
+++ b/.tekton/odh-workbench-jupyter-minimal-rocm-py312-pull-request.yaml
@@ -100,14 +100,6 @@ spec:
         limits:
           cpu: '3'
           memory: 8Gi
-    - name: sbom-syft-generate
-      computeResources:
-        requests:
-          cpu: '3'
-          memory: 8Gi
-        limits:
-          cpu: '3'
-          memory: 8Gi
     - name: build
       computeResources:
         requests:


### PR DESCRIPTION
## Summary

Removes the obsolete `sbom-syft-generate` step override from the `build-images`
`stepSpecs` in the RHOAI Konflux PipelineRuns.

Buildah task v0.11.0 removed the `sbom-syft-generate` step (SBOM generation now runs
inside the `build` step). A `stepSpecs` entry referencing a removed step fails pipeline
validation with:

    [User error] invalid StepOverride: No Step named sbom-syft-generate

The `prepare-sboms` and `build` overrides are retained (both steps still exist).
4 `.tekton/` pull-request PipelineRun files changed (8 lines removed each).

## Related

- konflux-central already fixed for the push-pipeline source: PR #3382 (main), #3381 (RHOAI-3.4) — merged.
- Migration guidance: buildah 0.11.0 removed `sbom-syft-generate`; SBOM generation moved into the build step.

## Testing

- All modified files still parse as valid YAML.
- No `sbom-syft-generate` references remain in `.tekton/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed SBOM generation resource configuration from multiple image build pipelines.
  - Image build steps and their existing compute resource settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->